### PR TITLE
Standardize formatting on python `**` power syntax

### DIFF
--- a/include/plain_formatter.h
+++ b/include/plain_formatter.h
@@ -4,22 +4,9 @@
 
 namespace math {
 
-// How to print the pow() operation:
-enum class PowerStyle {
-  // Use the ^ operator.
-  Hat,
-  // Use the python ** operator.
-  Python,
-};
-
 // Simple plain-text formatter.
 class PlainFormatter {
  public:
-  using ReturnType = void;
-
-  PlainFormatter() = default;
-  PlainFormatter(PowerStyle style) : power_style_(style) {}
-
   void operator()(const Addition& add);
   void operator()(const Conditional& conditional);
   void operator()(const Constant& constant);
@@ -47,7 +34,6 @@ class PlainFormatter {
   void FormatPower(const Expr& Base, const Expr& Exponent);
 
   std::string output_{};
-  PowerStyle power_style_{PowerStyle::Hat};
 };
 
 }  // namespace math

--- a/source/expression.cc
+++ b/source/expression.cc
@@ -24,7 +24,6 @@ Expr Expr::FromFloat(const double x) {
 Expr Expr::FromInt(const std::int64_t x) { return Integer::Create(x); }
 
 std::string Expr::ToString() const {
-  ASSERT(impl_);
   PlainFormatter formatter{};
   Visit(*this, formatter);
   return formatter.GetOutput();

--- a/source/plain_formatter.cc
+++ b/source/plain_formatter.cc
@@ -120,8 +120,8 @@ void PlainFormatter::operator()(const Matrix& mat) {
   elements.resize(mat.Size());
 
   // Format all the child elements up front. That way we can do alignment:
-  std::transform(mat.begin(), mat.end(), elements.begin(), [this](const Expr& expr) {
-    PlainFormatter child_formatter{power_style_};
+  std::transform(mat.begin(), mat.end(), elements.begin(), [](const Expr& expr) {
+    PlainFormatter child_formatter{};
     Visit(expr, child_formatter);
     return child_formatter.output_;
   });
@@ -244,11 +244,7 @@ void PlainFormatter::FormatPrecedence(const Precedence parent, const Expr& expr)
 
 void PlainFormatter::FormatPower(const Expr& base, const Expr& exponent) {
   FormatPrecedence(Precedence::Power, base);
-  if (power_style_ == PowerStyle::Hat) {
-    output_ += " ^ ";
-  } else if (power_style_ == PowerStyle::Python) {
-    output_ += " ** ";
-  }
+  output_ += " ** ";
   FormatPrecedence(Precedence::Power, exponent);
 }
 

--- a/sym_wrapper/expression_wrapper.cc
+++ b/sym_wrapper/expression_wrapper.cc
@@ -81,7 +81,7 @@ PYBIND11_MODULE(pysym, m) {
       // String conversion:
       .def("__repr__",
            [](const Expr& self) {
-             PlainFormatter formatter{PowerStyle::Python};
+             PlainFormatter formatter{};
              Visit(self, formatter);
              return formatter.GetOutput();
            })

--- a/sym_wrapper/matrix_wrapper.cc
+++ b/sym_wrapper/matrix_wrapper.cc
@@ -332,7 +332,7 @@ void WrapMatrixOperations(py::module_& m) {
       // Expr inherited properties:
       .def("__repr__",
            [](const MatrixExpr& self) {
-             PlainFormatter formatter{PowerStyle::Python};
+             PlainFormatter formatter{};
              Visit(static_cast<const Expr&>(self), formatter);
              return formatter.GetOutput();
            })

--- a/test/plain_formatter_test.cc
+++ b/test/plain_formatter_test.cc
@@ -82,8 +82,8 @@ TEST(PlainFormatterTest, TestMultiplication) {
   ASSERT_STR_EQ("x * y / z", x * y / z);
   ASSERT_STR_EQ("(1 + x) / (y * z)", (x + 1) / (y * z));
   ASSERT_STR_EQ("z * (1 + x) / y", (x + 1) / y * z);
-  ASSERT_STR_EQ("-2 * x ^ 3 * y", -2 * y * x * x * x);
-  ASSERT_STR_EQ("-2 * y / x ^ 3", -(x + x) * y / (x * x * x * x));
+  ASSERT_STR_EQ("-2 * x ** 3 * y", -2 * y * x * x * x);
+  ASSERT_STR_EQ("-2 * y / x ** 3", -(x + x) * y / (x * x * x * x));
   ASSERT_STR_EQ("-y * z * (x + z) / x", -y / x * z * (z + x));
   ASSERT_STR_EQ("z / (x + y)", z / (x + y));
   ASSERT_STR_EQ("y - z / x", -z / x + y);
@@ -92,12 +92,12 @@ TEST(PlainFormatterTest, TestMultiplication) {
   // Divisions including rationals:
   ASSERT_STR_EQ("5 * x / 7", (5 / 7_s) * x);
   ASSERT_STR_EQ("-6 * x / (11 * z)", (6 / 11_s) * x / -z);
-  ASSERT_STR_EQ("2 ^ (1 / 3) * 10 * x / 7", (5 / 7_s) * pow(2, 4 / 3_s) * x);
+  ASSERT_STR_EQ("2 ** (1 / 3) * 10 * x / 7", (5 / 7_s) * pow(2, 4 / 3_s) * x);
   ASSERT_STR_EQ("2 * x / (3 * y)", (-2 / 3_s) * x / -y);
 
   // Multiplications involving powers:
-  ASSERT_STR_EQ("y ^ x / (5 * x ^ z)", pow(y, x) / (pow(x, z) * 5));
-  ASSERT_STR_EQ("y ^ (3 * x / 5) / (x ^ 5.22 * z ^ (2 * w))",
+  ASSERT_STR_EQ("y ** x / (5 * x ** z)", pow(y, x) / (pow(x, z) * 5));
+  ASSERT_STR_EQ("y ** (3 * x / 5) / (x ** 5.22 * z ** (2 * w))",
                 pow(y, 3 / 5_s * x) * pow(z, -2 * w) * pow(x, -5.22_s));
 }
 
@@ -105,16 +105,16 @@ TEST(PlainFormatterTest, TestPower) {
   const Expr x{"x"};
   const Expr y{"y"};
   const Expr z{"z"};
-  ASSERT_STR_EQ("x ^ y", pow(x, y));
+  ASSERT_STR_EQ("x ** y", pow(x, y));
   ASSERT_STR_EQ("8", pow(2, 3));
-  ASSERT_STR_EQ("(x + y) ^ z", pow(x + y, z));
-  ASSERT_STR_EQ("x ^ (-y + z)", pow(x, z - y));
-  ASSERT_STR_EQ("x ^ z * y ^ z", pow(y * x, z));
-  ASSERT_STR_EQ("x ^ (z / y) * y ^ (z / y)", pow(y * x, z / y));
-  ASSERT_STR_EQ("(-y + x * y) ^ (x + y + z)", pow(y * x - y, z + y + x));
-  ASSERT_STR_EQ("y ^ (x ^ z)", pow(y, pow(x, z)));
-  ASSERT_STR_EQ("(x ^ (-x + y)) ^ (x ^ (-3 * z / 7))", pow(pow(x, y - x), pow(x, 3 * z / -7_s)));
-  ASSERT_STR_EQ("-5 ^ (2 / 3) * 7 ^ (2 / 3) + x - y * z",
+  ASSERT_STR_EQ("(x + y) ** z", pow(x + y, z));
+  ASSERT_STR_EQ("x ** (-y + z)", pow(x, z - y));
+  ASSERT_STR_EQ("x ** z * y ** z", pow(y * x, z));
+  ASSERT_STR_EQ("x ** (z / y) * y ** (z / y)", pow(y * x, z / y));
+  ASSERT_STR_EQ("(-y + x * y) ** (x + y + z)", pow(y * x - y, z + y + x));
+  ASSERT_STR_EQ("y ** (x ** z)", pow(y, pow(x, z)));
+  ASSERT_STR_EQ("(x ** (-x + y)) ** (x ** (-3 * z / 7))", pow(pow(x, y - x), pow(x, 3 * z / -7_s)));
+  ASSERT_STR_EQ("-5 ** (2 / 3) * 7 ** (2 / 3) + x - y * z",
                 pow(5 * 7, 2 / 3_s) * Constants::NegativeOne + x - y * z);
 }
 


### PR DESCRIPTION
- Get rid of hat formatting for powers and use python ** style everywhere