### PR TITLE
Remove Matrix from the expression type hierarchy

### DIFF
--- a/components/math/include/expression.h
+++ b/components/math/include/expression.h
@@ -57,6 +57,10 @@ class Expr {
   // Convert to string.
   std::string ToString() const;
 
+  // Convert to string of the expression tree.
+  // Defined in tree_formatter.cc
+  std::string ToExpressionTreeString() const;
+
   // Get the hash of the expression.
   std::size_t Hash() const { return impl_->GetHash(); }
 

--- a/components/math/include/geometry/quaternion.h
+++ b/components/math/include/geometry/quaternion.h
@@ -17,14 +17,7 @@ class Quaternion {
   // Initialize with elements in order [w, x, y, z].
   // No normalization occurs by default.
   Quaternion(Expr w, Expr x, Expr y, Expr z)
-      : wxyz_{std::move(w), std::move(x), std::move(y), std::move(z)} {
-    for (const Expr& expr : wxyz_) {
-      if (expr.Is<Matrix>()) {
-        throw TypeError("Arguments to Quaternion() cannot be matrices. Received: {}",
-                        expr.ToString());
-      }
-    }
-  }
+      : wxyz_{std::move(w), std::move(x), std::move(y), std::move(z)} {}
 
   // Default initialize to identity (w = 1, xyz = 0).
   Quaternion() : Quaternion(Constants::One, Constants::Zero, Constants::Zero, Constants::Zero) {}

--- a/components/math/include/plain_formatter.h
+++ b/components/math/include/plain_formatter.h
@@ -15,7 +15,7 @@ class PlainFormatter {
   void operator()(const FunctionArgument& func_arg);
   void operator()(const Infinity&);
   void operator()(const Integer& num);
-  void operator()(const Matrix& mat);
+  void operator()(const class Matrix& mat);
   void operator()(const Multiplication& mul);
   void operator()(const Power& pow);
   void operator()(const Rational& rational);
@@ -23,8 +23,8 @@ class PlainFormatter {
   void operator()(const Function& func);
   void operator()(const Variable& var);
 
-  // Get the output string.
-  const std::string& GetOutput() const { return output_; }
+  // Get the output string (transferring ownership to the caller).
+  std::string TakeOutput() const { return std::move(output_); }
 
  private:
   // Wrap `expr` in braces if the precedence is <= the parent.

--- a/components/math/include/visitor_base.h
+++ b/components/math/include/visitor_base.h
@@ -24,7 +24,6 @@ using ExpressionTypeList = TypeList<
     class FunctionArgument,
     class Infinity,
     class Integer,
-    class Matrix,
     class Multiplication,
     class Power,
     class Rational,

--- a/components/math/source/code_generation/ir_builder.cc
+++ b/components/math/source/code_generation/ir_builder.cc
@@ -59,9 +59,6 @@ struct DetermineNumericTypeVisitor {
 
   constexpr NumericType operator()(const Integer&) const { return NumericType::Integer; }
 
-  // TODO: For now all matrices are interpreted as real.
-  constexpr NumericType operator()(const Matrix&) const { return NumericType::Real; }
-
   NumericType operator()(const Multiplication& mul) const {
     // Multiplying booleans produces an integer, same as C++.
     NumericType type = NumericType::Integer;
@@ -370,10 +367,6 @@ struct IRFormVisitor {
         "Cannot generate code for expressions containing `Derivative`. Offending expression is: "
         "Derivative({}, {}, {})",
         derivative.Differentiand().ToString(), derivative.Arg().ToString(), derivative.Order());
-  }
-
-  ir::ValuePtr operator()(const Matrix&, const Expr&) const {
-    throw TypeError("Cannot evaluate this on a matrix.");
   }
 
   ir::ValuePtr operator()(const Function& func, const Expr&) {

--- a/components/math/source/collect.cc
+++ b/components/math/source/collect.cc
@@ -112,7 +112,6 @@ struct CollectVisitor {
     return CollectAdditionTerms(std::move(children));
   }
 
-  Expr operator()(const Matrix& mat) { return Recurse(mat); }
   Expr operator()(const Multiplication& mul, const Expr&) { return Recurse(mul); }
   Expr operator()(const Function& f) { return Recurse(f); }
   Expr operator()(const Power& pow) { return Recurse(pow); }

--- a/components/math/source/derivative.cc
+++ b/components/math/source/derivative.cc
@@ -71,11 +71,6 @@ class DiffVisitor {
     return Derivative::Create(derivative_abstract, argument_abstract_, 1);
   }
 
-  // Element-wise derivative of matrix.
-  Expr operator()(const Matrix& mat) {
-    return MapChildren(mat, [this](const Expr& x) { return VisitWithExprArg(x, *this); });
-  }
-
   // Do product expansion over all terms in the multiplication:
   // a * b
   // a' * b + a * b'

--- a/components/math/source/distribute.cc
+++ b/components/math/source/distribute.cc
@@ -11,7 +11,6 @@ namespace math {
 // (a + b) * (x + y) = a*x + a*y + b*x + b*y
 struct DistributeVisitor {
   Expr operator()(const Addition& add, const Expr&) const { return MapChildren(add, &Distribute); }
-  Expr operator()(const Matrix& mat, const Expr&) const { return MapChildren(mat, &Distribute); }
 
   Expr operator()(const Multiplication& mul, const Expr&) const {
     // First distribute all the children of the multiplication:

--- a/components/math/source/evaluate.cc
+++ b/components/math/source/evaluate.cc
@@ -9,7 +9,6 @@ struct EvaluateVisitor {
   using ReturnType = Expr;
 
   Expr operator()(const Addition& add, const Expr&) const { return MapChildren(add, &Eval); }
-  Expr operator()(const Matrix& mat, const Expr&) const { return MapChildren(mat, &Eval); }
   Expr operator()(const Multiplication& mul, const Expr&) const { return MapChildren(mul, &Eval); }
   Expr operator()(const Function& f, const Expr&) const { return MapChildren(f, &Eval); }
   Expr operator()(const Power& pow, const Expr&) const { return MapChildren(pow, &Eval); }

--- a/components/math/source/expression.cc
+++ b/components/math/source/expression.cc
@@ -26,7 +26,7 @@ Expr Expr::FromInt(const std::int64_t x) { return Integer::Create(x); }
 std::string Expr::ToString() const {
   PlainFormatter formatter{};
   Visit(*this, formatter);
-  return formatter.GetOutput();
+  return formatter.TakeOutput();
 }
 
 Expr Expr::operator-() const {
@@ -46,9 +46,6 @@ Expr operator-(const Expr& a, const Expr& b) {
 Expr operator*(const Expr& a, const Expr& b) { return Multiplication::FromOperands({a, b}); }
 
 Expr operator/(const Expr& a, const Expr& b) {
-  if (b.Is<Matrix>()) {
-    throw TypeError("Cannot divide by a matrix expression of type: {}", b.TypeName());
-  }
   auto one_over_b = Power::Create(b, Constants::NegativeOne);
   return Multiplication::FromOperands({a, one_over_b});
 }

--- a/components/math/source/expressions/addition.cc
+++ b/components/math/source/expressions/addition.cc
@@ -12,14 +12,7 @@
 namespace math {
 
 Expr Addition::FromOperands(absl::Span<const Expr> args) {
-  const bool any_matrices =
-      std::any_of(args.begin(), args.end(), [](const Expr& arg) { return arg.Is<Matrix>(); });
-  if (any_matrices) {
-    throw TypeError("This should be handled elsewhere!");
-  }
-
   // TODO: extract common denominator?
-
   AdditionParts parts{args.size()};
   for (const Expr& arg : args) {
     parts.Add(arg);
@@ -48,11 +41,6 @@ struct AdditionVisitor {
     } else {
       parts.float_term = (*parts.float_term) + f;
     }
-  }
-
-  void operator()(const Matrix&) {
-    throw TypeError("Cannot add a matrix into a scalar addition expression. Arg type = {}",
-                    Matrix::NameStr);
   }
 
   using ExcludedTypes = TypeList<Addition, Integer, Rational, Float, Matrix>;

--- a/components/math/source/expressions/matrix.cc
+++ b/components/math/source/expressions/matrix.cc
@@ -30,15 +30,6 @@ Matrix Matrix::Transpose() const {
   return Matrix(output_rows, output_cols, std::move(output));
 }
 
-void Matrix::MultiplyByScalarInPlace(const Expr& arg) {
-  if (arg.Is<Matrix>()) {
-    throw TypeError("Expected a scalar expression, but got a matrix of type: {}", arg.TypeName());
-  }
-  for (Expr& expr : data_) {
-    expr = expr * arg;
-  }
-}
-
 Matrix operator*(const Matrix& a, const Matrix& b) {
   if (a.NumCols() != b.NumRows()) {
     throw DimensionError(

--- a/components/math/source/expressions/multiplication.cc
+++ b/components/math/source/expressions/multiplication.cc
@@ -36,13 +36,6 @@ Expr Multiplication::FromOperands(absl::Span<const Expr> args) {
     return args.front();
   }
 
-  // TODO: Delete this once matrix is removed from `Expr` hierarchy.
-  const bool any_matrices =
-      std::any_of(args.begin(), args.end(), [](const Expr& x) { return x.Is<Matrix>(); });
-  if (any_matrices) {
-    throw TypeError("This should be handled elsewhere!");
-  }
-
   // Check for zeros:
   // TODO: This is not valid if there are divisions by zero...
   // We need an 'undefined' type.

--- a/components/math/source/functions.cc
+++ b/components/math/source/functions.cc
@@ -333,8 +333,6 @@ Expr max(const Expr& a, const Expr& b) { return where(a < b, b, a); }
 Expr min(const Expr& a, const Expr& b) { return where(b < a, b, a); }
 
 Expr where(const Expr& condition, const Expr& if_true, const Expr& if_false) {
-  ASSERT(!if_true.Is<Matrix>() && !if_false.Is<Matrix>(),
-         "TODO: Should be illegal to pass Matrix here.");
   return Conditional::Create(condition, if_true, if_false);
 }
 

--- a/components/math/source/matrix_expression.cc
+++ b/components/math/source/matrix_expression.cc
@@ -3,27 +3,32 @@
 
 #include "constants.h"
 #include "expressions/matrix.h"
+#include "plain_formatter.h"
 
 namespace math {
 
-MatrixExpr::MatrixExpr(Expr&& arg) : expr_(std::move(arg)) {
-  ASSERT(expr_.Impl(), "Expr is non-nullable");
-  // TODO: Need to handle other matrix types here eventually.
-  if (!CastPtr<Matrix>(expr_)) {
-    throw TypeError(
-        "Attempted to construct MatrixExpr from expression of type: {}. Expression = {}",
-        expr_.TypeName(), expr_.ToString());
-  }
-}
-
-MatrixExpr::MatrixExpr(const Expr& arg) : MatrixExpr(Expr{arg}) {}
+MatrixExpr::MatrixExpr(Matrix&& content)
+    : matrix_(std::make_shared<const Matrix>(std::move(content))) {}
 
 MatrixExpr MatrixExpr::Create(index_t rows, index_t cols, std::vector<Expr> args) {
-  return MatrixExpr{MakeExpr<Matrix>(rows, cols, std::move(args))};
+  return MatrixExpr{Matrix{rows, cols, std::move(args)}};
 }
 
 // For now, a lot of these methods just forward to the `Matrix` type. In the future,
 // we may have different matrix types.
+
+// Test if the two expressions are identical.
+bool MatrixExpr::IsIdenticalTo(const MatrixExpr& other) const {
+  return AsMatrix().IsIdenticalTo(other.AsMatrix());
+}
+
+std::string_view MatrixExpr::TypeName() const { return Matrix::NameStr; }
+
+std::string MatrixExpr::ToString() const {
+  PlainFormatter formatter{};
+  formatter(AsMatrix());
+  return formatter.TakeOutput();
+}
 
 index_t MatrixExpr::NumRows() const { return AsMatrix().NumRows(); }
 
@@ -35,34 +40,41 @@ const Expr& MatrixExpr::operator()(index_t i, index_t j) const { return AsMatrix
 
 MatrixExpr MatrixExpr::GetBlock(index_t row, index_t col, index_t nrows, index_t ncols) const {
   Matrix result = AsMatrix().GetBlock(row, col, nrows, ncols);
-  return MatrixExpr{MakeExpr<Matrix>(std::move(result))};
+  return MatrixExpr{std::move(result)};
 }
 
-MatrixExpr MatrixExpr::Transpose() const {
-  return MatrixExpr{MakeExpr<Matrix>(AsMatrix().Transpose())};
-}
+MatrixExpr MatrixExpr::Transpose() const { return MatrixExpr{AsMatrix().Transpose()}; }
 
-const Matrix& MatrixExpr::AsMatrix() const {
-  // We already checked the type in the constructor, so just static-cast here with no validation.
-  return CastUnchecked<Matrix>(expr_);
-}
+const Matrix& MatrixExpr::AsMatrix() const { return *matrix_.get(); }
 
 MatrixExpr MatrixExpr::operator-() const {
   return matrix_operator_overloads::operator*(*this, Constants::NegativeOne);
 }
 
+MatrixExpr MatrixExpr::Diff(const Expr& var, int reps) const {
+  return MatrixExpr{AsMatrix().Map([&](const Expr& x) { return x.Diff(var, reps); })};
+}
+
+MatrixExpr MatrixExpr::Distribute() const { return MatrixExpr{AsMatrix().Map(&math::Distribute)}; }
+
+MatrixExpr MatrixExpr::Subs(const Expr& target, const Expr& replacement) const {
+  return MatrixExpr{AsMatrix().Map([&](const Expr& x) { return x.Subs(target, replacement); })};
+}
+
+MatrixExpr MatrixExpr::Eval() const { return MatrixExpr{AsMatrix().Map(&math::Eval)}; }
+
 namespace matrix_operator_overloads {
 
 MatrixExpr operator+(const MatrixExpr& a, const MatrixExpr& b) {
-  return MatrixExpr{MakeExpr<Matrix>(a.AsMatrix() + b.AsMatrix())};
+  return MatrixExpr{a.AsMatrix() + b.AsMatrix()};
 }
 
 MatrixExpr operator-(const MatrixExpr& a, const MatrixExpr& b) {
-  return MatrixExpr{MakeExpr<Matrix>(a.AsMatrix() - b.AsMatrix())};
+  return MatrixExpr{a.AsMatrix() - b.AsMatrix()};
 }
 
 MatrixExpr operator*(const MatrixExpr& a, const MatrixExpr& b) {
-  return MatrixExpr{MakeExpr<Matrix>(a.AsMatrix() * b.AsMatrix())};
+  return MatrixExpr{a.AsMatrix() * b.AsMatrix()};
 }
 
 MatrixExpr operator*(const MatrixExpr& a, const Expr& b) {
@@ -73,7 +85,7 @@ MatrixExpr operator*(const MatrixExpr& a, const Expr& b) {
   std::transform(a_mat.begin(), a_mat.end(), std::back_inserter(data),
                  [&b](const Expr& a_expr) { return a_expr * b; });
 
-  return MatrixExpr{MakeExpr<Matrix>(a_mat.NumRows(), a_mat.NumCols(), std::move(data))};
+  return MatrixExpr{Matrix(a_mat.NumRows(), a_mat.NumCols(), std::move(data))};
 }
 
 }  // namespace matrix_operator_overloads

--- a/components/math/source/matrix_functions.cc
+++ b/components/math/source/matrix_functions.cc
@@ -336,9 +336,8 @@ std::tuple<MatrixExpr, MatrixExpr, MatrixExpr, MatrixExpr> FactorizeFullPivLU(
   auto U = std::move(std::get<2>(results));
 
   // Convert to MatrixExpr:
-  return std::make_tuple(
-      CreateMatrixFromPermutations(P), MatrixExpr{MakeExpr<Matrix>(std::move(L))},
-      MatrixExpr{MakeExpr<Matrix>(std::move(U))}, CreateMatrixFromPermutations(Q));
+  return std::make_tuple(CreateMatrixFromPermutations(P), MatrixExpr{std::move(L)},
+                         MatrixExpr{std::move(U)}, CreateMatrixFromPermutations(Q));
 }
 
 Expr Determinant(const MatrixExpr& m) {

--- a/components/math/source/ordering.cc
+++ b/components/math/source/ordering.cc
@@ -9,9 +9,9 @@ namespace math {
 struct OrderVisitor {
   using ReturnType = RelativeOrder;
 
-  using OrderOfTypes = TypeList<Float, Integer, Rational, Constant, Infinity, Variable,
-                                FunctionArgument, Multiplication, Addition, Power, Function,
-                                Relational, Conditional, Derivative, Matrix>;
+  using OrderOfTypes =
+      TypeList<Float, Integer, Rational, Constant, Infinity, Variable, FunctionArgument,
+               Multiplication, Addition, Power, Function, Relational, Conditional, Derivative>;
 
   // Every type in the approved type list must appear here, or we get a compile error:
   static_assert(TypeListSize<OrderOfTypes>::Value == TypeListSize<ExpressionTypeList>::Value);
@@ -75,17 +75,6 @@ struct OrderVisitor {
   }
 
   RelativeOrder Compare(const Multiplication& a, const Multiplication& b) const {
-    return LexicographicalCompare(a.begin(), a.end(), b.begin(), b.end());
-  }
-
-  RelativeOrder Compare(const Matrix& a, const Matrix& b) const {
-    const auto dims_a = std::make_pair(a.NumRows(), a.NumCols());
-    const auto dims_b = std::make_pair(b.NumRows(), b.NumCols());
-    if (dims_a < dims_b) {
-      return RelativeOrder::LessThan;
-    } else if (dims_a > dims_b) {
-      return RelativeOrder::GreaterThan;
-    }
     return LexicographicalCompare(a.begin(), a.end(), b.begin(), b.end());
   }
 

--- a/components/math/source/tree_formatter.cc
+++ b/components/math/source/tree_formatter.cc
@@ -1,9 +1,10 @@
 // Copyright 2022 Gareth Cross
-#include <fmt/format.h>
 #include <vector>
 
 #include "expression.h"
 #include "expressions/all_expressions.h"
+#include "fmt_imports.h"
+#include "matrix_expression.h"
 #include "visitor_impl.h"
 
 namespace math {
@@ -159,12 +160,12 @@ struct TreeFormatter {
   }
 
   // Get the output string via move.
-  void TakeOutput(std::string& output) {
+  std::string TakeOutput() {
     // Somewhat hacky. The formatter appends a superfluous newline on the last element. I think
     // this is tricky to avoid w/o knowing the tree depth apriori. Instead, just trim it from the
     // end.
     RightTrimInPlace(output_);
-    output = std::move(output_);
+    return std::move(output_);
   }
 
  private:
@@ -175,12 +176,16 @@ struct TreeFormatter {
   std::string output_;
 };
 
-std::string FormatDebugTree(const Expr& expr) {
+std::string Expr::ToExpressionTreeString() const {
   TreeFormatter formatter{};
-  Visit(expr, formatter);
-  std::string output;
-  formatter.TakeOutput(output);
-  return output;
+  Visit(*this, formatter);
+  return formatter.TakeOutput();
+}
+
+std::string MatrixExpr::ToExpressionTreeString() const {
+  TreeFormatter formatter{};
+  formatter(AsMatrix());
+  return formatter.TakeOutput();
 }
 
 }  // namespace math

--- a/components/python/sym/code_generation.py
+++ b/components/python/sym/code_generation.py
@@ -284,17 +284,12 @@ def codegen_function(
     for val in result_expressions:
         if not isinstance(val, (ReturnValue, OutputArg)):
             raise TypeError(f"Returned values must be: {ReturnValueOrOutputArg}, got: {type(val)}")
-        elif isinstance(val.expression, sym.Expr):
-            # If return value is `Expr`, see if it can be coerced to matrix:
-            try:
-                val.expression = sym.MatrixExpr(val.expression)
-            except sym.TypeError:
-                pass
 
         if isinstance(val.expression, sym.Expr):
             output_type = codegen.ScalarType(codegen.NumericType.Real)
             group_expressions = [val.expression]
         else:
+            assert isinstance(val.expression, sym.MatrixExpr), "Expected MatrixExpr"
             output_type = codegen.MatrixType(*val.expression.shape)
             group_expressions = val.expression.to_list()
 

--- a/components/sym_wrapper/expression_wrapper.cc
+++ b/components/sym_wrapper/expression_wrapper.cc
@@ -85,18 +85,9 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       .def(py::init<std::int64_t>())
       .def(py::init<double>())
       // String conversion:
-      .def("__repr__",
-           [](const Expr& self) {
-             PlainFormatter formatter{};
-             Visit(self, formatter);
-             return formatter.GetOutput();
-           })
-      .def("expression_tree_str", &FormatDebugTree,
+      .def("__repr__", &Expr::ToString)
+      .def("expression_tree_str", &Expr::ToExpressionTreeString,
            "Retrieve the expression tree as a pretty-printed string.")
-      .def(
-          "print_expression_tree",
-          [](const Expr& self) { fmt::print("{}\n", FormatDebugTree(self)); },
-          "Print the expression tree to standard out.")
       .def(
           "is_identical_to",
           [](const Expr& self, const Expr& other) { return self.IsIdenticalTo(other); }, "other"_a,

--- a/test/matrix_operations_test.cc
+++ b/test/matrix_operations_test.cc
@@ -56,10 +56,6 @@ TEST(MatrixOperationsTest, TestConstruct) {
   ASSERT_THROW(m(0, -1), DimensionError);
   ASSERT_THROW(m(5, 0), DimensionError);
   ASSERT_THROW(m(1, 10), DimensionError);
-
-  // Cannot make a matrix from sub-matrices:
-  ASSERT_THROW(RowVector(2.0, m), TypeError);
-  ASSERT_THROW(CreateMatrix(1, 1, m), TypeError);
 }
 
 TEST(MatrixOperationsTest, TestGetBlock) {
@@ -142,8 +138,6 @@ TEST(MatrixOperationsTest, TestAddition) {
   // Dimension mismatch:
   ASSERT_THROW(Vector(a, b) + RowVector(c, d), DimensionError);
   ASSERT_THROW(Vector(a, b) + CreateMatrix(2, 2, c, d, 2, -3_s / 5), DimensionError);
-  ASSERT_THROW(static_cast<Expr>(RowVector(c, d)) + a, TypeError);
-  ASSERT_THROW(static_cast<Expr>(RowVector(c, d)) - d, TypeError);
 
   const MatrixExpr m = CreateMatrix(2, 2, a, b, c, d);
   ASSERT_IDENTICAL(m, m + Zeros(2, 2));
@@ -195,9 +189,6 @@ TEST(MatrixOperationsTest, TestMultiplication) {
   ASSERT_THROW(Zeros(2, 3) * Zeros(4, 2), DimensionError);
   ASSERT_THROW(Zeros(10, 10) * Vector(x, y, z), DimensionError);
   ASSERT_THROW(RowVector(1, -3, z) * Vector(z, sin(y)), DimensionError);
-
-  // Cannot divide by matrix.
-  ASSERT_THROW(1 / static_cast<Expr>(Vector(1, 2, w)), TypeError);
 }
 
 void CheckFullPivLUSolution(

--- a/test/plain_formatter_test.cc
+++ b/test/plain_formatter_test.cc
@@ -34,7 +34,7 @@ testing::AssertionResult StringEqualTestHelper(const std::string&, const std::st
              "String `{}` does not match ({}).ToString(), where:\n({}).ToString() = {}\n"
              "The expression tree for `{}` is:\n{}",
              EscapeNewlines(a), name_b, name_b, EscapeNewlines(b_str), name_b,
-             FormatDebugTree(static_cast<Expr>(b)));
+             b.ToExpressionTreeString());
 }
 
 TEST(PlainFormatterTest, TestAdditionAndSubtraction) {

--- a/test/quaternion_test.cc
+++ b/test/quaternion_test.cc
@@ -19,9 +19,6 @@ TEST(QuaternionTest, TestConstructor) {
   ASSERT_IDENTICAL(y, q.y());
   ASSERT_IDENTICAL(z, q.z());
 
-  // Cannot pass vector or matrix arg
-  ASSERT_THROW(Quaternion(Vector(x, y, z).AsExpr(), x, y, z), TypeError);
-
   // Default construction:
   Quaternion q_identity{};
   ASSERT_IDENTICAL(0, q_identity.x());

--- a/test/substitute_test.cc
+++ b/test/substitute_test.cc
@@ -158,12 +158,6 @@ TEST(SubstituteTest, TestMatrix) {
   const auto [a, b, c] = Symbols("a", "b", "c");
   const MatrixExpr m0 = Vector(a + b, c + sin(b), 22 + c);
   ASSERT_IDENTICAL(Vector(a - log(c), c - sin(log(c)), 22 + c), m0.Subs(b, -log(c)));
-
-  // Replace a whole matrix at once:
-  // TODO: Does it make sense to allow this?
-  const MatrixExpr m1 = CreateMatrix(2, 2, a * b, c - Constants::Pi, cos(b), atan(b));
-  const auto I2 = static_cast<Expr>(Identity(2));
-  ASSERT_IDENTICAL(Identity(2), m1.Subs(static_cast<Expr>(m1), I2));
 }
 
 TEST(SubstituteTest, TestRelational) {

--- a/test/test_helpers.cc
+++ b/test/test_helpers.cc
@@ -1,34 +1,3 @@
 #include "test_helpers.h"
 
-#include <fmt/format.h>
-
-#include "plain_formatter.h"
-
-namespace math {
-
-inline std::size_t CountNewlines(const std::string& str) {
-  return std::count(str.begin(), str.end(), '\n');
-}
-
-testing::AssertionResult FormatFailedResult(const std::string_view description,
-                                            const std::string& name_a, const std::string& name_b,
-                                            const Expr& a, const Expr& b) {
-  // If the formatted string has multiple lines, preface it w/ a line break:
-  const std::string a_str = a.ToString();
-  const std::string b_str = b.ToString();
-  const std::string_view a_prefix = CountNewlines(a_str) > 0 ? "\n" : " ";
-  const std::string_view b_prefix = CountNewlines(b_str) > 0 ? "\n" : " ";
-
-  // clang-format off
-  return testing::AssertionFailure() << fmt::format(
-             "{} {} {}, where:\n{} ={}{}\nand {} ={}{}\n"
-             "expression tree for `{}`:\n{}\n"
-             "expression tree for `{}`:\n{}",
-             name_a, description, name_b,
-             name_a, a_prefix, a_str, name_b, b_prefix, b_str,
-             name_a, FormatDebugTree(a),
-             name_b, FormatDebugTree(b));
-  // clang-format on
-}
-
-}  // namespace math
+namespace math {}  // namespace math

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <gtest/gtest.h>
+#include "fmt_imports.h"
 
 #include "expression.h"
 #include "matrix_expression.h"
@@ -9,30 +10,77 @@ namespace math {
 #define ASSERT_IDENTICAL(val1, val2) ASSERT_PRED_FORMAT2(IdenticalTestHelper, val1, val2)
 #define ASSERT_NOT_IDENTICAL(val1, val2) ASSERT_PRED_FORMAT2(NotIdenticalTestHelper, val1, val2)
 
+template <typename A, typename B>
 testing::AssertionResult FormatFailedResult(const std::string_view description,
-                                            const std::string& name_a, const std::string& name_b,
-                                            const Expr& a, const Expr& b);
+                                            const std::string_view name_a,
+                                            const std::string_view name_b, const A& a, B& b) {
+  // If the formatted string has multiple lines, preface it w/ a line break:
+  const std::string a_str = a.ToString();
+  const std::string b_str = b.ToString();
+  const std::string_view a_prefix = std::count(a_str.begin(), a_str.end(), '\n') > 0 ? "\n" : " ";
+  const std::string_view b_prefix = std::count(b_str.begin(), b_str.end(), '\n') > 0 ? "\n" : " ";
+
+  // clang-format off
+  return testing::AssertionFailure() << fmt::format(
+             "{} {} {}, where:\n{} ={}{}\nand {} ={}{}\n"
+             "expression tree for `{}`:\n{}\n"
+             "expression tree for `{}`:\n{}",
+             name_a, description, name_b,
+             name_a, a_prefix, a_str, name_b, b_prefix, b_str,
+             name_a, a.ToExpressionTreeString(),
+             name_b, b.ToExpressionTreeString());
+  // clang-format on
+}
+
+// This indirection exists so that we can coerce numeric literals to expressions.
+template <typename T, typename = void>
+struct ConvertAssertionArgument;
+template <typename T>
+struct ConvertAssertionArgument<T, std::enable_if_t<std::is_convertible_v<T, Expr>>> {
+  // This overload will get selected for numeric literals.
+  Expr operator()(const T& arg) const { return static_cast<Expr>(arg); }
+};
+template <>
+struct ConvertAssertionArgument<MatrixExpr> {
+  MatrixExpr operator()(const MatrixExpr& arg) const { return arg; }
+};
 
 // Test IsIdenticalTo
 template <typename A, typename B>
-testing::AssertionResult IdenticalTestHelper(const std::string& name_a, const std::string& name_b,
-                                             const A& a, const B& b) {
-  if (static_cast<Expr>(a).IsIdenticalTo(static_cast<Expr>(b))) {
+testing::AssertionResult IdenticalTestHelper2(const std::string_view name_a,
+                                              const std::string_view name_b, const A& a,
+                                              const B& b) {
+  if (a.IsIdenticalTo(b)) {
     return testing::AssertionSuccess();
   }
-  return FormatFailedResult("is not identical to", name_a, name_b, static_cast<Expr>(a),
-                            static_cast<Expr>(b));
+  return FormatFailedResult("is not identical to", name_a, name_b, a, b);
+}
+
+template <typename A, typename B>
+testing::AssertionResult IdenticalTestHelper(const std::string_view name_a,
+                                             const std::string_view name_b, const A& a,
+                                             const B& b) {
+  return IdenticalTestHelper2(name_a, name_b, ConvertAssertionArgument<A>{}(a),
+                              ConvertAssertionArgument<B>{}(b));
 }
 
 // Test !IsIdenticalTo
 template <typename A, typename B>
-testing::AssertionResult NotIdenticalTestHelper(const std::string& name_a,
-                                                const std::string& name_b, const A& a, const B& b) {
-  if (!static_cast<Expr>(a).IsIdenticalTo(static_cast<Expr>(b))) {
+testing::AssertionResult NotIdenticalTestHelper2(const std::string_view name_a,
+                                                 const std::string_view name_b, const A& a,
+                                                 const B& b) {
+  if (!a.IsIdenticalTo(b)) {
     return testing::AssertionSuccess();
   }
-  return FormatFailedResult("is identical (and should not be) to", name_a, name_b,
-                            static_cast<Expr>(a), static_cast<Expr>(b));
+  return FormatFailedResult("is identical (and should not be) to", name_a, name_b, a, b);
+}
+
+template <typename A, typename B>
+testing::AssertionResult NotIdenticalTestHelper(const std::string_view name_a,
+                                                const std::string_view name_b, const A& a,
+                                                const B& b) {
+  return NotIdenticalTestHelper2(name_a, name_b, ConvertAssertionArgument<A>{}(a),
+                                 ConvertAssertionArgument<B>{}(b));
 }
 
 }  // namespace math


### PR DESCRIPTION
Matrix type was awkwardly part of the `Expr` type hierarchy. This did not make sense, and complicated implementation in a few places. In future it might make sense to have a separate hierarchy for symbolic matrix expressions.