### PR TITLE
Simplify handling of output expressions, remove matrix return support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(${LIBRARY_NAME}_HEADERS
     include/expression_concept.h
     include/expression_impl.h
     include/functions.h
+    include/output_annotations.h
     include/function_evaluator.h
     include/function_evaluator_detail.h
     include/hashing.h

--- a/include/code_generation/expression_group.h
+++ b/include/code_generation/expression_group.h
@@ -19,28 +19,20 @@ struct OutputKey {
   // How this block of expressions is used in the generated code.
   ExpressionUsage usage;
 
-  // Position in the output. If this is a return value, this indicates whether it
-  // is the first, second, ... return value in a tuple. If this is an output argument, then this
-  // indicates the position in the argument list.
-  std::size_t arg_position;
+  // Name of the output. If this is the return value, it will be empty.
+  // If this is an output argument, this is the name of the argument.
+  std::string name;
 
-  constexpr OutputKey(ExpressionUsage usage, std::size_t arg_position)
-      : usage(usage), arg_position(arg_position) {}
+  // Construct w/ usage ane name.
+  OutputKey(ExpressionUsage usage, std::string_view name) : usage(usage), name(name) {}
 
   // Equality test.
   constexpr bool operator==(const OutputKey& other) const {
-    return usage == other.usage && arg_position == other.arg_position;
+    return usage == other.usage && name == other.name;
   }
 
   // Non-equality test.
-  constexpr bool operator!=(const OutputKey& other) const {
-    return usage != other.usage || arg_position != other.arg_position;
-  }
-
-  // Relative order (lexicographical order).
-  constexpr bool operator<(const OutputKey& other) const {
-    return std::make_pair(usage, arg_position) < std::make_pair(other.usage, other.arg_position);
-  }
+  constexpr bool operator!=(const OutputKey& other) const { return !operator==(other); }
 };
 
 // Convert `ExpressionUsage` to a string.
@@ -59,7 +51,7 @@ inline constexpr std::string_view StringFromExpressionUsage(const ExpressionUsag
 // Hash `OutputKey` type.
 struct OutputKeyHasher {
   constexpr std::size_t operator()(const OutputKey& k) const {
-    return HashCombine(static_cast<std::size_t>(k.usage), k.arg_position);
+    return HashCombine(static_cast<std::size_t>(k.usage), HashString(k.name));
   }
 };
 
@@ -73,7 +65,7 @@ struct ExpressionGroup {
   OutputKey key;
 
   ExpressionGroup(std::vector<Expr> expressions, OutputKey key)
-      : expressions(std::move(expressions)), key(key) {}
+      : expressions(std::move(expressions)), key(std::move(key)) {}
 };
 
 }  // namespace math

--- a/include/code_generation/ir_builder.h
+++ b/include/code_generation/ir_builder.h
@@ -102,6 +102,6 @@ ir::BlockPtr FindMergePoint(const ir::BlockPtr left, const ir::BlockPtr right,
 
 // Re-create `Expr` tree from the IR representation. For use in unit tests.
 std::unordered_map<OutputKey, std::vector<Expr>, OutputKeyHasher> CreateOutputExpressionMap(
-    ir::BlockPtr starting_block, const std::unordered_map<std::size_t, bool>* output_arg_exists);
+    ir::BlockPtr starting_block, const std::unordered_map<std::string, bool>* output_arg_exists);
 
 }  // namespace math

--- a/include/code_generation/ir_types.h
+++ b/include/code_generation/ir_types.h
@@ -212,16 +212,14 @@ struct OutputRequired {
   constexpr static bool IsCommutative() { return false; }
   constexpr static int NumValueOperands() { return 0; }
   constexpr std::string_view ToString() const { return "oreq"; }
-  constexpr std::size_t Hash() const { return arg_position; }
-  constexpr bool IsSame(const OutputRequired& other) const {
-    return arg_position == other.arg_position;
-  }
+  constexpr std::size_t Hash() const { return HashString(name); }
+  bool IsSame(const OutputRequired& other) const { return name == other.name; }
 
   constexpr NumericType DetermineType() const { return NumericType::Bool; }
 
-  explicit OutputRequired(std::size_t arg_position) : arg_position(arg_position) {}
+  explicit OutputRequired(std::string name) : name(name) {}
 
-  std::size_t arg_position;
+  std::string name;
 };
 
 // Phi function. The output is equal to whichever operand was generated on the evaluated code-path.
