### PR TITLE
Disambiguate assertion macros

### DIFF
--- a/components/math/include/assertions.h
+++ b/components/math/include/assertions.h
@@ -41,39 +41,40 @@ void raise_assert_binary_op(const char* const condition, const char* const file,
 
 // Assertion macros.
 // Based on: http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert
-#define ASSERT_IMPL(cond, file, line, handler, ...) \
-  do {                                              \
-    if (!static_cast<bool>(cond)) {                 \
-      handler(#cond, file, line, ##__VA_ARGS__);    \
-    }                                               \
+#define ZEN_ASSERT_IMPL(cond, file, line, handler, ...) \
+  do {                                                  \
+    if (!static_cast<bool>(cond)) {                     \
+      handler(#cond, file, line, ##__VA_ARGS__);        \
+    }                                                   \
   } while (false)
 
 // Macro to use when defining an assertion.
-#define ASSERT(cond, ...) ASSERT_IMPL(cond, __FILE__, __LINE__, math::raise_assert, ##__VA_ARGS__)
+#define ZEN_ASSERT(cond, ...) \
+  ZEN_ASSERT_IMPL(cond, __FILE__, __LINE__, math::raise_assert, ##__VA_ARGS__)
 
-#define ASSERT_EQUAL(a, b, ...)                                                           \
-  ASSERT_IMPL((a) == (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_EQUAL(a, b, ...)                                                           \
+  ZEN_ASSERT_IMPL((a) == (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
-#define ASSERT_NOT_EQUAL(a, b, ...)                                                       \
-  ASSERT_IMPL((a) != (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_NOT_EQUAL(a, b, ...)                                                       \
+  ZEN_ASSERT_IMPL((a) != (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
-#define ASSERT_LESS(a, b, ...)                                                           \
-  ASSERT_IMPL((a) < (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_LESS(a, b, ...)                                                           \
+  ZEN_ASSERT_IMPL((a) < (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
-#define ASSERT_GREATER(a, b, ...)                                                        \
-  ASSERT_IMPL((a) > (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_GREATER(a, b, ...)                                                        \
+  ZEN_ASSERT_IMPL((a) > (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
-#define ASSERT_LESS_OR_EQ(a, b, ...)                                                      \
-  ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_LESS_OR_EQ(a, b, ...)                                                      \
+  ZEN_ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
-#define ASSERT_GREATER_OR_EQ(a, b, ...)                                                   \
-  ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-              ##__VA_ARGS__)
+#define ZEN_ASSERT_GREATER_OR_EQ(a, b, ...)                                                   \
+  ZEN_ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                  ##__VA_ARGS__)
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/components/math/include/code_generation/ast.h
+++ b/components/math/include/code_generation/ast.h
@@ -36,7 +36,7 @@ class MatrixType {
 
   // Convert to [row, col] indices (assuming row major order).
   std::pair<index_t, index_t> compute_indices(std::size_t element) const {
-    ASSERT_LESS(element, static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_));
+    ZEN_ASSERT_LESS(element, static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_));
     return std::make_pair(static_cast<index_t>(element) / cols_,
                           static_cast<index_t>(element) % cols_);
   }
@@ -99,7 +99,7 @@ struct FunctionSignature {
   const std::shared_ptr<const ast::Argument>& get_argument(const std::string_view str) const {
     auto it = std::find_if(arguments.begin(), arguments.end(),
                            [&](const auto& arg) { return arg->name() == str; });
-    ASSERT(it != arguments.end(), "Argument does not exist: {}", str);
+    ZEN_ASSERT(it != arguments.end(), "Argument does not exist: {}", str);
     return *it;
   }
 

--- a/components/math/include/code_generation/code_formatter.h
+++ b/components/math/include/code_generation/code_formatter.h
@@ -44,7 +44,7 @@ class CodeFormatter {
   template <typename Callable>
   void with_indentation(const int indent, const std::string_view open, const std::string_view close,
                         Callable&& callable) {
-    ASSERT_GREATER_OR_EQ(indent, 0);
+    ZEN_ASSERT_GREATER_OR_EQ(indent, 0);
     // Move output_ -> appended
     std::string appended{};
     std::swap(output_, appended);

--- a/components/math/include/code_generation/cpp_code_generator.h
+++ b/components/math/include/code_generation/cpp_code_generator.h
@@ -76,13 +76,13 @@ class CppCodeGenerator {
 
   // Accept ast::VariantPtr
   void operator()(CodeFormatter& formatter, const ast::VariantPtr& var) const {
-    ASSERT(var);
+    ZEN_ASSERT(var);
     operator()(formatter, *var);
   }
 
   // Format ptr to argument.
   void operator()(CodeFormatter& formatter, const std::shared_ptr<const ast::Argument>& var) const {
-    ASSERT(var);
+    ZEN_ASSERT(var);
     formatter.format(var->name());
   }
 

--- a/components/math/include/code_generation/ir_builder.h
+++ b/components/math/include/code_generation/ir_builder.h
@@ -77,7 +77,7 @@ struct OutputIr {
     const auto it =
         std::find_if(blocks_.begin(), blocks_.end(),
                      [](const ir::Block::unique_ptr& block) { return block->has_no_ancestors(); });
-    ASSERT(it != blocks_.end(), "Must be an entry block");
+    ZEN_ASSERT(it != blocks_.end(), "Must be an entry block");
     return ir::BlockPtr{*it};
   }
 

--- a/components/math/include/code_generation/ir_types.h
+++ b/components/math/include/code_generation/ir_types.h
@@ -325,7 +325,7 @@ class Value {
 
   // Set the parent pointer.
   void set_parent(ir::BlockPtr b) {
-    ASSERT(!std::holds_alternative<ir::JumpCondition>(op_));
+    ZEN_ASSERT(!std::holds_alternative<ir::JumpCondition>(op_));
     parent_ = b;
   }
 
@@ -408,7 +408,7 @@ class Value {
 
   // Get the first operand.
   const ValuePtr& first_operand() const {
-    ASSERT(!operands_.empty());
+    ZEN_ASSERT(!operands_.empty());
     return operands_.front();
   }
 
@@ -488,7 +488,7 @@ class Value {
   void check_num_operands() {
     constexpr int expected_num_args = OpType::num_value_operands();
     if constexpr (expected_num_args >= 0) {
-      ASSERT_EQUAL(static_cast<std::size_t>(expected_num_args), operands_.size());
+      ZEN_ASSERT_EQUAL(static_cast<std::size_t>(expected_num_args), operands_.size());
     }
   }
 

--- a/components/math/include/code_generation/rust_code_generator.h
+++ b/components/math/include/code_generation/rust_code_generator.h
@@ -64,7 +64,7 @@ class RustCodeGenerator {
 
   // Accept ast::VariantPtr
   void operator()(CodeFormatter& formatter, const ast::VariantPtr& var) const {
-    ASSERT(var);
+    ZEN_ASSERT(var);
     operator()(formatter, *var);
   }
 

--- a/components/math/include/expressions/addition.h
+++ b/components/math/include/expressions/addition.h
@@ -18,7 +18,7 @@ class Addition {
 
   // Move-construct.
   explicit Addition(ContainerType&& terms) : terms_(std::move(terms)) {
-    ASSERT_GREATER_OR_EQ(terms_.size(), 2);
+    ZEN_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
     // Place into a deterministic (but otherwise mostly arbitrary) order.
     std::sort(terms_.begin(), terms_.end(), [](const Expr& a, const Expr& b) {
       if (a.get_hash() < b.get_hash()) {

--- a/components/math/include/expressions/derivative_expression.h
+++ b/components/math/include/expressions/derivative_expression.h
@@ -17,7 +17,7 @@ class Derivative {
 
   Derivative(Expr differentiand, Expr arg, int order = 1)
       : children_{std::move(differentiand), std::move(arg)}, order_(order) {
-    ASSERT_GREATER_OR_EQ(order_, 1);
+    ZEN_ASSERT_GREATER_OR_EQ(order_, 1);
   }
 
   // The function we are taking the derivative of:

--- a/components/math/include/expressions/function_expressions.h
+++ b/components/math/include/expressions/function_expressions.h
@@ -103,7 +103,7 @@ inline Expr Function::create(BuiltInFunctionName name, Function::ContainerType&&
     case BuiltInFunctionName::ENUM_SIZE:
       break;
   }
-  ASSERT(false, "Invalid function name: {}", to_string(name));
+  ZEN_ASSERT(false, "Invalid function name: {}", to_string(name));
   return Constants::Zero;  //  Unreachable.
 }
 

--- a/components/math/include/expressions/matrix.h
+++ b/components/math/include/expressions/matrix.h
@@ -24,8 +24,8 @@ class Matrix {
       throw DimensionError("Mismatch between shape and # of elements. size = {}, shape = [{}, {}]",
                            data_.size(), rows_, cols_);
     }
-    ASSERT_GREATER_OR_EQ(rows_, 0);
-    ASSERT_GREATER_OR_EQ(cols_, 0);
+    ZEN_ASSERT_GREATER_OR_EQ(rows_, 0);
+    ZEN_ASSERT_GREATER_OR_EQ(cols_, 0);
   }
 
   // All elements must match.

--- a/components/math/include/expressions/multiplication.h
+++ b/components/math/include/expressions/multiplication.h
@@ -19,7 +19,7 @@ class Multiplication {
 
   // Move-construct.
   explicit Multiplication(ContainerType&& terms) : terms_(std::move(terms)) {
-    ASSERT_GREATER_OR_EQ(terms_.size(), 2);
+    ZEN_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
     sort_terms();
   }
 
@@ -31,8 +31,8 @@ class Multiplication {
     terms_.reserve(sizeof...(terms));
     (terms_.emplace_back(std::forward<Ts>(terms)), ...);
     for (const auto& term : terms_) {
-      ASSERT(!term.is_type<Multiplication>(), "Multiplications should all be flattened: {}",
-             term.to_string());
+      ZEN_ASSERT(!term.is_type<Multiplication>(), "Multiplications should all be flattened: {}",
+                 term.to_string());
     }
     sort_terms();
   }

--- a/components/math/include/expressions/numeric_expressions.h
+++ b/components/math/include/expressions/numeric_expressions.h
@@ -158,7 +158,7 @@ class Float {
   // Create floating point expression.
   static Expr create(Float f) { return make_expr<Float>(f); }
   static Expr create(FloatType f) {
-    ASSERT(std::isfinite(f), "Float values must be finite: {}", f);
+    ZEN_ASSERT(std::isfinite(f), "Float values must be finite: {}", f);
     return create(Float{f});
   }
 

--- a/components/math/include/non_null_ptr.h
+++ b/components/math/include/non_null_ptr.h
@@ -7,7 +7,7 @@ namespace math {
 template <typename T>
 class non_null_ptr {
  public:
-  explicit non_null_ptr(T* ptr) : ptr_(ptr) { ASSERT(ptr_, "Cannot be constructed null"); }
+  explicit non_null_ptr(T* ptr) : ptr_(ptr) { ZEN_ASSERT(ptr_, "Cannot be constructed null"); }
 
   // Construct from unique_ptr.
   explicit non_null_ptr(const std::unique_ptr<T>& ptr) : non_null_ptr(ptr.get()) {}

--- a/components/math/include/type_annotations.h
+++ b/components/math/include/type_annotations.h
@@ -23,8 +23,8 @@ template <index_t Rows, index_t Cols>
 struct StaticMatrix {
   // Allow implicit construction from MatrixExpr.
   StaticMatrix(MatrixExpr expr) : expr_(std::move(expr)) {  // NOLINT(google-explicit-constructor)
-    ASSERT_EQUAL(Rows, expr_.rows());
-    ASSERT_EQUAL(Cols, expr_.cols());
+    ZEN_ASSERT_EQUAL(Rows, expr_.rows());
+    ZEN_ASSERT_EQUAL(Cols, expr_.cols());
   }
 
   constexpr index_t rows() const { return Rows; }
@@ -44,8 +44,8 @@ struct StaticMatrix {
 
   // Assign from MatrixExpr
   StaticMatrix& operator=(const MatrixExpr& other) {
-    ASSERT_EQUAL(Rows, other.rows());
-    ASSERT_EQUAL(Cols, other.cols());
+    ZEN_ASSERT_EQUAL(Rows, other.rows());
+    ZEN_ASSERT_EQUAL(Cols, other.cols());
     expr_ = other;
     return *this;
   }

--- a/components/math/include/visitor_impl.h
+++ b/components/math/include/visitor_impl.h
@@ -81,7 +81,7 @@ struct VisitorWithCapturedResult final
     if constexpr (std::is_default_constructible_v<ReturnType>) {
       return std::move(result);
     } else {
-      ASSERT(result.has_value());
+      ZEN_ASSERT(result.has_value());
       return std::move(*result);
     }
   }

--- a/components/math/source/code_generation/ast.cc
+++ b/components/math/source/code_generation/ast.cc
@@ -38,7 +38,7 @@ struct AstBuilder {
   }
 
   void process_block(ir::BlockPtr block) {
-    ASSERT(!block->is_empty());
+    ZEN_ASSERT(!block->is_empty());
     if (stop_set_.count(block)) {
       return;
     }
@@ -107,7 +107,7 @@ struct AstBuilder {
       }
 
       if (key.usage == ExpressionUsage::ReturnValue) {
-        ASSERT(block->descendants.empty());  //  This must be the final block.
+        ZEN_ASSERT(block->descendants.empty());  //  This must be the final block.
         emplace_operation<ast::ConstructReturnValue>(signature_.return_value.value(),
                                                      std::move(args));
       } else {
@@ -123,11 +123,11 @@ struct AstBuilder {
     ir::ValuePtr last_op = block->operations.back();
     if (!last_op->is_type<ir::JumpCondition>()) {
       // just keep appending:
-      ASSERT_EQUAL(1, block->descendants.size());
+      ZEN_ASSERT_EQUAL(1, block->descendants.size());
       process_block(block->descendants.front());
     } else {
-      ASSERT(last_op->is_type<ir::JumpCondition>());
-      ASSERT_EQUAL(2, block->descendants.size());
+      ZEN_ASSERT(last_op->is_type<ir::JumpCondition>());
+      ZEN_ASSERT_EQUAL(2, block->descendants.size());
 
       // Find phi functions:
       const ir::BlockPtr merge_point = find_merge_point(
@@ -153,7 +153,7 @@ struct AstBuilder {
 
       ir::ValuePtr condition = last_op->first_operand();
       if (condition->is_type<ir::OutputRequired>()) {
-        ASSERT(operations_false.empty());
+        ZEN_ASSERT(operations_false.empty());
         const ir::OutputRequired& oreq = condition->as_type<ir::OutputRequired>();
         // Create an optional-output assignment block
         emplace_operation<ast::OptionalOutputBranch>(signature_.get_argument(oreq.name),

--- a/components/math/source/code_generation/cpp_code_generator.cc
+++ b/components/math/source/code_generation/cpp_code_generator.cc
@@ -164,7 +164,7 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter,
 
   } else {
     // Otherwise it is a scalar, so just assign it:
-    ASSERT_EQUAL(1, assignment.values.size());
+    ZEN_ASSERT_EQUAL(1, assignment.values.size());
     formatter.format("{} = {};", dest_name, assignment.values.front());
   }
 }
@@ -239,8 +239,8 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::Branch& x
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter,
                                   const ast::ConstructReturnValue& x) const {
-  ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
-  ASSERT_EQUAL(1, x.args.size());
+  ZEN_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
+  ZEN_ASSERT_EQUAL(1, x.args.size());
   formatter.format("return {};", make_view(x.args[0]));
 }
 
@@ -254,7 +254,7 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::Declarati
 }
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::InputValue& x) const {
-  ASSERT(x.argument);
+  ZEN_ASSERT(x.argument);
   if (std::holds_alternative<ast::ScalarType>(x.argument->type())) {
     formatter.format(x.argument->name());
   } else {

--- a/components/math/source/code_generation/expr_from_ir.cc
+++ b/components/math/source/code_generation/expr_from_ir.cc
@@ -22,7 +22,7 @@ struct ExprFromIrVisitor {
   }
 
   Expr operator()(const ir::OutputRequired& output, const std::vector<ir::ValuePtr>&) const {
-    ASSERT(output_arg_exists_, "Must have an output arg map to process `OutputRequired`");
+    ZEN_ASSERT(output_arg_exists_, "Must have an output arg map to process `OutputRequired`");
     return output_arg_exists_->at(output.name) ? Constants::True : Constants::False;
   }
 
@@ -47,17 +47,17 @@ struct ExprFromIrVisitor {
   }
 
   Expr operator()(const ir::Phi&, const std::vector<ir::ValuePtr>& args) const {
-    ASSERT_EQUAL(2, args.size());
+    ZEN_ASSERT_EQUAL(2, args.size());
 
     // We find to find the condition for this jump:
     const ir::BlockPtr jump_block =
         find_merge_point(args.front()->parent(), args.back()->parent(), SearchDirection::Upwards);
 
     // Determine the condition:
-    ASSERT(!jump_block->is_empty());
+    ZEN_ASSERT(!jump_block->is_empty());
 
     const ir::ValuePtr jump_val = jump_block->operations.back();
-    ASSERT(jump_val->is_type<ir::JumpCondition>());
+    ZEN_ASSERT(jump_val->is_type<ir::JumpCondition>());
 
     return where(map_value(jump_val->first_operand()), map_value(args[0]), map_value(args[1]));
   }
@@ -76,7 +76,7 @@ struct ExprFromIrVisitor {
 
   Expr map_value(const ir::ValuePtr& val) const {
     const auto arg_it = value_to_expression_.find(val);
-    ASSERT(arg_it != value_to_expression_.end(), "Missing value: {}", val->name());
+    ZEN_ASSERT(arg_it != value_to_expression_.end(), "Missing value: {}", val->name());
     return arg_it->second;
   }
 
@@ -123,7 +123,7 @@ create_output_expression_map(ir::BlockPtr starting_block,
             output_expressions.reserve(code->num_operands());
             for (const ir::ValuePtr operand : code->operands()) {
               auto it = value_to_expression.find(operand);
-              ASSERT(it != value_to_expression.end(), "Missing value: {}", operand->name());
+              ZEN_ASSERT(it != value_to_expression.end(), "Missing value: {}", operand->name());
               output_expressions.push_back(it->second);
             }
             output_map.emplace(save.key, std::move(output_expressions));

--- a/components/math/source/code_generation/rust_code_generator.cc
+++ b/components/math/source/code_generation/rust_code_generator.cc
@@ -144,7 +144,7 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter,
         "\n", range);
   } else {
     // Otherwise it is a scalar, so just assign it:
-    ASSERT_EQUAL(1, assignment.values.size());
+    ZEN_ASSERT_EQUAL(1, assignment.values.size());
     formatter.format("*{} = {};", dest_name, assignment.values.front());
   }
 }
@@ -154,7 +154,7 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::AssignTe
 }
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Branch& x) const {
-  ASSERT(x.condition);
+  ZEN_ASSERT(x.condition);
   formatter.format("if {} ", make_view(x.condition));
   formatter.with_indentation(2, "{\n", "\n}", [&] { formatter.join(*this, "\n", x.if_branch); });
 
@@ -216,8 +216,8 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Compare&
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter,
                                    const ast::ConstructReturnValue& x) const {
-  ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
-  ASSERT_EQUAL(1, x.args.size());
+  ZEN_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
+  ZEN_ASSERT_EQUAL(1, x.args.size());
   formatter.format("{}", make_view(x.args[0]));
 }
 
@@ -231,7 +231,7 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Declarat
 }
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::InputValue& x) const {
-  ASSERT(x.argument);
+  ZEN_ASSERT(x.argument);
   if (x.argument->is_matrix()) {
     const ast::MatrixType mat = std::get<ast::MatrixType>(x.argument->type());
     const auto [r, c] = mat.compute_indices(x.element);

--- a/components/math/source/derivative.cc
+++ b/components/math/source/derivative.cc
@@ -162,7 +162,7 @@ class DiffVisitor {
       case BuiltInFunctionName::ENUM_SIZE:
         break;
     }
-    ASSERT(false, "Invalid unary function: {}", func.function_name());
+    ZEN_ASSERT(false, "Invalid unary function: {}", func.function_name());
     return Constants::Zero;
   }
 
@@ -224,7 +224,7 @@ inline Expr diff_typed(const Expr& expr, const T& arg, const Expr& arg_abstract,
 }
 
 Expr diff(const Expr& differentiand, const Expr& arg, const int reps) {
-  ASSERT_GREATER_OR_EQ(reps, 0);
+  ZEN_ASSERT_GREATER_OR_EQ(reps, 0);
   if (const Variable* var = cast_ptr<Variable>(arg); var != nullptr) {
     return diff_typed<Variable>(differentiand, *var, arg, reps);
   } else if (const FunctionArgument* func = cast_ptr<FunctionArgument>(arg); func != nullptr) {

--- a/components/math/source/distribute.cc
+++ b/components/math/source/distribute.cc
@@ -46,8 +46,8 @@ struct DistributeVisitor {
     for (const Expr& expr : children) {
       if (const Addition* add = cast_ptr<Addition>(expr); add != nullptr) {
         // For additions, first update the step by dividing by the size of this addition:
-        ASSERT_EQUAL(0, step % add->arity());
-        ASSERT_GREATER_OR_EQ(step / add->arity(), 1);
+        ZEN_ASSERT_EQUAL(0, step % add->arity());
+        ZEN_ASSERT_GREATER_OR_EQ(step / add->arity(), 1);
         step /= add->arity();
         // Now multiply terms in the addition:
         for (std::size_t out = 0; out < total_terms;) {

--- a/components/math/source/evaluate.cc
+++ b/components/math/source/evaluate.cc
@@ -18,8 +18,8 @@ struct EvaluateVisitor {
 
   Expr operator()(const Constant& c) const {
     const double value = double_from_symbolic_constant(c.name());
-    ASSERT(!std::isnan(value), "Invalid symbolic constant: {}",
-           string_from_symbolic_constant(c.name()));
+    ZEN_ASSERT(!std::isnan(value), "Invalid symbolic constant: {}",
+               string_from_symbolic_constant(c.name()));
     return Float::create(value);
   }
 

--- a/components/math/source/expressions/addition.cc
+++ b/components/math/source/expressions/addition.cc
@@ -49,7 +49,7 @@ struct AdditionVisitor {
   void operator()(const T&, const Expr& input_expression) {
     // Everything else: Just add to the coeff
     auto [coeff, mul] = as_coeff_and_mul(input_expression);
-    ASSERT(!mul.is_type<Addition>(), "TODO: Should just silently merge cases like this");
+    ZEN_ASSERT(!mul.is_type<Addition>(), "TODO: Should just silently merge cases like this");
 
     const auto [it, was_inserted] = parts.terms.emplace(std::move(mul), coeff);
     if (!was_inserted) {

--- a/components/math/source/expressions/derivative_expression.cc
+++ b/components/math/source/expressions/derivative_expression.cc
@@ -6,7 +6,7 @@
 namespace math {
 
 Expr Derivative::create(Expr differentiand, Expr arg, int order) {
-  ASSERT_GREATER_OR_EQ(order, 1, "Order of the derivative must >= 1");
+  ZEN_ASSERT_GREATER_OR_EQ(order, 1, "Order of the derivative must >= 1");
 
   if (!arg.is_type<Variable, FunctionArgument>()) {
     throw TypeError("Derivatives can only be taken with respect to variables. Arg = {}",

--- a/components/math/source/expressions/multiplication.cc
+++ b/components/math/source/expressions/multiplication.cc
@@ -30,7 +30,7 @@ static inline Expr multiply_into_addition(const Addition& add, const Expr& numer
 }
 
 Expr Multiplication::from_operands(absl::Span<const Expr> args) {
-  ASSERT(!args.empty());
+  ZEN_ASSERT(!args.empty());
   if (args.size() < 2) {
     return args.front();
   }

--- a/components/math/source/expressions/power.cc
+++ b/components/math/source/expressions/power.cc
@@ -38,7 +38,7 @@ struct PowerNumerics {
   // If both operands are integers:
   Expr apply_int_and_int(const Integer& a, const Integer& b) {
     if (b.get_value() < 0) {
-      ASSERT_NOT_EQUAL(a.get_value(), 0, "TODO: Handle taking 0 to a negative power?");
+      ZEN_ASSERT_NOT_EQUAL(a.get_value(), 0, "TODO: Handle taking 0 to a negative power?");
       // Convert a -> (1/a), then take the power:
       return apply_rational_and_int(Rational{1, a.get_value()}, -b);
     }
@@ -62,7 +62,7 @@ struct PowerNumerics {
 
   // If the left operand is integer, and the right is rational:
   Expr apply_int_and_rational(const Integer& a, const Rational& b) {
-    ASSERT_GREATER(b.denominator(), 0, "Rational must have positive denominator");
+    ZEN_ASSERT_GREATER(b.denominator(), 0, "Rational must have positive denominator");
     if (a.get_value() == 1) {
       return Constants::One;
     } else if (a.get_value() == 0) {
@@ -71,9 +71,9 @@ struct PowerNumerics {
 
     // Factorize the integer into primes:
     const std::vector<PrimeFactor> factors = compute_prime_factors(a.get_value());
-    ASSERT(std::is_sorted(factors.begin(), factors.end(),
-                          [](const auto& x, const auto& y) { return x.base < y.base; }),
-           "Factors should be sorted");
+    ZEN_ASSERT(std::is_sorted(factors.begin(), factors.end(),
+                              [](const auto& x, const auto& y) { return x.base < y.base; }),
+               "Factors should be sorted");
 
     // Next we will create expressions.
     std::vector<Expr> operands{};
@@ -90,7 +90,7 @@ struct PowerNumerics {
     for (const PrimeFactor& f : factors) {
       // Multiply the power by the rational to get the exponent applied to this prime factor:
       const Rational actual_exp = b * static_cast<Rational>(Integer{f.exponent});
-      ASSERT_GREATER(f.exponent, 0);  //  Exponents must be >= 1 in this context.
+      ZEN_ASSERT_GREATER(f.exponent, 0);  //  Exponents must be >= 1 in this context.
 
       // Factorize the exponent: x^(int_part + frac_part) --> x^int_part * x^frac_part
       // Both of these should have the same sign as actual_exp.

--- a/components/math/source/expressions/relational.cc
+++ b/components/math/source/expressions/relational.cc
@@ -49,13 +49,13 @@ struct CompareNumerics {
   // Integer and float:
   bool operator()(const Integer& a, const Float& b) const {
     const auto result = compare_int_float(a.get_value(), b.get_value());
-    ASSERT(result.has_value(), "Invalid float value: {}", b);
+    ZEN_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == RelativeOrder::LessThan;
   }
 
   bool operator()(const Float& a, const Integer& b) const {
     const auto result = compare_int_float(b.get_value(), a.get_value());
-    ASSERT(result.has_value(), "Invalid float value: {}", b);
+    ZEN_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == RelativeOrder::GreaterThan;
   }
 };
@@ -94,8 +94,8 @@ struct RelationalSimplification {
       } else if (operation_ == RelationalOperation::Equal) {
         return (!a_lt_b && !b_lt_a) ? TriState::True : TriState::False;
       }
-      ASSERT(operation_ == RelationalOperation::LessThanOrEqual, "Invalid relational operation: {}",
-             string_from_relational_operation(operation_));
+      ZEN_ASSERT(operation_ == RelationalOperation::LessThanOrEqual,
+                 "Invalid relational operation: {}", string_from_relational_operation(operation_));
       // either `a` < `b`, or: `a` >= `b` and `b` is not less than `a`, so `a` == `b`
       return a_lt_b || !b_lt_a ? TriState::True : TriState::False;
     } else {

--- a/components/math/source/functions.cc
+++ b/components/math/source/functions.cc
@@ -256,7 +256,7 @@ Expr abs(const Expr& arg) {
   if (const std::optional<Rational> r = try_cast_to_rational(arg); r.has_value()) {
     // If the inner argument is a negative integer or rational, just flip it.
     if (r->numerator() >= 0) {
-      ASSERT_GREATER(r->denominator(), 0);
+      ZEN_ASSERT_GREATER(r->denominator(), 0);
       return arg;
     }
     return Rational::create(-r->numerator(), r->denominator());
@@ -292,7 +292,7 @@ struct SignumVisitor {
   std::optional<Expr> operator()(const Integer& i) const { return Expr{sign(i.get_value())}; }
   std::optional<Expr> operator()(const Rational& r) const { return Expr{sign(r.numerator())}; }
   std::optional<Expr> operator()(const Float& f) const {
-    ASSERT(!std::isnan(f.get_value()));
+    ZEN_ASSERT(!std::isnan(f.get_value()));
     return Expr{sign(f.get_value())};
   }
 

--- a/components/math/source/matrix_functions.cc
+++ b/components/math/source/matrix_functions.cc
@@ -94,7 +94,7 @@ struct PermutationMatrix {
     }
     p_.insert(p_.begin(), 0);
     if (row != 0) {
-      ASSERT_LESS(static_cast<std::size_t>(row), p_.size());
+      ZEN_ASSERT_LESS(static_cast<std::size_t>(row), p_.size());
       std::swap(p_[0], p_[row]);
       ++num_swaps_;
     }
@@ -107,7 +107,7 @@ struct PermutationMatrix {
     }
     p_.insert(p_.begin(), 0);
     auto it = std::find(p_.begin(), p_.end(), row);
-    ASSERT(it != p_.end());
+    ZEN_ASSERT(it != p_.end());
     if (it != p_.begin()) {
       std::swap(*it, p_[0]);
       ++num_swaps_;
@@ -175,12 +175,12 @@ static inline std::optional<std::tuple<std::size_t, std::size_t>> find_pivot(
 static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_internal(
     dynamic_row_major_span L, dynamic_row_major_span U) {
   if (L.rows() == 1) {
-    ASSERT_EQUAL(1, L.cols());
+    ZEN_ASSERT_EQUAL(1, L.cols());
     L(0, 0) = Constants::One;
     return std::make_tuple(PermutationMatrix(1), PermutationMatrix(U.cols()));
   }
 
-  ASSERT_GREATER_OR_EQ(U.rows(), 2);
+  ZEN_ASSERT_GREATER_OR_EQ(U.rows(), 2);
 
   // Search for a non-zero pivot.
   auto pivot_indices = find_pivot(U);
@@ -230,7 +230,7 @@ static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_in
   L(0, 0) = Constants::One;
 
   // then the column underneath it:
-  ASSERT_EQUAL(static_cast<std::size_t>(P.rows()), c.rows());
+  ZEN_ASSERT_EQUAL(static_cast<std::size_t>(P.rows()), c.rows());
   for (std::size_t i = 0; i < c.rows(); ++i) {
     L(i + 1, 0) = c(P.permuted_row_transposed(static_cast<index_t>(i)), 0) / pivot;
   }
@@ -243,7 +243,7 @@ static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_in
   }
 
   // Permute the top-right row of U:
-  ASSERT_EQUAL(static_cast<std::size_t>(Q.rows()), r_t.cols());
+  ZEN_ASSERT_EQUAL(static_cast<std::size_t>(Q.rows()), r_t.cols());
   for (std::size_t j = 0; j < r_t.cols(); ++j) {
     U(0, j + 1) = r_t_copied[Q.PermutedRow(static_cast<index_t>(j))];
   }
@@ -269,10 +269,10 @@ factorize_full_piv_lu_internal(const Matrix& A) {
     Matrix U_out = L.transposed();
     Matrix L_out = U.transposed();
 
-    ASSERT_EQUAL(L_out.rows(), A.rows());
-    ASSERT_EQUAL(L_out.cols(), A.cols());
-    ASSERT_EQUAL(U_out.rows(), A.cols());
-    ASSERT_EQUAL(U_out.rows(), U_out.cols());
+    ZEN_ASSERT_EQUAL(L_out.rows(), A.rows());
+    ZEN_ASSERT_EQUAL(L_out.cols(), A.cols());
+    ZEN_ASSERT_EQUAL(U_out.rows(), A.cols());
+    ZEN_ASSERT_EQUAL(U_out.rows(), U_out.cols());
 
     // Then we need to normalize the diagonal of L
     for (index_t col = 0; col < L_out.cols(); ++col) {

--- a/components/math/source/plain_formatter.cc
+++ b/components/math/source/plain_formatter.cc
@@ -11,7 +11,7 @@
 namespace math {
 
 void PlainFormatter::operator()(const Addition& expr) {
-  ASSERT_GREATER_OR_EQ(expr.arity(), 2);
+  ZEN_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
 
   // Sort into canonical order:
   absl::InlinedVector<std::pair<Expr, Expr>, 16> terms;
@@ -104,8 +104,8 @@ void PlainFormatter::operator()(const FunctionArgument& func_arg) {
 }
 
 void PlainFormatter::operator()(const Matrix& mat) {
-  ASSERT_GREATER_OR_EQ(mat.rows(), 0);
-  ASSERT_GREATER_OR_EQ(mat.cols(), 0);
+  ZEN_ASSERT_GREATER_OR_EQ(mat.rows(), 0);
+  ZEN_ASSERT_GREATER_OR_EQ(mat.cols(), 0);
 
   if (mat.size() == 0) {
     // Empty matrix:
@@ -154,7 +154,7 @@ void PlainFormatter::operator()(const Matrix& mat) {
 }
 
 void PlainFormatter::operator()(const Multiplication& expr) {
-  ASSERT_GREATER_OR_EQ(expr.arity(), 2);
+  ZEN_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
   using BaseExp = MultiplicationFormattingInfo::BaseExp;
 
   // Break multiplication up into numerator and denominator:

--- a/components/math/source/substitute.cc
+++ b/components/math/source/substitute.cc
@@ -190,7 +190,7 @@ struct SubstituteMulVisitor : public SubstituteVisitorBase<SubstituteMulVisitor,
     const Integer max_valid_exponent = max_valid_integer_exponent.value();
     for (const auto& [base, exponent] : target_parts.terms) {
       auto it = input_parts.terms.find(base);
-      ASSERT(it != input_parts.terms.end());
+      ZEN_ASSERT(it != input_parts.terms.end());
       it->second = it->second - (exponent * max_valid_exponent.get_value());
     }
 

--- a/components/sym_wrapper/codegen_wrapper.cc
+++ b/components/sym_wrapper/codegen_wrapper.cc
@@ -195,7 +195,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def_property_readonly("left", [](const ast::AssignTemporary& x) { return x.left; })
       .def_property_readonly("right",
                              [](const ast::AssignTemporary& x) {
-                               ASSERT(x.right);
+                               ZEN_ASSERT(x.right);
                                return *x.right;
                              })
       .def("__repr__", &format_ast<ast::AssignTemporary>);
@@ -203,7 +203,7 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::AssignOutputArgument>(m, "AssignOutputArgument")
       .def_property_readonly("argument",
                              [](const ast::AssignOutputArgument& x) {
-                               ASSERT(x.argument);
+                               ZEN_ASSERT(x.argument);
                                return *x.argument;
                              })
       .def_property_readonly("values", [](const ast::AssignOutputArgument& x) { return x.values; })
@@ -225,7 +225,7 @@ void wrap_codegen_operations(py::module_& m) {
                              [](const ast::Cast& c) { return c.destination_type; })
       .def_property_readonly("arg",
                              [](const ast::Cast& c) {
-                               ASSERT(c.arg);
+                               ZEN_ASSERT(c.arg);
                                return *c.arg;
                              })
       .def("__repr__", &format_ast<ast::Cast>);
@@ -233,12 +233,12 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::Compare>(m, "Compare")
       .def_property_readonly("left",
                              [](const ast::Compare& c) {
-                               ASSERT(c.left);
+                               ZEN_ASSERT(c.left);
                                return *c.left;
                              })
       .def_property_readonly("right",
                              [](const ast::Compare& c) {
-                               ASSERT(c.right);
+                               ZEN_ASSERT(c.right);
                                return *c.right;
                              })
       .def_property_readonly("operation", [](const ast::Compare& c) { return c.operation; })
@@ -278,12 +278,12 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::Multiply>(m, "Multiply")
       .def_property_readonly("left",
                              [](const ast::Multiply& x) {
-                               ASSERT(x.left);
+                               ZEN_ASSERT(x.left);
                                return *x.left;
                              })
       .def_property_readonly("right",
                              [](const ast::Multiply& x) {
-                               ASSERT(x.right);
+                               ZEN_ASSERT(x.right);
                                return *x.right;
                              })
       .def("__repr__", &format_ast<ast::Multiply>);

--- a/components/sym_wrapper/matrix_wrapper.cc
+++ b/components/sym_wrapper/matrix_wrapper.cc
@@ -215,7 +215,7 @@ inline MatrixExpr stack_iterables(const std::vector<py::object>& rows) {
   }
 
   // Figure out how many rows we extracted:
-  ASSERT_EQUAL(0, converted.size() % expected_num_cols);
+  ZEN_ASSERT_EQUAL(0, converted.size() % expected_num_cols);
   const auto total_rows = static_cast<index_t>(converted.size() / expected_num_cols);
   return MatrixExpr::create(total_rows, static_cast<index_t>(expected_num_cols),
                             std::move(converted));

--- a/test/ir_builder_test.cc
+++ b/test/ir_builder_test.cc
@@ -42,7 +42,7 @@ struct OptionalArgPermutations {
         scatter_.emplace(it->key.name, scatter_.size());
       }
     }
-    ASSERT_LESS(scatter_.size(), MaxOptionalArgs);
+    ZEN_ASSERT_LESS(scatter_.size(), MaxOptionalArgs);
   }
 
   std::size_t num_permutations() const {
@@ -55,7 +55,7 @@ struct OptionalArgPermutations {
   // Get the n'th permutation of optional arguments.
   // The returned map is a mapping from `arg name` --> whether the argument is to be computed.
   std::unordered_map<std::string, bool> get_permutation(std::size_t n) const {
-    ASSERT_LESS(n, num_permutations());
+    ZEN_ASSERT_LESS(n, num_permutations());
     const std::bitset<MaxOptionalArgs> permutation{n};
 
     std::unordered_map<std::string, bool> output{};

--- a/test/numeric_testing.h
+++ b/test/numeric_testing.h
@@ -28,8 +28,8 @@ struct convert_output_arg_type;
 struct NumericFunctionEvaluator {
   Expr operator()(const FunctionArgument& arg, const Expr&) const {
     auto it = values.find(arg);
-    ASSERT(it != values.end(), "Missing function argument: ({}, {})", arg.arg_index(),
-           arg.element_index());
+    ZEN_ASSERT(it != values.end(), "Missing function argument: ({}, {})", arg.arg_index(),
+               arg.element_index());
     return it->second;
   }
 
@@ -91,8 +91,8 @@ template <index_t Rows, index_t Cols>
 struct apply_numeric_evaluator_impl<ta::StaticMatrix<Rows, Cols>> {
   Eigen::Matrix<double, Rows, Cols> operator()(const NumericFunctionEvaluator& evaluator,
                                                const MatrixExpr& input) const {
-    ASSERT_EQUAL(input.rows(), Rows);
-    ASSERT_EQUAL(input.cols(), Cols);
+    ZEN_ASSERT_EQUAL(input.rows(), Rows);
+    ZEN_ASSERT_EQUAL(input.cols(), Cols);
     Eigen::Matrix<double, Rows, Cols> output;
     for (index_t i = 0; i < Rows; ++i) {
       for (index_t j = 0; j < Cols; ++j) {


### PR DESCRIPTION
Assertion macros had overly generic names, which caused confusion when seeing them side-by-side with gtest macros.