@@ -265,6 +263,8 @@ struct Save {
   constexpr bool IsSame(const Save& other) const {
     return key == other.key;  // && output_index == other.output_index;
   }
+
+  constexpr bool IsReturnValue() const { return key.usage == ExpressionUsage::ReturnValue; }
 
   OutputKey key;
 };

--- a/include/constants.h
+++ b/include/constants.h
@@ -24,7 +24,4 @@ inline bool IsPi(const Expr& expr) { return expr.IsIdenticalTo(Constants::Pi); }
 
 inline bool IsInfinity(const Expr& expr) { return expr.IsIdenticalTo(Constants::Infinity); }
 
-// A placeholder used to default initialize certain expressions during code-generation.
-Expr GetUnfilledExprPlaceholder();
-
 }  // namespace math

--- a/include/cpp_code_generator.h
+++ b/include/cpp_code_generator.h
@@ -66,8 +66,6 @@ class CppCodeGenerator {
 
   void operator()(CodeFormatter& formatter, const ast::OutputExists& x) const;
 
-  void operator()(CodeFormatter& formatter, const ast::ReturnValue& v) const;
-
   // Accept ast::Variant and delegate formatting of the stored type to our derived class.
   // Using enable_if here to prevent implicit conversion to the variant type.
   template <typename T, typename = std::enable_if_t<std::is_same_v<T, ast::Variant>>>
@@ -88,7 +86,6 @@ class CppCodeGenerator {
   }
 
  protected:
-  void FormatReturnType(CodeFormatter& formatter, const ast::FunctionSignature& signature) const;
   void FormatSignature(CodeFormatter& formatter, const ast::FunctionSignature& signature) const;
 };
 

--- a/include/function_evaluator.h
+++ b/include/function_evaluator.h
@@ -7,34 +7,12 @@
 
 namespace math {
 
-template <typename T, typename F, std::size_t... I>
-constexpr auto CreateVectorFromSequence(F&& func, std::integer_sequence<T, I...>) {
-  using U = std::invoke_result_t<F, T>;
-  std::vector<U> result;
-  result.reserve(sizeof...(I));
-  (result.push_back(func(I)), ...);
-  return result;
-}
-
-template <typename T>
-constexpr bool IsTuple = false;
-
-template <typename... Ts>
-constexpr bool IsTuple<std::tuple<Ts...>> = true;
-
-template <typename T>
-constexpr auto MaybeMakeTuple(T&& arg) {
-  if constexpr (IsTuple<T>) {
-    // Just copy it.
-    return T{std::forward<T>(arg)};
-  } else {
-    return std::make_tuple(std::forward<T>(arg));
-  }
-}
-
+// Invoke the provided function `func` and capture all the output expressions.
+// The outputs are inspected and converted into an instance of `ast::FunctionSignature` and a
+// vector of output expressions.
 template <typename Func, typename... ArgumentInfo>
 std::tuple<ast::FunctionSignature, std::vector<ExpressionGroup>> BuildFunctionDescription(
-    Func&& func, const std::string_view function_name, const ArgumentInfo&... args_in) {
+    Func&& func, const std::string_view function_name, ArgumentInfo&&... args_in) {
   static_assert(std::conjunction_v<std::is_constructible<Arg, ArgumentInfo>...>,
                 "args_in must be convertible to type Arg.");
 
@@ -45,43 +23,35 @@ std::tuple<ast::FunctionSignature, std::vector<ExpressionGroup>> BuildFunctionDe
   static_assert(TypeListSize<ArgList>::Value == sizeof...(ArgumentInfo),
                 "Mismatch in # args and # arg names");
 
-  const std::array<Arg, sizeof...(ArgumentInfo)> args = {Arg(args_in)...};
-
-  ast::FunctionSignature signature{std::string(function_name)};
-  detail::RecordArgs<ArgList>(signature, args, std::make_index_sequence<Traits::Arity>());
-  if constexpr (!std::is_same_v<void, ReturnType>) {
-    detail::RecordReturnTypes<ReturnType>{}(signature);
-  }
+  // Convert args into an array so that we can index them.
+  const std::array<Arg, sizeof...(ArgumentInfo)> args = {
+      Arg(std::forward<ArgumentInfo>(args_in))...};
 
   // Build inputs and invoke the function
-  auto [result, output_args] = detail::InvokeWithOutputCapture<ArgList>(
+  std::tuple outputs = detail::InvokeWithOutputCapture<ArgList>(
       std::forward<Func>(func), std::make_index_sequence<Traits::Arity>());
 
-  // If result was not a tuple, we convert it to a tuple w/ a single element.
-  const std::tuple result_as_tuple = MaybeMakeTuple(std::move(result));
+  // Copy expressions into `ExpressionGroup` objects, one per output:
+  std::vector<ExpressionGroup> groups{};
+  detail::CopyOutputExpressionsFromTuple(outputs, groups);
 
-  // Get the indices of only output arguments, as an array.
-  // Stupid that we have to use vector here, but std::array cannot be default constructed when size
-  // is zero.
-  const std::vector<OutputKey> output_arg_keys = CreateVectorFromSequence(
-      [&](std::size_t pos) {
-        return OutputKey(args[pos].IsOptional() ? ExpressionUsage::OptionalOutputArgument
-                                                : ExpressionUsage::OutputArgument,
-                         pos);
+  // Add all the input arguments:
+  ast::FunctionSignature signature{std::string(function_name)};
+  detail::RecordInputArgs<ArgList>(signature, args, std::make_index_sequence<Traits::Arity>());
+
+  // Record all the output arguments:
+  std::apply(
+      [&](auto&&... output_expression) {
+        static_assert(
+            std::conjunction_v<
+                IsOutputArgOrReturnValue<std::decay_t<decltype(output_expression)>>...>,
+            "All returned elements of the tuple must be explicitly marked as `ReturnValue` or "
+            "`OutputArg`.");
+        (detail::RecordOutput<std::decay_t<decltype(output_expression)>>{}(signature,
+                                                                           output_expression),
+         ...);
       },
-      detail::FilterArguments<false>(ArgList{}));
-
-  // Compile time iota for the # of return values:
-  constexpr std::size_t num_return_vals = std::tuple_size_v<decltype(result_as_tuple)>;
-  const std::vector<OutputKey> return_val_keys = CreateVectorFromSequence(
-      [&](std::size_t pos) { return OutputKey(ExpressionUsage::ReturnValue, pos); },
-      std::make_index_sequence<num_return_vals>());
-
-  std::vector<ExpressionGroup> groups;
-  groups.reserve(output_arg_keys.size() + return_val_keys.size());
-
-  detail::CopyOutputExpressions(output_args, output_arg_keys, groups);
-  detail::CopyOutputExpressions(result_as_tuple, return_val_keys, groups);
+      outputs);
 
   return std::make_tuple(std::move(signature), std::move(groups));
 }

--- a/include/output_annotations.h
+++ b/include/output_annotations.h
@@ -1,0 +1,111 @@
+#pragma once
+#include <string>
+#include <type_traits>
+
+namespace math {
+
+// Denote a captured result from a function that should be mapped to an output argument.
+// Stores the symbolic expression, a variable name, and whether the output should be optional.
+template <typename T>
+class OutputArg {
+ public:
+  template <typename U>
+  using EnableIfDecayedTypeMatches = std::enable_if_t<std::is_same_v<T, std::decay_t<U>>>;
+
+  template <typename U, typename = EnableIfDecayedTypeMatches<U>>
+  constexpr OutputArg(std::string_view name, U&& u)
+      : value_(std::forward<U>(u)), name_(name), is_optional_(false) {}
+
+  template <typename U, typename = EnableIfDecayedTypeMatches<U>>
+  constexpr OutputArg(std::string_view name, U&& u, bool is_optional)
+      : value_(std::forward<U>(u)), name_(name), is_optional_(is_optional) {}
+
+  // Access the output value. Typically, an `Expr` or `MatrixExpr`, etc.
+  constexpr const T& Value() const { return value_; }
+
+  // Name of the argument.
+  constexpr const std::string& Name() const { return name_; }
+
+  // True if the output argument is optional.
+  constexpr bool IsOptional() const { return is_optional_; }
+
+ private:
+  T value_;
+  std::string name_;
+  bool is_optional_;
+};
+
+// Deduction guide for `OutputArg`.
+template <class T>
+OutputArg(std::string_view name, T&& value) -> OutputArg<std::decay_t<T>>;
+
+// Construct an output argument and designate it as optional.
+template <typename T>
+constexpr auto OptionalOutputArg(std::string_view name, T&& value) {
+  return OutputArg<std::decay_t<T>>(name, std::forward<T>(value), true);
+}
+
+// Denote a captured result from a function that should be mapped to a return value.
+// Return values can never be optional.
+template <typename T>
+class ReturnValue {
+ public:
+  template <typename U>
+  using EnableIfDecayedTypeMatches = std::enable_if_t<std::is_same_v<T, std::decay_t<U>>>;
+
+  template <typename U, typename = EnableIfDecayedTypeMatches<U>>
+  explicit ReturnValue(U&& value) : value_(std::forward<U>(value)) {}
+
+  // Access the output value. Typically, an `Expr` or `MatrixExpr`, etc.
+  constexpr const T& Value() const { return value_; }
+
+  // Convert to `OutputArg`.
+  OutputArg<T> ToOutputArg(const std::string_view name) const { return OutputArg(name, value_); }
+
+ private:
+  T value_;
+};
+
+// Deduction guide for `ReturnValue`.
+template <class T>
+ReturnValue(T&& value) -> ReturnValue<std::decay_t<T>>;
+
+template <typename T>
+struct IsOutputArg : public std::false_type {};
+template <typename T>
+struct IsOutputArg<OutputArg<T>> : public std::true_type {};
+
+template <typename T>
+struct IsReturnValue : public std::false_type {};
+template <typename T>
+struct IsReturnValue<ReturnValue<T>> : public std::true_type {};
+
+template <typename T>
+struct IsOutputArgOrReturnValue : public std::disjunction<IsOutputArg<T>, IsReturnValue<T>> {};
+
+// Count the number of instances of `ReturnValue` in a type pack.
+template <typename... Ts>
+constexpr std::size_t CountReturnValues =
+    (static_cast<std::size_t>(IsReturnValue<Ts>::value) + ...);
+
+namespace detail {
+template <std::ptrdiff_t Index>
+constexpr std::ptrdiff_t ReturnValueIndexRecursive() {
+  return -1;
+}
+template <std::ptrdiff_t Index, typename T, typename... Ts>
+constexpr std::ptrdiff_t ReturnValueIndexRecursive() {
+  return IsReturnValue<T>::value ? Index : ReturnValueIndexRecursive<Index + 1, Ts...>();
+}
+}  // namespace detail
+
+// Get the index of the first `ReturnValue` type in a type pack or tuple by recursively searching
+// the list of types. Yields -1 if there is no return value.
+template <typename T>
+struct ReturnValueIndex;
+template <typename... Ts>
+struct ReturnValueIndex<std::tuple<Ts...>> {
+  static constexpr std::ptrdiff_t value = detail::ReturnValueIndexRecursive<0, Ts...>();
+};
+
+}  // namespace math

--- a/include/template_utils.h
+++ b/include/template_utils.h
@@ -175,6 +175,12 @@ struct DecayRValueToValue {
       std::conditional_t<std::is_rvalue_reference_v<T>, std::decay_t<T>, const std::decay_t<T>&>;
 };
 
+// True if the type is a tuple.
+template <typename T>
+constexpr bool IsTuple = false;
+template <typename... Ts>
+constexpr bool IsTuple<std::tuple<Ts...>> = true;
+
 namespace detail {
 template <class... Ts>
 struct Overloaded : Ts... {

--- a/include/type_annotations.h
+++ b/include/type_annotations.h
@@ -9,16 +9,12 @@ namespace math {
 // User specifies this as an argument to `BuildFunctionDescription`.
 struct Arg {
   Arg() = default;
-  explicit Arg(const std::string_view name, bool optional = false)
-      : name_(name), optional_(optional) {}
+  explicit Arg(const std::string_view name) : name_(name) {}
 
-  const std::string& GetName() const { return name_; }
-
-  bool IsOptional() const { return optional_; }
+  constexpr const std::string& GetName() const { return name_; }
 
  private:
   std::string name_;
-  bool optional_{false};
 };
 
 namespace type_annotations {
@@ -30,6 +26,9 @@ struct StaticMatrix {
     ASSERT_EQUAL(Rows, expr_.NumRows());
     ASSERT_EQUAL(Cols, expr_.NumCols());
   }
+
+  constexpr index_t NumRows() const { return Rows; }
+  constexpr index_t NumCols() const { return Cols; }
 
   template <typename... Args>
   static std::enable_if_t<std::conjunction_v<std::is_constructible<Expr, Args>...>, StaticMatrix>

--- a/source/code_generation/expr_from_ir.cc
+++ b/source/code_generation/expr_from_ir.cc
@@ -10,7 +10,7 @@ namespace math {
 
 struct ExprFromIrVisitor {
   explicit ExprFromIrVisitor(const std::unordered_map<ir::ValuePtr, Expr>& value_to_expression,
-                             const std::unordered_map<std::size_t, bool>* output_arg_exists)
+                             const std::unordered_map<std::string, bool>* output_arg_exists)
       : value_to_expression_(value_to_expression), output_arg_exists_(output_arg_exists) {}
 
   Expr operator()(const ir::Add&, const std::vector<ir::ValuePtr>& args) const {
@@ -23,7 +23,7 @@ struct ExprFromIrVisitor {
 
   Expr operator()(const ir::OutputRequired& output, const std::vector<ir::ValuePtr>&) const {
     ASSERT(output_arg_exists_, "Must have an output arg map to process `OutputRequired`");
-    return output_arg_exists_->at(output.arg_position) ? Constants::True : Constants::False;
+    return output_arg_exists_->at(output.name) ? Constants::True : Constants::False;
   }
 
   Expr operator()(const ir::Pow&, const std::vector<ir::ValuePtr>& args) const {
@@ -77,11 +77,11 @@ struct ExprFromIrVisitor {
   }
 
   const std::unordered_map<ir::ValuePtr, Expr>& value_to_expression_;
-  const std::unordered_map<std::size_t, bool>* output_arg_exists_;
+  const std::unordered_map<std::string, bool>* output_arg_exists_;
 };
 
 std::unordered_map<OutputKey, std::vector<Expr>, OutputKeyHasher> CreateOutputExpressionMap(
-    ir::BlockPtr starting_block, const std::unordered_map<std::size_t, bool>* output_arg_exists) {
+    ir::BlockPtr starting_block, const std::unordered_map<std::string, bool>* output_arg_exists) {
   std::unordered_map<ir::ValuePtr, Expr> value_to_expression{};
   value_to_expression.reserve(200);
 

--- a/source/constants.cc
+++ b/source/constants.cc
@@ -15,9 +15,4 @@ const Expr Constants::Infinity = MakeExpr<math::Infinity>();
 const Expr Constants::True = MakeExpr<Constant>(SymbolicConstants::True);
 const Expr Constants::False = MakeExpr<Constant>(SymbolicConstants::False);
 
-Expr GetUnfilledExprPlaceholder() {
-  static const Expr expr{"<PLACEHOLDER>"};
-  return expr;
-}
-
 }  // namespace math

--- a/sym_wrapper/python_test/codegen_wrapper_test.py
+++ b/sym_wrapper/python_test/codegen_wrapper_test.py
@@ -38,8 +38,8 @@ class CodeGenerationWrapperTest(MathTestBase):
         return super().setUp()
 
     def tearDown(self) -> None:
-        # if self._tmp_dir is not None:
-        # shutil.rmtree(self._tmp_dir, ignore_errors=True)
+        if self._tmp_dir is not None:
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)
         return super().tearDown()
 
     def load_code(self, code: str, name: str) -> T.Callable:

--- a/sym_wrapper/python_test/run_python_tests.py
+++ b/sym_wrapper/python_test/run_python_tests.py
@@ -23,7 +23,11 @@ def main():
     env['PYTHONPATH'] = f'{str(binary_dir)}{sep}{str(SCRIPT_PATH.parent.parent)}'
 
     for name in ['codegen_wrapper_test.py', 'expression_wrapper_test.py', 'matrix_wrapper_test.py']:
-        subprocess.check_call([sys.executable, "-B", str(SCRIPT_PATH / name)], env=env)
+        try:
+            subprocess.check_call([sys.executable, "-B", str(SCRIPT_PATH / name)], env=env)
+        except subprocess.CalledProcessError:
+            print(f"\n*** The following test failed: {name}\n")
+            raise
 
 
 if __name__ == '__main__':

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,8 @@ function(add_code_generation_test NAME GENERATION_SOURCE_FILE TEST_SOURCE_FILE)
 
   # Then create a target that evaluates the result:
   set(evaluate_target ${NAME}_evaluate)
-  add_executable(${evaluate_target} ${TEST_SOURCE_FILE} custom_main.cc)
+  add_executable(${evaluate_target} ${TEST_SOURCE_FILE} custom_main.cc
+                                    "${TEST_OUTPUT_DIR}/generated.h")
   target_link_libraries(${evaluate_target} ${TEST_LIBRARY_NAME} gtest
                         math_runtime eigen)
   target_include_directories(${evaluate_target} PRIVATE ${TEST_OUTPUT_DIR})

--- a/test/cpp_generation_gen.cc
+++ b/test/cpp_generation_gen.cc
@@ -50,9 +50,14 @@ int main() {
   code += "namespace gen {\n\n";
 
   GenerateFunc(code, &SimpleMultiplyAdd, "simple_multiply_add", "x", "y", "z");
-  GenerateFunc(code, &VectorRotation2D, "vector_rotation_2d", "theta", "v", Arg("v_rot"),
-               Arg("D_theta", true));
-  GenerateFunc(code, &VectorNorm3D, "vector_norm_3d", "v", Arg("D_v", false));
+  GenerateFunc(
+      code,
+      [](Expr theta, ta::StaticMatrix<2, 1> v) {
+        auto [v_rot, v_rot_D_theta] = VectorRotation2D(theta, v);
+        return std::make_tuple(v_rot.ToOutputArg("v_rot"), std::move(v_rot_D_theta));
+      },
+      "vector_rotation_2d", "theta", "v");
+  GenerateFunc(code, &VectorNorm3D, "vector_norm_3d", "v");
   GenerateFunc(code, &Heaviside, "heaviside", Arg("x"));
   GenerateFunc(code, &ExclusiveOr, "exclusive_or", Arg("x"), Arg("y"));
 

--- a/test/cpp_generation_test.cc
+++ b/test/cpp_generation_test.cc
@@ -36,8 +36,8 @@ TEST(CppGenerationTest, TestSimpleMultiplyAdd) {
 TEST(CppGenerationTest, TestVectorRotation2D) {
   auto evaluator = CreateEvaluator(&VectorRotation2D);
 
-  Eigen::Vector2d v_rot_eval, D_angle_eval;
-  evaluator(1.12, {-6.5, 7.2}, v_rot_eval, D_angle_eval);
+  Eigen::Vector2d D_angle_eval;
+  Eigen::Vector2d v_rot_eval = evaluator(1.12, {-6.5, 7.2}, D_angle_eval);
 
   Eigen::Vector2d v_rot_gen, D_angle_gen;
   gen::vector_rotation_2d(1.12, Eigen::Vector2d{-6.5, 7.2}, v_rot_gen, D_angle_gen);
@@ -45,21 +45,21 @@ TEST(CppGenerationTest, TestVectorRotation2D) {
   EXPECT_EIGEN_NEAR(D_angle_eval, D_angle_gen, 1.0e-15);
 
   // should still work if the optional arg is omitted
-  evaluator(-0.7, {-5.5, 12.0}, v_rot_eval, D_angle_eval);
+  v_rot_eval = evaluator(-0.7, {-5.5, 12.0}, D_angle_eval);
   gen::vector_rotation_2d(-0.7, Eigen::Vector2d{-5.5, 12.0}, v_rot_gen, nullptr);
   EXPECT_EIGEN_NEAR(v_rot_eval, v_rot_gen, 1.0e-15);
 
   // Pass a map to the data:
   const std::array<double, 2> input_v = {7.123, -4.001};
   const Eigen::Map<const Eigen::Vector2d> input_v_map(input_v.data());
-  evaluator(22.0, input_v_map, v_rot_eval, D_angle_eval);
+  v_rot_eval = evaluator(22.0, input_v_map, D_angle_eval);
   gen::vector_rotation_2d(22.0, input_v_map, v_rot_gen, D_angle_gen);
 
   EXPECT_EIGEN_NEAR(v_rot_eval, v_rot_gen, 1.0e-15);
   EXPECT_EIGEN_NEAR(D_angle_eval, D_angle_gen, 1.0e-15);
 
   // pass a map for the output:
-  evaluator(0.3, {2.0, 3.0}, v_rot_eval, D_angle_eval);
+  v_rot_eval = evaluator(0.3, {2.0, 3.0}, D_angle_eval);
   gen::vector_rotation_2d(0.3, Eigen::Vector2d{2.0, 3.0}, v_rot_gen,
                           Eigen::Map<Eigen::Vector2d>(D_angle_gen.data()));
   EXPECT_EIGEN_NEAR(v_rot_eval, v_rot_gen, 1.0e-15);

--- a/test/span_test.cc
+++ b/test/span_test.cc
@@ -124,7 +124,7 @@ TEST(SpanTest, TestConstructor) {
 }
 
 TEST(SpanTest, TestMakeNullSpan) {
-  auto span = make_always_null_span<float, 2, 3>();
+  auto span = make_always_null_span<2, 3>();
   EXPECT_FALSE(span);
   EXPECT_EQ(nullptr, span.data());
   EXPECT_EQ(2, span.rows());

--- a/test/test_expressions.h
+++ b/test/test_expressions.h
@@ -12,20 +12,19 @@ namespace ta = type_annotations;
 
 inline Expr SimpleMultiplyAdd(Expr x, Expr y, Expr z) { return x * y + z; }
 
-inline void VectorRotation2D(Expr theta, ta::StaticMatrix<2, 1> v,
-                             ta::StaticMatrix<2, 1>& v_rot_out, ta::StaticMatrix<2, 1>& D_theta) {
+inline auto VectorRotation2D(Expr theta, ta::StaticMatrix<2, 1> v) {
   using namespace matrix_operator_overloads;
   MatrixExpr R = CreateMatrix(2, 2, cos(theta), -sin(theta), sin(theta), cos(theta));
   MatrixExpr v_rot{R * v};
-  v_rot_out = v_rot;
-  D_theta = v_rot.Diff(theta);
+  ta::StaticMatrix<2, 1> v_dot_D_theta{v_rot.Diff(theta)};
+  return std::make_tuple(ReturnValue(v_rot), OptionalOutputArg("D_theta", v_dot_D_theta));
 }
 
 // Norm of a 3D vector + the 1x3 derivative.
-inline Expr VectorNorm3D(ta::StaticMatrix<3, 1> v, ta::StaticMatrix<1, 3>& D_v) {
+inline auto VectorNorm3D(ta::StaticMatrix<3, 1> v) {
   Expr len = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-  D_v = ta::StaticMatrix<1, 3>::Create(len.Diff(v[0]), len.Diff(v[1]), len.Diff(v[2]));
-  return len;
+  auto D_v = ta::StaticMatrix<1, 3>::Create(len.Diff(v[0]), len.Diff(v[1]), len.Diff(v[2]));
+  return std::make_tuple(ReturnValue(len), OutputArg("D_v", D_v));
 }
 
 // Heaviside step function - a very simple conditional.


### PR DESCRIPTION
- [x] Remove support for emitting matrices as return types in C++
- [x] Simplify return value handling (only one return value allowed)
- [x] Cleanup interface for calling `BuildFunctionDescription` (all output values are passed by return now)