### PR TITLE
Add basic limit evaluation

### DIFF
--- a/components/math/CMakeLists.txt
+++ b/components/math/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   source/ordering.cc
   source/plain_formatter.cc
   source/substitute.cc
+  source/limits.cc
   source/tree_formatter.cc)
 
 # Turn on C++17

--- a/components/math/include/constants.h
+++ b/components/math/include/constants.h
@@ -9,9 +9,10 @@ class Constants {
   static const Expr Pi;
   static const Expr Euler;
   static const Expr NegativeOne;
-  static const Expr Infinity;
+  static const Expr ComplexInfinity;
   static const Expr True;
   static const Expr False;
+  static const Expr Undefined;
 };
 
 inline bool is_zero(const Expr& expr) { return expr.is_identical_to(Constants::Zero); }
@@ -24,6 +25,14 @@ inline bool is_negative_one(const Expr& expr) {
 
 inline bool is_pi(const Expr& expr) { return expr.is_identical_to(Constants::Pi); }
 
-inline bool is_infinity(const Expr& expr) { return expr.is_identical_to(Constants::Infinity); }
+inline bool is_complex_infinity(const Expr& expr) {
+  return expr.is_identical_to(Constants::ComplexInfinity);
+}
+
+inline bool is_undefined(const Expr& expr) { return expr.is_identical_to(Constants::Undefined); }
+
+inline bool is_numeric_or_constant(const Expr& expr) {
+  return expr.is_type<Constant, Integer, Float, Rational>();
+}
 
 }  // namespace math

--- a/components/math/include/expressions/addition.h
+++ b/components/math/include/expressions/addition.h
@@ -5,6 +5,7 @@
 #include "absl_imports.h"
 #include "constants.h"
 #include "expressions/numeric_expressions.h"
+#include "expressions/special_constants.h"
 #include "hashing.h"
 #include "visitor_impl.h"
 
@@ -97,6 +98,9 @@ struct AdditionParts {
 
   // Map from multiplicand to coefficient.
   std::unordered_map<Expr, Expr, hash_struct<Expr>, IsIdenticalOperator<Expr>> terms{};
+
+  // Number of infinities.
+  std::size_t num_infinities{0};
 
   // Update the internal representation by adding `arg`.
   void add_terms(const Expr& arg);

--- a/components/math/include/expressions/multiplication.h
+++ b/components/math/include/expressions/multiplication.h
@@ -6,6 +6,7 @@
 #include "absl_imports.h"
 #include "constants.h"
 #include "expressions/numeric_expressions.h"
+#include "expressions/special_constants.h"
 #include "hashing.h"
 
 namespace math {
@@ -122,6 +123,8 @@ struct MultiplicationParts {
   std::optional<Float> float_coeff{};
   // Map from base to exponent.
   std::unordered_map<Expr, Expr, hash_struct<Expr>, IsIdenticalOperator<Expr>> terms{};
+  // Number of infinities.
+  std::size_t num_infinities{0};
 
   // Update the internal product by multiplying on `arg`.
   void multiply_term(const Expr& arg, bool factorize_integers = false);

--- a/components/math/include/expressions/numeric_expressions.h
+++ b/components/math/include/expressions/numeric_expressions.h
@@ -35,6 +35,12 @@ class Integer {
   // True if this integer is zero.
   constexpr bool is_zero() const noexcept { return val_ == 0; }
 
+  // True if this integer is less than zero.
+  constexpr bool is_negative() const noexcept { return val_ < 0; }
+
+  // True if this integer is even. (Zero is even).
+  constexpr bool is_even() const noexcept { return !static_cast<bool>(val_ & 1); }
+
   // Cast to integer:
   constexpr explicit operator Float() const;
 
@@ -66,26 +72,29 @@ class Rational {
   // Construct a rational from an integer value.
   explicit constexpr Rational(const Integer& integer) : n_(integer.get_value()), d_(1) {}
 
-  constexpr bool is_identical_to(const Rational& other) const {
+  constexpr bool is_identical_to(const Rational& other) const noexcept {
     return n_ == other.n_ && d_ == other.d_;
   }
 
   // Access numerator and denominator.
-  constexpr IntegralType numerator() const { return n_; }
-  constexpr IntegralType denominator() const { return d_; }
+  constexpr IntegralType numerator() const noexcept { return n_; }
+  constexpr IntegralType denominator() const noexcept { return d_; }
 
   // Cast to float.
   explicit operator Float() const;
 
   // True if numerator equals denominator.
-  constexpr bool is_one() const { return n_ == d_; }
+  constexpr bool is_one() const noexcept { return n_ == d_; }
 
   // True if numerator is zero.
-  constexpr bool is_zero() const { return n_ == 0; }
+  constexpr bool is_zero() const noexcept { return n_ == 0; }
+
+  // True if negative (only the numerator may be < 0).
+  constexpr bool is_negative() const noexcept { return n_ < 0; }
 
   // Try converting the rational to an integer. If the numerator and denominator divide
   // evenly, returns a valid optional.
-  constexpr std::optional<Integer> try_convert_to_integer() const {
+  constexpr std::optional<Integer> try_convert_to_integer() const noexcept {
     if (n_ % d_ == 0) {
       return {Integer(n_ / d_)};
     }
@@ -144,13 +153,19 @@ class Float {
   using FloatType = double;
 
   // Construct from float value.
-  explicit constexpr Float(FloatType val) : val_(val) {}
+  explicit constexpr Float(FloatType val) noexcept : val_(val) {}
 
   // Check if numerical constants are completely identical.
-  constexpr bool is_identical_to(const Float& other) const { return val_ == other.val_; }
+  constexpr bool is_identical_to(const Float& other) const noexcept { return val_ == other.val_; }
 
   // Access numeric value.
-  constexpr FloatType get_value() const { return val_; }
+  constexpr FloatType get_value() const noexcept { return val_; }
+
+  // Is this float identical to zero?
+  constexpr bool is_zero() const noexcept { return val_ == static_cast<FloatType>(0); }
+
+  // True if the float is negative.
+  constexpr bool is_negative() const noexcept { return val_ < static_cast<FloatType>(0); }
 
   // Get absolute value.
   Float abs() const { return Float{std::abs(val_)}; }

--- a/components/math/include/expressions/power.h
+++ b/components/math/include/expressions/power.h
@@ -11,36 +11,37 @@ class Power {
   static constexpr std::string_view NameStr = "Power";
   static constexpr bool IsLeafNode = false;
 
-  Power(Expr base, Expr exponent) : base_(std::move(base)), exponent_(std::move(exponent)) {}
+  Power(Expr base, Expr exponent) : children_{std::move(base), std::move(exponent)} {}
 
   // Base and exponent must match.
   bool is_identical_to(const Power& other) const {
-    return base_.is_identical_to(other.base_) && exponent_.is_identical_to(other.exponent_);
+    return base().is_identical_to(other.base()) && exponent().is_identical_to(other.exponent());
   }
 
   // Implement ExpressionImpl::Iterate
   template <typename Operation>
-  void for_each(Operation operation) const {
-    operation(base_);
-    operation(exponent_);
+  void for_each(Operation&& operation) const {
+    std::for_each(children_.begin(), children_.end(), std::forward<Operation>(operation));
   }
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
   Expr map_children(Operation&& operation) const {
-    return Power::create(operation(base_), operation(exponent_));
+    return Power::create(operation(base()), operation(exponent()));
   }
 
   // Create a new power.
   // Will apply rules to simplify automatically.
-  static Expr create(const Expr& a, const Expr& b);
+  static Expr create(Expr a, Expr b);
 
-  const Expr& base() const { return base_; }
-  const Expr& exponent() const { return exponent_; }
+  constexpr const Expr& base() const noexcept { return children_[0]; }
+  constexpr const Expr& exponent() const noexcept { return children_[1]; }
+
+  constexpr auto begin() const noexcept { return children_.begin(); }
+  constexpr auto end() const noexcept { return children_.end(); }
 
  protected:
-  Expr base_;
-  Expr exponent_;
+  std::array<Expr, 2> children_;
 };
 
 // Convert an expression to a base/exponent pair.

--- a/components/math/include/expressions/special_constants.h
+++ b/components/math/include/expressions/special_constants.h
@@ -26,21 +26,29 @@ class Constant {
   SymbolicConstants name_;
 };
 
-// Complex infinity.
-// TODO: Should this store an enum to support different types of infinities?
-// For example, complex, +real, -real, etc.
+// Complex infinity (the north-pole of the riemann sphere).
 class Infinity {
  public:
-  static constexpr std::string_view NameStr = "Infinity";
+  static constexpr std::string_view NameStr = "ComplexInfinity";
   static constexpr bool IsLeafNode = true;
 
-  Infinity() = default;
+  constexpr Infinity() noexcept = default;
   constexpr bool is_identical_to(const Infinity&) const noexcept { return true; }
+};
+
+// Result of invalid expressions.
+class Undefined {
+ public:
+  static constexpr std::string_view NameStr = "Undefined";
+  static constexpr bool IsLeafNode = true;
+
+  Undefined() noexcept = default;
+  constexpr bool is_identical_to(const Undefined&) const noexcept { return true; }
 };
 
 // Convert symbolic constant enum to string constant.
 // For debugging purposes.
-inline constexpr std::string_view string_from_symbolic_constant(SymbolicConstants value) {
+inline constexpr std::string_view string_from_symbolic_constant(SymbolicConstants value) noexcept {
   switch (value) {
     case SymbolicConstants::Euler:
       return "e";
@@ -55,7 +63,7 @@ inline constexpr std::string_view string_from_symbolic_constant(SymbolicConstant
 }
 
 // Convert `SymbolicConstants` to a floating point double.
-constexpr double double_from_symbolic_constant(SymbolicConstants constant) {
+constexpr double double_from_symbolic_constant(SymbolicConstants constant) noexcept {
   switch (constant) {
     case SymbolicConstants::Euler:
       return M_E;
@@ -70,22 +78,30 @@ constexpr double double_from_symbolic_constant(SymbolicConstants constant) {
 }
 
 // Order constants by their enum values.
-inline constexpr bool operator<(const Constant& a, const Constant& b) {
+inline constexpr bool operator<(const Constant& a, const Constant& b) noexcept {
   return a.name() < b.name();
 }
 
 template <>
 struct hash_struct<Constant> {
-  constexpr std::size_t operator()(const Constant& c) const {
+  constexpr std::size_t operator()(const Constant& c) const noexcept {
     return static_cast<std::size_t>(c.name());
   }
 };
 
 template <>
 struct hash_struct<Infinity> {
-  constexpr std::size_t operator()(const Infinity&) const {
+  constexpr std::size_t operator()(const Infinity&) const noexcept {
     constexpr auto inf_hash = hash_string_fnv("inf");
     return inf_hash;
+  }
+};
+
+template <>
+struct hash_struct<Undefined> {
+  constexpr std::size_t operator()(const Undefined&) const noexcept {
+    constexpr auto undef_hash = hash_string_fnv("undef");
+    return undef_hash;
   }
 };
 

--- a/components/math/include/geometry/quaternion.h
+++ b/components/math/include/geometry/quaternion.h
@@ -200,14 +200,12 @@ class Quaternion {
              pow(R(2, 0) + R(0, 2), 2) +
              pow(R(2, 1) + R(1, 2), 2) +
              pow(R(2, 2) - R(0, 0) - R(1, 1) + 1, 2);
-    return {
-    sqrt(a) / 4,
-      // TODO: Add a sign-no-zero method to avoid conditional here?
-    where(R(2, 1) - R(1, 2) >= 0, 1, -1) * sqrt(b) / 4,
-    where(R(0, 2) - R(2, 0) >= 0, 1, -1) * sqrt(c) / 4,
-    where(R(1, 0) - R(0, 1) >= 0, 1, -1) * sqrt(d) / 4
-    };
     // clang-format on
+    return {sqrt(a) / 4,
+            // TODO: Add a sign-no-zero method to avoid conditional here?
+            where(R(2, 1) - R(1, 2) >= 0, 1, -1) * sqrt(b) / 4,
+            where(R(0, 2) - R(2, 0) >= 0, 1, -1) * sqrt(c) / 4,
+            where(R(1, 0) - R(0, 1) >= 0, 1, -1) * sqrt(d) / 4};
   }
 
  private:

--- a/components/math/include/operations.h
+++ b/components/math/include/operations.h
@@ -1,8 +1,11 @@
 // Copyright 2023 Gareth Cross
 #include "absl_imports.h"
 
+#include <optional>
+
 namespace math {
 class Expr;
+class MatrixExpr;
 
 // Replace instances of `target` w/ `replacement` in the input expression tree `input`.
 // Implemented in substitute.cc
@@ -22,11 +25,20 @@ Expr distribute(const Expr& arg);
 // Implemented in collect.cc
 Expr collect_many(const Expr& arg, absl::Span<const Expr> terms);
 
-// Version of `CollectMany` that accepts a single term.
+// Version of `collect_many` that accepts a single term.
 Expr collect(const Expr& arg, const Expr& term);
 
 // Evaluate to a number. If the result is a matrix, returns a matrix expression of numbers.
 // Implemented in evaluate.cc
 Expr evaluate(const Expr& arg);
+
+// Take the limit of `f_of_x` as `x` goes to 0 from the right.
+// The expression `x` must be a variable.
+// Implemented in limit.cc
+std::optional<Expr> limit(const Expr& f_of_x, const Expr& x);
+
+// Take the limit of matrix-valued function `f_of_x` as `x` goes to 0 from the right.
+// The expression `x` must be a variable.
+std::optional<MatrixExpr> limit(const MatrixExpr& f_of_x, const Expr& x);
 
 }  // namespace math

--- a/components/math/include/plain_formatter.h
+++ b/components/math/include/plain_formatter.h
@@ -21,6 +21,7 @@ class PlainFormatter {
   void operator()(const Rational& rational);
   void operator()(const Relational& relational);
   void operator()(const Function& func);
+  void operator()(const Undefined&);
   void operator()(const Variable& var);
 
   // Get the output string (transferring ownership to the caller).

--- a/components/math/include/visitor_base.h
+++ b/components/math/include/visitor_base.h
@@ -28,6 +28,7 @@ using ExpressionTypeList = type_list<
     class Power,
     class Rational,
     class Relational,
+    class Undefined,
     class Variable
     >;
 // clang-format on

--- a/components/math/source/code_generation/ir_builder.cc
+++ b/components/math/source/code_generation/ir_builder.cc
@@ -78,6 +78,9 @@ struct DetermineNumericTypeVisitor {
 
   constexpr NumericType operator()(const Function&) const { return NumericType::Real; }
 
+  // Not really true, but it doesn't matter what we return in this context.
+  constexpr NumericType operator()(const Undefined&) const { return NumericType::Real; }
+
   constexpr NumericType operator()(const Variable&) const { return NumericType::Real; }
 };
 
@@ -408,6 +411,10 @@ struct IRFormVisitor {
     NumericType promoted_type = std::max(left->determine_type(), right->determine_type());
     return push_operation(ir::Compare{relational.operation()}, maybe_cast(left, promoted_type),
                           maybe_cast(right, promoted_type));
+  }
+
+  ir::ValuePtr operator()(const Undefined&) const {
+    throw TypeError("Cannot generate code with expressions containing {}", Undefined::NameStr);
   }
 
   ir::ValuePtr operator()(const Variable&, const Expr& input_expression) {

--- a/components/math/source/collect.cc
+++ b/components/math/source/collect.cc
@@ -75,7 +75,7 @@ struct CollectVisitor {
 
     // We need to recurse on the remaining terms in the container.
     // Some terms ignored above could still be relevant to the other terms we are collecting over.
-    if (collected_terms_.size() > 1) {
+    if (collected_terms_.size() > 1 && !container.empty()) {
       Expr remaining_addition_terms =
           CollectVisitor{collected_terms_.subspan(1)}.collect_addition_terms(std::move(container));
       container.clear();
@@ -124,6 +124,7 @@ struct CollectVisitor {
   Expr operator()(const FunctionArgument&, const Expr& arg) const { return arg; }
   Expr operator()(const Rational&, const Expr& arg) const { return arg; }
   Expr operator()(const Relational& relation) { return recurse(relation); }
+  Expr operator()(const Undefined&) const { return Constants::Undefined; }
   Expr operator()(const Variable&, const Expr& arg) const { return arg; }
 
  private:

--- a/components/math/source/constants.cc
+++ b/components/math/source/constants.cc
@@ -11,8 +11,9 @@ const Expr Constants::One = make_expr<Integer>(1);
 const Expr Constants::Pi = make_expr<Constant>(SymbolicConstants::Pi);
 const Expr Constants::Euler = make_expr<Constant>(SymbolicConstants::Euler);
 const Expr Constants::NegativeOne = make_expr<Integer>(-1);
-const Expr Constants::Infinity = make_expr<math::Infinity>();
+const Expr Constants::ComplexInfinity = make_expr<Infinity>();
 const Expr Constants::True = make_expr<Constant>(SymbolicConstants::True);
 const Expr Constants::False = make_expr<Constant>(SymbolicConstants::False);
+const Expr Constants::Undefined = make_expr<math::Undefined>();
 
 }  // namespace math

--- a/components/math/source/derivative.cc
+++ b/components/math/source/derivative.cc
@@ -79,6 +79,7 @@ class DiffVisitor {
   Expr operator()(const Multiplication& mul) {
     std::vector<Expr> add_terms;  //  TODO: Small vector.
     add_terms.reserve(mul.arity());
+
     // Differentiate wrt every argument:
     for (std::size_t i = 0; i < mul.arity(); ++i) {
       std::vector<Expr> mul_terms;
@@ -92,6 +93,7 @@ class DiffVisitor {
       }
       add_terms.push_back(Multiplication::from_operands(mul_terms));
     }
+
     // TODO: Move, don't copy.
     return Addition::from_operands(add_terms);
   }
@@ -198,6 +200,8 @@ class DiffVisitor {
                     relational.left().to_string(), relational.operation_string(),
                     relational.right().to_string());
   }
+
+  Expr operator()(const Undefined&) const { return Constants::Undefined; }
 
   Expr operator()(const Variable& var) const {
     if constexpr (std::is_same_v<Variable, T>) {

--- a/components/math/source/distribute.cc
+++ b/components/math/source/distribute.cc
@@ -93,6 +93,7 @@ struct DistributeVisitor {
   Expr operator()(const Relational& relation, const Expr&) const {
     return relation.map_children(&distribute);
   }
+  Expr operator()(const Undefined&) const { return Constants::Undefined; }
   Expr operator()(const Variable&, const Expr& arg) const { return arg; }
 };
 

--- a/components/math/source/evaluate.cc
+++ b/components/math/source/evaluate.cc
@@ -33,6 +33,7 @@ struct EvaluateVisitor {
   Expr operator()(const FunctionArgument&, const Expr& arg) const { return arg; }
   Expr operator()(const Rational& r) const { return Float::create(static_cast<Float>(r)); }
   Expr operator()(const Relational& r) const { return r.map_children(&evaluate); }
+  Expr operator()(const Undefined&) const { return Constants::Undefined; }
   Expr operator()(const Variable&, const Expr& arg) const { return arg; }
 };
 

--- a/components/math/source/expressions/addition.cc
+++ b/components/math/source/expressions/addition.cc
@@ -2,16 +2,25 @@
 #include "expressions/addition.h"
 
 #include <algorithm>
-#include <unordered_map>
 
 #include "expressions/matrix.h"
 #include "expressions/multiplication.h"
 #include "expressions/numeric_expressions.h"
+#include "expressions/special_constants.h"
 #include "hashing.h"
 
 namespace math {
 
 Expr Addition::from_operands(absl::Span<const Expr> args) {
+  ZEN_ASSERT(!args.empty(), "Cannot call from_operands with an empty span.");
+  if (args.size() < 2) {
+    return args.front();
+  }
+
+  if (std::any_of(args.begin(), args.end(), &is_undefined)) {
+    return Constants::Undefined;
+  }
+
   // TODO: extract common denominator?
   AdditionParts parts{args.size()};
   for (const Expr& arg : args) {
@@ -43,13 +52,21 @@ struct AdditionVisitor {
     }
   }
 
-  using ExcludedTypes = type_list<Addition, Integer, Rational, Float, Matrix>;
+  constexpr void operator()(const Infinity&) noexcept { ++parts.num_infinities; }
+
+  using ExcludedTypes = type_list<Addition, Integer, Rational, Float, Infinity>;
 
   template <typename T, typename = enable_if_does_not_contain_type_t<T, ExcludedTypes>>
   void operator()(const T&, const Expr& input_expression) {
     // Everything else: Just add to the coeff
     auto [coeff, mul] = as_coeff_and_mul(input_expression);
-    ZEN_ASSERT(!mul.is_type<Addition>(), "TODO: Should just silently merge cases like this");
+
+    if (mul.is_type<Addition>()) {
+      // This is probably not great for performance, but shouldn't be _that_ common.
+      Expr distributed = input_expression.distribute();
+      operator()(cast_checked<Addition>(distributed));
+      return;
+    }
 
     const auto [it, was_inserted] = parts.terms.emplace(std::move(mul), coeff);
     if (!was_inserted) {
@@ -71,6 +88,7 @@ void AdditionParts::add_terms(const Expr& arg) {
   if (is_zero(arg)) {
     return;
   }
+
   AdditionVisitor visitor{*this};
   visit_with_expr(arg, visitor);
 }
@@ -88,13 +106,25 @@ void AdditionParts::normalize_coefficients() {
 
 Expr AdditionParts::create_addition() const {
   Addition::ContainerType args{};
-  if (float_term.has_value()) {
-    const Float promoted_rational = static_cast<Float>(rational_term);
-    args.push_back(make_expr<Float>(float_term.value() + promoted_rational));
-  } else if (rational_term.is_zero()) {
-    // Don't insert a useless zero in the add.
-  } else {
-    args.push_back(Rational::create(rational_term));
+
+  // handle infinities in the input
+  if (num_infinities > 1) {
+    // any additive/subtractive combination of complex infinities is undefined
+    return Constants::Undefined;
+  } else if (num_infinities > 0) {
+    args.push_back(Constants::ComplexInfinity);
+  }
+
+  // If we didn't add infinity, now consider float/rational.
+  if (args.empty()) {
+    if (float_term.has_value()) {
+      const Float promoted_rational = static_cast<Float>(rational_term);
+      args.push_back(make_expr<Float>(float_term.value() + promoted_rational));
+    } else if (rational_term.is_zero()) {
+      // Don't insert a useless zero in the add.
+    } else {
+      args.push_back(Rational::create(rational_term));
+    }
   }
 
   args.reserve(args.size() + terms.size());

--- a/components/math/source/expressions/matrix.cc
+++ b/components/math/source/expressions/matrix.cc
@@ -53,7 +53,11 @@ Matrix operator*(const Matrix& a, const Matrix& b) {
         addition_args.push_back(std::move(prod));
       }
     }
-    output.push_back(Addition::from_operands(addition_args));
+    if (addition_args.empty()) {
+      output.push_back(Constants::Zero);
+    } else {
+      output.push_back(Addition::from_operands(addition_args));
+    }
   });
   return Matrix(output_rows, output_cols, std::move(output));
 }

--- a/components/math/source/expressions/relational.cc
+++ b/components/math/source/expressions/relational.cc
@@ -107,6 +107,11 @@ struct RelationalSimplification {
 };
 
 Expr Relational::create(RelationalOperation operation, Expr left, Expr right) {
+  if (is_complex_infinity(left) || is_complex_infinity(right) || is_undefined(left) ||
+      is_undefined(right)) {
+    throw TypeError("Cannot construct relational with types: {} {} {}", left.type_name(),
+                    string_from_relational_operation(operation), right.type_name());
+  }
   // See if this relational automatically simplifies to a boolean constant:
   const TriState simplified = visit_binary(left, right, RelationalSimplification{operation});
   if (simplified == TriState::True) {

--- a/components/math/source/limits.cc
+++ b/components/math/source/limits.cc
@@ -1,0 +1,536 @@
+// Copyright 2023 Gareth Cross
+#include "common_visitors.h"
+#include "expressions/all_expressions.h"
+#include "matrix_expression.h"
+#include "operations.h"
+#include "visitor_impl.h"
+
+#include <algorithm>
+
+namespace math {
+using namespace math::custom_literals;
+
+// Steps:
+//  (1) substitute values
+//  (2) see if it produces a case we can handle w/ Hôpital's rule
+//  (3) try to apply the rule
+class LimitVisitor {
+ public:
+  // x is the variable we are taking the limit wrt to.
+  // 0+ is the value of `x` at the limit.
+  explicit LimitVisitor(const Expr& x)
+      : x_(x), x_typed_(cast_checked<Variable>(x_)), positive_inf_{"pinf"}, negative_inf_{"ninf"} {}
+
+  // Check the cache, and if no value exists, visit with this:
+  std::optional<Expr> visit(const Expr& expr) {
+    auto it = cache_.find(expr);
+    if (it != cache_.end()) {
+      return it->second;
+    }
+    std::optional<Expr> result = visit_with_expr(expr, *this);
+    cache_.emplace(expr, result);
+    return result;
+  }
+
+  std::optional<Expr> visit_no_inf(const Expr& expr) {
+    std::optional<Expr> result = visit(expr);
+    // Don't allow positive/negative affine infinity to leak out of the limit visitor.
+    if (result.has_value() &&
+        (result->is_identical_to(positive_inf_) || result->is_identical_to(negative_inf_))) {
+      return std::nullopt;
+    }
+    return result;
+  }
+
+  std::optional<Expr> operator()(const Addition& add) {
+    Addition::ContainerType f_funcs{}, g_funcs{}, terms{};
+    for (const Expr& expr : add) {
+      std::optional<Expr> child = visit(expr);
+      if (!child || is_undefined(*child) || is_complex_infinity(*child)) {
+        return std::nullopt;
+      } else if (child->is_identical_to(positive_inf_)) {
+        f_funcs.push_back(expr);
+      } else if (child->is_identical_to(negative_inf_)) {
+        g_funcs.push_back(expr);
+      } else {
+        terms.push_back(std::move(*child));
+      }
+    }
+
+    const bool has_non_constant_terms = std::any_of(
+        terms.begin(), terms.end(), [](const Expr& v) { return !is_numeric_or_constant(v); });
+
+    if (f_funcs.empty() != g_funcs.empty()) {
+      // only one kind of infinity:
+      if (has_non_constant_terms) {
+        return std::nullopt;
+      } else {
+        return f_funcs.empty() ? negative_inf_ : positive_inf_;
+      }
+    }
+
+    if (!f_funcs.empty() && !g_funcs.empty()) {
+      const Expr f = Addition::from_operands(f_funcs);
+      const Expr g = Addition::from_operands(g_funcs);
+      std::optional<Expr> indeterminate_term = visit((1 / g + 1 / f) * (g * f));
+      if (!indeterminate_term) {
+        return std::nullopt;
+      }
+      terms.push_back(std::move(*indeterminate_term));
+    }
+
+    return Addition::from_operands(terms);
+  }
+
+  std::optional<Expr> operator()(const Conditional& cond) {
+    std::optional<Expr> condition = visit(cond.condition());
+    if (!condition) {
+      return std::nullopt;
+    }
+
+    if (condition->is_identical_to(Constants::True)) {
+      return visit(cond.if_branch());
+    } else if (condition->is_identical_to(Constants::False)) {
+      return visit(cond.else_branch());
+    }
+
+    std::optional<Expr> if_branch = visit(cond.if_branch());
+    std::optional<Expr> else_branch = visit(cond.else_branch());
+    if (!if_branch) {
+      return std::nullopt;
+    }
+    if (!else_branch) {
+      return std::nullopt;
+    }
+    return Conditional::create(std::move(*condition), std::move(*if_branch),
+                               std::move(*else_branch));
+  }
+
+  std::optional<Expr> operator()(const Constant&, const Expr& expr) const { return expr; }
+
+  std::optional<Expr> operator()(const Derivative&, const Expr& expr) const {
+    throw TypeError("Cannot take limits of expressions containing `{}`. Encountered expression: {}",
+                    Derivative::NameStr, expr);
+  }
+
+  // Evaluate Hôpital's rule on a limit of the form:
+  //  lim[x->c] f(x) / g(x)
+  std::optional<Expr> hopitals_rule_quotient(const Expr& f, const Expr& g) {
+    // Take the derivative and substitute:
+    const Expr df = f.diff(x_);
+    const Expr dg = g.diff(x_);
+    const Expr df_over_dg = df / dg;
+
+#if 0
+    const std::string prefix(num_recursions_, ' ');
+    fmt::print("{}f: {}\n", prefix, f);
+    fmt::print("{}g: {}\n", prefix, g);
+    fmt::print("{}df: {} --> {}\n", prefix, f, df);
+    fmt::print("{}dg: {} --> {}\n", prefix, g, dg);
+    fmt::print("{}df_over_dg: {}\n", prefix, df_over_dg);
+#endif
+
+    constexpr std::size_t max_recursions = 4;
+    if (num_recursions_ >= max_recursions) {
+      return std::nullopt;
+    }
+
+    ++num_recursions_;
+    std::optional<Expr> df_over_dg_eval = visit(df_over_dg);
+    --num_recursions_;
+    if (!df_over_dg_eval || is_undefined(*df_over_dg_eval)) {
+      return std::nullopt;
+    }
+    return df_over_dg_eval;
+  }
+
+  struct IntegralPowers {
+    std::vector<Integer> powers{};
+
+    bool are_all_identical_up_to_sign() const {
+      ZEN_ASSERT(!powers.empty());
+      const auto first = powers.begin();
+      return std::all_of(std::next(first), powers.end(),
+                         [&](const Integer& i) { return first->abs() == i.abs(); });
+    }
+
+    std::tuple<int, int> determine_signs() const {
+      int num_positive = 0;
+      int num_negative = 0;
+      for (const Integer i : powers) {
+        if (i.get_value() >= 0) {
+          ++num_positive;
+        } else {
+          ++num_negative;
+        }
+      }
+      return std::make_tuple(num_positive, num_negative);
+    }
+
+    bool are_all_one() const {
+      return std::all_of(powers.begin(), powers.end(),
+                         [&](const Integer& i) { return i.get_value() == 1; });
+    }
+  };
+
+  template <typename Container>
+  std::optional<IntegralPowers> extract_integer_exponents(const Container& mul) {
+    IntegralPowers result{};
+    for (const Expr& expr : mul) {
+      auto [base, exp] = as_base_and_exp(expr);
+      if (const Integer* i = cast_ptr<Integer>(exp); i != nullptr) {
+        result.powers.push_back(*i);
+      } else {
+        return std::nullopt;
+      }
+    }
+    return {std::move(result)};
+  }
+
+  // Process multiplied terms that evaluate to a combination of zeros and infinities.
+  // This is used to handle multiplications that produce an indeterminate forms:
+  //  ∞ * 0, ∞ / ∞, 0 / 0
+  template <typename Container>
+  std::optional<Expr> process_indeterminate_form_multiplied_terms_1(const Container& mul) {
+    if (std::optional<IntegralPowers> integral_exponents = extract_integer_exponents(mul);
+        integral_exponents.has_value() && integral_exponents->are_all_identical_up_to_sign() &&
+        !integral_exponents->are_all_one()) {
+      const Integer int_power = integral_exponents->powers.front().abs();
+      const auto [num_positive, num_negative] = integral_exponents->determine_signs();
+
+      std::vector<Expr> terms{};
+      if (num_positive == 0 || num_negative == 0) {
+        // all negative or positive
+        std::transform(mul.begin(), mul.end(), std::back_inserter(terms), [](const Expr& v) {
+          auto [base, _] = as_base_and_exp(v);
+          return base;
+        });
+      } else {
+        // mixed
+        std::transform(mul.begin(), mul.end(), std::back_inserter(terms), [&](const Expr& v) {
+          auto [base, exponent] = as_base_and_exp(v);
+          return Power::create(base, exponent / int_power.get_value());
+        });
+      }
+
+      std::optional<Expr> inner_limit = process_indeterminate_form_multiplied_terms_2(terms);
+      if (inner_limit.has_value()) {
+        if (num_positive == 0) {
+          return Power::create(std::move(*inner_limit), -int_power.get_value());
+        } else {
+          return Power::create(std::move(*inner_limit), int_power.get_value());
+        }
+      } else {
+        return std::nullopt;
+      }
+    }
+    return process_indeterminate_form_multiplied_terms_2(mul);
+  }
+
+  template <typename Container>
+  std::optional<Expr> process_indeterminate_form_multiplied_terms_2(const Container& mul) {
+    // `f_funcs` contains functions that evaluate to zero, while `g_funcs` contains functions that
+    // evaluate to infinity.
+    Multiplication::ContainerType f_funcs{}, g_funcs{};
+    for (const Expr& expr : mul) {
+      std::optional<Expr> child = visit(expr);
+      ZEN_ASSERT(child.has_value(), "Already checked this expression is valid: {}", expr);
+      if (is_zero(*child)) {
+        f_funcs.push_back(expr);
+      } else if (is_inf(*child)) {
+        g_funcs.push_back(expr);
+      } else {
+        throw TypeError("Child expression should be zero or infinity. Found: {}", *child);
+      }
+    }
+
+    // We have both infinity and zero, so we can apply the rule for an indeterminate form:
+    //  lim[x->c] f(x)g(x) where lim[x->c] f(x) = 0 and lim[x->c] g(x) = ∞
+    //
+    // Which we can re-write as:
+    //  lim[x->c] f(x)g(x) = lim[x->c] f(x) / (1 / g(x)) = 0 / 0
+    //
+    // Or as:
+    //  lim[x->c] f(x)g(x) = lim[x->c] g(x) / (1 / f(x)) = ∞ / ∞
+    //
+    // Either form qualifies for Hôpital's rule, but one might recurse indefinitely.
+    const Expr f = Multiplication::from_operands(f_funcs);
+    const Expr g = Multiplication::from_operands(g_funcs);
+
+    std::optional<Expr> result = hopitals_rule_quotient(f, pow(g, -1));
+    if (!result.has_value()) {
+      // Try switching indeterminate forms:
+      //  lim[x->c] f(x) / g(x) = inf/inf -----> lim[x->c] [f(x)]^-1 / [g(x)]^-1 = 0 / 0
+      result = hopitals_rule_quotient(g, pow(f, -1));
+    }
+    return result;
+  }
+
+  template <typename Container>
+  std::optional<Expr> process_multiplied_terms(const Container& mul) {
+    // visit children and sort them:
+    //  0 --> f_funcs
+    //  infinity --> g_funcs
+    //  everything else --> remainder
+    Multiplication::ContainerType indeterminate_terms{}, remainder{};
+
+    std::size_t num_zeros = 0;
+    std::size_t num_infinities = 0;
+    std::size_t inf_sign_bits = 0;
+    for (const Expr& expr : mul) {
+      std::optional<Expr> child = visit(expr);
+      if (!child || is_complex_infinity(*child) || is_undefined(*child)) {
+        return std::nullopt;
+      }
+      if (is_zero(*child)) {
+        ++num_zeros;
+        indeterminate_terms.push_back(expr);
+      } else if (is_inf(*child)) {
+        ++num_infinities;
+        inf_sign_bits += child->is_identical_to(negative_inf_);
+        indeterminate_terms.push_back(expr);
+      } else {
+        remainder.push_back(std::move(*child));
+      }
+    }
+
+    // We need at least one: ∞ * 0
+    // Otherwise we delegate to Multiplication::from_operands
+    if (num_infinities == 0) {
+      if (num_zeros > 0) {
+        remainder.push_back(Constants::Zero);
+      }
+      return Multiplication::from_operands(remainder);
+    }
+
+    // We have at least one infinity. Do we have zeros?
+    if (num_zeros == 0) {
+      // There are no zeros, so we can't apply an indeterminate form.
+      std::size_t sign_bits = inf_sign_bits;
+      for (const Expr& v : remainder) {
+        if (is_numeric_or_constant(v)) {
+          if (is_negative_number(v)) {
+            ++sign_bits;
+          }
+        } else {
+          // We can't evaluate limits of the form: g(y) * ∞ (since we don't know the form of `g` or
+          // `y`).
+          return std::nullopt;
+        }
+      }
+      if (sign_bits & 1) {
+        return negative_inf_;
+      } else {
+        return positive_inf_;
+      }
+    }
+
+    std::optional<Expr> indeterminate_result =
+        process_indeterminate_form_multiplied_terms_1(indeterminate_terms);
+    if (!indeterminate_result) {
+      return std::nullopt;
+    }
+    remainder.push_back(std::move(*indeterminate_result));
+    return Multiplication::from_operands(remainder);
+  }
+
+  std::optional<Expr> operator()(const Multiplication& mul) {
+    return process_multiplied_terms(mul);
+  }
+
+  bool is_inf(const Expr& v) const {
+    return v.is_identical_to(positive_inf_) || v.is_identical_to(negative_inf_);
+  }
+
+  std::optional<Expr> process_power(const Expr& b, const Expr& e) {
+    // Substitute into base and exponent (first extract constant coefficients):
+    auto base_sub_opt = visit(b);
+    if (!base_sub_opt) {
+      return std::nullopt;
+    }
+    auto exp_sub_opt = visit(e);
+    if (!exp_sub_opt) {
+      return std::nullopt;
+    }
+
+    const Expr base_sub = std::move(*base_sub_opt);
+    const Expr exp_sub = std::move(*exp_sub_opt);
+    if (is_undefined(base_sub) || is_complex_infinity(base_sub) || is_undefined(exp_sub) ||
+        is_complex_infinity(exp_sub)) {
+      return std::nullopt;
+    }
+
+    ZEN_ASSERT(!exp_sub.is_identical_to(Constants::False));
+
+    if (is_zero(exp_sub) && (is_inf(base_sub) || is_zero(base_sub))) {
+      // 0 ^ 0 is an indeterminate form, and ∞ ^ 0
+      // lim[x->c] f(x)^g(x) = e ^ (lim[x->c] g(x) * log(f(x)))
+      // Where f(x) base `b` and g(x) is exponent `e`.
+      // TODO: There is a requirement that f(x) approaches 0 from above, if the result is to be
+      //  a real value (for 0^0).
+      std::optional<Expr> exponent = visit(e * log(b));
+      if (!exponent) {
+        return std::nullopt;
+      }
+      return Power::create(Constants::Euler, std::move(*exponent));
+    } else if (is_one(base_sub) && is_inf(exp_sub)) {
+      // 1 ^ ∞ is an indeterminate form
+      // lim[x->c] f(x)^g(x) = e ^ (lim[x->c] log(f(x)) * g(x))
+      // Where f(x) -> 1 (the base) and g(x) -> ∞ (the exponent)
+      std::optional<Expr> exponent = visit(log(b) * e);
+      if (!exponent) {
+        return std::nullopt;
+      }
+      return Power::create(Constants::Euler, std::move(*exponent));
+    } else if (is_zero(base_sub)) {
+      // base is zero, exponent is either function or a (+/-) constant
+      if (is_numeric_or_constant(exp_sub)) {
+        if (is_negative_number(exp_sub)) {
+          // (1/0)^(positive number) --> ∞
+          return positive_inf_;
+        } else {
+          // 0^positive --> 0
+          return Constants::Zero;
+        }
+      }
+    } else if (is_inf(base_sub)) {
+      if (base_sub.is_identical_to(positive_inf_)) {
+        if (is_numeric_or_constant(exp_sub)) {
+          return is_negative_number(exp_sub) ? Constants::Zero : positive_inf_;
+        }
+      } else {
+        if (is_numeric_or_constant(exp_sub) && is_negative_number(exp_sub)) {
+          return Constants::Zero;  // (-∞)^u where u < 0
+        } else if (const Integer* exp_int = cast_ptr<Integer>(exp_sub); exp_int != nullptr) {
+          ZEN_ASSERT(!exp_int->is_zero() && !exp_int->is_negative(), "value = {}", *exp_int);
+          if (exp_int->is_even()) {
+            return positive_inf_;
+          } else {
+            return negative_inf_;
+          }
+        } else {
+          return std::nullopt;
+        }
+      }
+      return std::nullopt;  // ∞^g(y), or -∞^(positive value)
+    } else if (is_inf(exp_sub)) {
+      if (is_numeric_or_constant(base_sub)) {
+        if (is_negative_number(base_sub)) {
+          //  In the context of limits, we treat (negative value)^∞ as undefined.
+          return std::nullopt;
+        } else {
+          // (positive) ^ ∞ --> ∞
+          // (positive) ^ -∞ --> 0
+          return exp_sub.is_identical_to(positive_inf_) ? positive_inf_ : Constants::Zero;
+        }
+      } else {
+        // We don't handle g(y)^∞
+        return std::nullopt;
+      }
+    }
+
+    return Power::create(base_sub, exp_sub);
+  }
+
+  // TODO: We need to handle the case of functions going to infinity.
+  std::optional<Expr> operator()(const Function& func) {
+    Function::ContainerType args{};
+    for (const Expr& arg : func) {
+      std::optional<Expr> arg_limit = visit(arg);
+      if (!arg_limit) {
+        return std::nullopt;
+      } else {
+        args.push_back(std::move(*arg_limit));
+      }
+    }
+
+    switch (func.enum_value()) {
+      case BuiltInFunctionName::Log: {
+        ZEN_ASSERT_EQUAL(1, args.size());
+        if (is_zero(args[0])) {
+          // In the context of a limit, allow log(0) --> -∞
+          return negative_inf_;
+        }
+      } break;
+      default:
+        break;
+    }
+    return Function::create(func.enum_value(), std::move(args));
+  }
+
+  std::optional<Expr> operator()(const Infinity&, const Expr& expr) const { return expr; }
+  std::optional<Expr> operator()(const Integer&, const Expr& expr) { return expr; }
+  std::optional<Expr> operator()(const Float&, const Expr& expr) { return expr; }
+  std::optional<Expr> operator()(const FunctionArgument&, const Expr& expr) { return expr; }
+  std::optional<Expr> operator()(const Rational&, const Expr& expr) { return expr; }
+
+  std::optional<Expr> operator()(const Power& pow) {
+    return process_power(pow.base(), pow.exponent());
+  }
+
+  std::optional<Expr> operator()(const Relational& rel, const Expr&) {
+    // For relationals, we do a substitution:
+    std::optional<Expr> left = visit(rel.left());
+    if (!left) {
+      return std::nullopt;
+    }
+    std::optional<Expr> right = visit(rel.right());
+    if (!right) {
+      return std::nullopt;
+    }
+    return Relational::create(rel.operation(), std::move(*left), std::move(*right));
+  }
+
+  std::optional<Expr> operator()(const Undefined&) const { return Constants::Undefined; }
+
+  std::optional<Expr> operator()(const Variable& var, const Expr& expr) const {
+    if (x_typed_.is_identical_to(var)) {
+      return Constants::Zero;  //  TODO: Support any value here.
+    }
+    return expr;
+  }
+
+ private:
+  const Expr& x_;
+  const Variable& x_typed_;
+
+  // Placeholders we insert for positive/negative.
+  Expr positive_inf_;
+  Expr negative_inf_;
+
+  // Cache of sub-expressions we've already evaluated the limit on.
+  std::unordered_map<Expr, std::optional<Expr>, hash_struct<Expr>, IsIdenticalOperator<Expr>>
+      cache_{};
+
+  // Used to detect the # of times hôpital's rule has recursed.
+  std::size_t num_recursions_{0};
+};
+
+// TODO: Add support for limits going to infinity.
+std::optional<Expr> limit(const Expr& f_of_x, const Expr& x) {
+  if (!x.is_type<Variable>()) {
+    throw TypeError(
+        "Limit argument `x` must be a variable. Encountered expression of type `{}`: {}",
+        x.type_name(), x);
+  }
+  return LimitVisitor{x}.visit_no_inf(f_of_x);
+}
+
+std::optional<MatrixExpr> limit(const MatrixExpr& f_of_x, const Expr& x) {
+  // Reuse the visitor, so that we get the benefit of caching results:
+  LimitVisitor visitor{x};
+
+  std::vector<Expr> values;
+  values.reserve(f_of_x.size());
+  for (const Expr& f : f_of_x.as_matrix()) {
+    std::optional<Expr> f_lim = visitor.visit_no_inf(f);
+    if (!f_lim) {
+      return std::nullopt;
+    } else {
+      values.push_back(std::move(*f_lim));
+    }
+  }
+  return MatrixExpr::create(f_of_x.rows(), f_of_x.cols(), std::move(values));
+}
+
+}  // namespace math

--- a/components/math/source/ordering.cc
+++ b/components/math/source/ordering.cc
@@ -7,9 +7,9 @@ namespace math {
 
 // Visitor that can be used to sort expressions by determining their relative order.
 struct OrderVisitor {
-  using OrderOfTypes =
-      type_list<Float, Integer, Rational, Constant, Infinity, Variable, FunctionArgument,
-                Multiplication, Addition, Power, Function, Relational, Conditional, Derivative>;
+  using OrderOfTypes = type_list<Float, Integer, Rational, Constant, Infinity, Variable,
+                                 FunctionArgument, Multiplication, Addition, Power, Function,
+                                 Relational, Conditional, Derivative, Undefined>;
 
   // Every type in the approved type list must appear here, or we get a compile error:
   static_assert(type_list_size<OrderOfTypes>::value == type_list_size<ExpressionTypeList>::value);
@@ -56,7 +56,7 @@ struct OrderVisitor {
     return RelativeOrder::Equal;
   }
 
-  constexpr RelativeOrder compare(const Infinity&, const Infinity&) const {
+  constexpr RelativeOrder compare(const Infinity&, const Infinity&) const noexcept {
     return RelativeOrder::Equal;
   }
 
@@ -123,6 +123,10 @@ struct OrderVisitor {
       return RelativeOrder::GreaterThan;
     }
     return visit_binary(a.right(), b.right(), OrderVisitor{});
+  }
+
+  constexpr RelativeOrder compare(const Undefined&, const Undefined&) const noexcept {
+    return RelativeOrder::Equal;
   }
 
   RelativeOrder compare(const Variable& a, const Variable& b) const {

--- a/components/math/source/plain_formatter.cc
+++ b/components/math/source/plain_formatter.cc
@@ -87,7 +87,7 @@ void PlainFormatter::operator()(const Derivative& derivative) {
 }
 
 void PlainFormatter::operator()(const Infinity&) {
-  fmt::format_to(std::back_inserter(output_), "z-inf");
+  fmt::format_to(std::back_inserter(output_), "zoo");
 }
 
 void PlainFormatter::operator()(const Integer& expr) {
@@ -227,6 +227,8 @@ void PlainFormatter::operator()(const Relational& expr) {
   fmt::format_to(std::back_inserter(output_), " {} ", expr.operation_string());
   format_precedence(Precedence::Relational, expr.right());
 }
+
+void PlainFormatter::operator()(const Undefined&) { output_.append("nan"); }
 
 void PlainFormatter::operator()(const Variable& expr) { output_ += expr.name(); }
 

--- a/components/math/source/tree_formatter.cc
+++ b/components/math/source/tree_formatter.cc
@@ -115,7 +115,7 @@ struct TreeFormatter {
     visit_right(op.exponent());
   }
 
-  void operator()(const Infinity&) { append_name("Infinity"); }
+  void operator()(const Infinity&) { append_name("{}", Infinity::NameStr); }
 
   void operator()(const Integer& neg) { append_name("Integer ({})", neg.get_value()); }
 
@@ -144,7 +144,9 @@ struct TreeFormatter {
     visit_right(*it);
   }
 
-  void operator()(const Variable& var) { append_name("Variable ({})", var.name()); }
+  void operator()(const Undefined&) { append_name(Undefined::NameStr); }
+
+  void operator()(const Variable& var) { append_name("{} ({})", Variable::NameStr, var.name()); }
 
   void operator()(const Conditional& conditional) {
     append_name("Conditional:");

--- a/components/sym_wrapper/expression_wrapper.cc
+++ b/components/sym_wrapper/expression_wrapper.cc
@@ -170,7 +170,7 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
 
   // Special constants:
   m.attr("euler") = Constants::Euler;
-  m.attr("inf") = Constants::Infinity;
+  m.attr("zoo") = Constants::ComplexInfinity;
   m.attr("one") = Constants::One;
   m.attr("pi") = Constants::Pi;
   m.attr("zero") = Constants::Zero;

--- a/components/sym_wrapper/python_test/expression_wrapper_test.py
+++ b/components/sym_wrapper/python_test/expression_wrapper_test.py
@@ -86,8 +86,8 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(0, sym.cos(-sym.pi / 2))
 
         self.assertIdentical(0, sym.tan(arg=0))
-        self.assertIdentical(sym.inf, sym.tan(arg=sym.pi / 2))
-        self.assertIdentical(sym.inf, sym.tan(arg=-sym.pi / 2))
+        self.assertIdentical(sym.zoo, sym.tan(arg=sym.pi / 2))
+        self.assertIdentical(sym.zoo, sym.tan(arg=-sym.pi / 2))
 
         self.assertIdentical(sym.pi / 2, sym.atan2(1, 0))
         self.assertIdentical(sym.pi / 4, sym.atan2(1, 1))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_custom_test(matrix_operations_test.cc)
 add_custom_test(ir_builder_test.cc)
 add_custom_test(substitute_test.cc)
 add_custom_test(quaternion_test.cc)
+add_custom_test(limits_test.cc)
 
 # TODO: MSVC doesn't care about our request for C++11, and just compiles with
 # C++14.

--- a/test/derivatives_test.cc
+++ b/test/derivatives_test.cc
@@ -3,6 +3,7 @@
 #include "expressions/derivative_expression.h"
 #include "functions.h"
 #include "matrix_functions.h"
+
 #include "test_helpers.h"
 
 // Test `diff` operation.
@@ -15,7 +16,7 @@ TEST(DerivativesTest, TestConstants) {
   ASSERT_IDENTICAL(Constants::Zero, (22.5_s).diff(x, 4));
   ASSERT_IDENTICAL(Constants::Zero, Constants::Pi.diff(x));
   ASSERT_IDENTICAL(Constants::Zero, Constants::Euler.diff(x));
-  ASSERT_IDENTICAL(Constants::Zero, Constants::Infinity.diff(x));
+  ASSERT_IDENTICAL(Constants::Zero, Constants::ComplexInfinity.diff(x));
   ASSERT_THROW(x.diff(5), TypeError);
   ASSERT_THROW(x.diff(Constants::Pi), TypeError);
 }

--- a/test/functions_test.cc
+++ b/test/functions_test.cc
@@ -8,8 +8,8 @@ namespace math {
 using namespace math::custom_literals;
 
 TEST(FunctionsTest, TestLog) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(log(x), log(x));
   ASSERT_NOT_IDENTICAL(log(x), log(y));
   ASSERT_IDENTICAL(Constants::One, log(Constants::Euler));
@@ -17,8 +17,8 @@ TEST(FunctionsTest, TestLog) {
 }
 
 TEST(FunctionsTest, TestCosine) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(cos(x), cos(x));
   ASSERT_NOT_IDENTICAL(cos(x), cos(y));
 
@@ -54,11 +54,14 @@ TEST(FunctionsTest, TestCosine) {
   for (double v : {-0.51, 0.78, 1.8, -2.1}) {
     ASSERT_IDENTICAL(Float::create(std::cos(v)), cos(v));
   }
+
+  ASSERT_IDENTICAL(Constants::Undefined, cos(Constants::ComplexInfinity));
+  ASSERT_IDENTICAL(Constants::Undefined, cos(Constants::Undefined));
 }
 
 TEST(FunctionsTest, TestSine) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(sin(x), sin(x));
   ASSERT_NOT_IDENTICAL(sin(x), sin(y));
 
@@ -92,11 +95,14 @@ TEST(FunctionsTest, TestSine) {
   for (double v : {6.0, 0.112, -0.65, 0.22}) {
     ASSERT_IDENTICAL(Float::create(std::sin(v)), sin(v));
   }
+
+  ASSERT_IDENTICAL(Constants::Undefined, sin(Constants::ComplexInfinity));
+  ASSERT_IDENTICAL(Constants::Undefined, sin(Constants::Undefined));
 }
 
 TEST(FunctionsTest, TestTan) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(tan(x), tan(x));
   ASSERT_NOT_IDENTICAL(tan(x), tan(y));
 
@@ -107,7 +113,8 @@ TEST(FunctionsTest, TestTan) {
 
   // Infinity at odd multiples of pi/2:
   for (int i = -15; i < 15; ++i) {
-    ASSERT_IDENTICAL(Constants::Infinity, tan(Integer::create(i * 2 + 1) * Constants::Pi / 2_s));
+    ASSERT_IDENTICAL(Constants::ComplexInfinity,
+                     tan(Integer::create(i * 2 + 1) * Constants::Pi / 2_s));
   }
 
   // Modulo pi:
@@ -124,21 +131,28 @@ TEST(FunctionsTest, TestTan) {
   for (double v : {-4.0, -0.132, 1.6, 6.8}) {
     ASSERT_IDENTICAL(Float::create(std::tan(v)), tan(v));
   }
+
+  ASSERT_IDENTICAL(Constants::Undefined, tan(Constants::ComplexInfinity));
+  ASSERT_IDENTICAL(Constants::Undefined, tan(Constants::Undefined));
 }
 
 TEST(FunctionsTest, TestArccos) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(acos(x), acos(x));
   ASSERT_NOT_IDENTICAL(acos(x), acos(y));
+
   ASSERT_IDENTICAL(Constants::Zero, acos(1_s));
   ASSERT_IDENTICAL(Constants::Pi, acos(-1_s));
   ASSERT_IDENTICAL(Constants::Pi / 2_s, acos(Constants::Zero));
+
+  ASSERT_IDENTICAL(Constants::Undefined, acos(Constants::Undefined));
+  ASSERT_IDENTICAL(Constants::Undefined, acos(Constants::ComplexInfinity));
 }
 
 TEST(FunctionsTest, TestArcsin) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(asin(x), asin(x));
   ASSERT_NOT_IDENTICAL(asin(x), asin(y));
   ASSERT_IDENTICAL(-asin(x), asin(-x));
@@ -147,11 +161,14 @@ TEST(FunctionsTest, TestArcsin) {
   ASSERT_IDENTICAL(Constants::Zero, asin(0_s));
   ASSERT_IDENTICAL(Constants::Pi / 2_s, asin(1_s));
   ASSERT_IDENTICAL(-Constants::Pi / 2_s, asin(-1_s));
+
+  ASSERT_IDENTICAL(Constants::Undefined, asin(Constants::Undefined));
+  ASSERT_IDENTICAL(Constants::Undefined, asin(Constants::ComplexInfinity));
 }
 
 TEST(FunctionsTest, TestArctan) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(atan(x), atan(x));
   ASSERT_NOT_IDENTICAL(atan(x), atan(y));
   ASSERT_IDENTICAL(-atan(x), atan(-x));
@@ -159,11 +176,14 @@ TEST(FunctionsTest, TestArctan) {
   ASSERT_IDENTICAL(Constants::Zero, atan(0_s));
   ASSERT_IDENTICAL(Constants::Pi / 4_s, atan(1_s));
   ASSERT_IDENTICAL(-Constants::Pi / 4_s, atan(-1_s));
+
+  ASSERT_IDENTICAL(Constants::Undefined, atan(Constants::Undefined));
+  ASSERT_IDENTICAL(Constants::Undefined, atan(Constants::ComplexInfinity));
 }
 
 TEST(FunctionsTest, TestArctan2) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(atan2(y, x), atan2(y, x));
   ASSERT_NOT_IDENTICAL(atan2(y, x), atan2(x, y));
   ASSERT_IDENTICAL(0, atan2(0, 1));
@@ -179,11 +199,17 @@ TEST(FunctionsTest, TestArctan2) {
   // floating point inputs should be evaluated immediately
   ASSERT_IDENTICAL(std::atan2(0.1, -0.6), atan2(0.1, -0.6));
   ASSERT_IDENTICAL(std::atan2(-1.2, 0.2), atan2(-1.2, 0.2));
+
+  // undefined and infinity
+  ASSERT_IDENTICAL(Constants::Undefined, atan2(y, Constants::Undefined));
+  ASSERT_IDENTICAL(Constants::Undefined, atan2(y, Constants::ComplexInfinity));
+  ASSERT_IDENTICAL(Constants::Undefined, atan2(Constants::Undefined, x));
+  ASSERT_IDENTICAL(Constants::Undefined, atan2(Constants::ComplexInfinity, x));
 }
 
 TEST(FunctionsTest, TestAbs) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(abs(x), abs(x));
   ASSERT_NOT_IDENTICAL(abs(x), abs(y));
   ASSERT_IDENTICAL(abs(x), abs(abs(x)));
@@ -193,10 +219,13 @@ TEST(FunctionsTest, TestAbs) {
   ASSERT_IDENTICAL(3 / 2_s, abs(-3 / 2_s));
   ASSERT_IDENTICAL(0.1, abs(-0.1));
   ASSERT_IDENTICAL(Constants::Pi, abs(Constants::Pi));
+  ASSERT_IDENTICAL(Constants::Undefined, abs(Constants::ComplexInfinity));
+  ASSERT_IDENTICAL(Constants::Undefined, abs(Constants::Undefined));
 }
 
 TEST(FunctionsTest, TestSignum) {
   const auto [x, y] = make_symbols("x", "y");
+
   ASSERT_IDENTICAL(signum(x), signum(x));
   ASSERT_NOT_IDENTICAL(signum(x), signum(y));
 
@@ -212,6 +241,8 @@ TEST(FunctionsTest, TestSignum) {
 
   ASSERT_IDENTICAL(1, signum(Constants::Pi));
   ASSERT_IDENTICAL(1, signum(Constants::Euler));
+
+  ASSERT_IDENTICAL(Constants::Undefined, signum(Constants::Undefined));
 }
 
 TEST(FunctionTest, TestMinMax) {

--- a/test/limits_test.cc
+++ b/test/limits_test.cc
@@ -1,0 +1,256 @@
+// Copyright 2023 Gareth Cross
+#include "constants.h"
+#include "expression.h"
+#include "functions.h"
+#include "operations.h"
+
+#include "geometry/quaternion.h"
+#include "test_helpers.h"
+
+// Test `limits` operation.
+namespace math {
+using namespace custom_literals;
+
+// Test some trivial limits.
+TEST(LimitsTest, TestSimpleLimits1) {
+  auto [x, y] = make_symbols("x", "y");
+  ASSERT_IDENTICAL(22, limit(22, y).value());
+  ASSERT_IDENTICAL(0, limit(x, x).value());
+  ASSERT_IDENTICAL(-y, limit(x - y, x).value());
+  ASSERT_IDENTICAL(6, limit((x - 3) * (x - 2), x).value());
+  ASSERT_IDENTICAL(1, limit(cos(x), x).value());
+  ASSERT_IDENTICAL(-1, limit(sin(x - Constants::Pi / 2), x).value());
+}
+
+TEST(LimitsTest, TestIndeterminateMultiplicativeForms1) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  // (x^3 - x*y^2) / (x - x*y)
+  auto f0 = (pow(x, 3) - x * y * y) / (x - x * y);
+  ASSERT_IDENTICAL(Constants::Undefined, f0.subs(x, 0));
+  ASSERT_IDENTICAL(-pow(y, 2) / (1 - y), limit(f0, x).value());
+
+  auto f1 = sin(x) / x;
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f1, x).value());
+
+  auto f2 = sin(x) / (2 * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(1_s / 2, limit(f2, x).value());
+
+  auto f3 = sin(x * y) / (x * z);
+  ASSERT_IDENTICAL(Constants::Undefined, f3.subs(x, 0));
+  ASSERT_IDENTICAL(y / z, limit(f3, x).value());
+  ASSERT_IDENTICAL(pow(y / z, 2), limit(pow(f3, 2), x).value());
+  ASSERT_IDENTICAL(pow(y / z, 3), limit(pow(f3, 3), x).value());
+  ASSERT_IDENTICAL(z / y, limit(pow(f3, -1), x).value());
+
+  auto f4 = (1 - cos(x)) / pow(x, 2);
+  ASSERT_IDENTICAL(Constants::Undefined, f4.subs(x, 0));
+  ASSERT_IDENTICAL(1_s / 2, limit(f4, x).value());
+
+  auto f5 = x * log(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f5.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f5, x).value());
+
+  auto f6 = sin(sqrt(x)) / sqrt(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f6.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f6, x).value());
+
+  auto f7 = pow(x, 2) * pow(log(x), 2);
+  ASSERT_IDENTICAL(0, limit(f7, x).value());
+
+  auto f8 = sin(z * x) / tan(x * y);
+  ASSERT_IDENTICAL(Constants::Undefined, f8.subs(x, 0));
+  ASSERT_IDENTICAL(z / y, limit(f8, x).value());
+
+  auto f9 = tan(3 * x) / tan(5 * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f9.subs(x, 0));
+  ASSERT_IDENTICAL(3_s / 5, limit(f9, x).value());
+
+  auto f10 = pow(sin(x), 2) / (x * cos(x));
+  ASSERT_IDENTICAL(Constants::Undefined, f10.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f10, x).value());
+
+  auto f11 = sin(x) * log(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f11.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f11, x).value());
+  ASSERT_IDENTICAL(0, limit(pow(f11, 2), x).value());
+
+  auto f12 = x * z / sqrt(x * x * z + y * y * z);
+  ASSERT_IDENTICAL(0, limit(f12, z).value());
+}
+
+TEST(LimitsTest, TestIndeterminateMultiplicativeForms2) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  auto f1 = tan(7 * x) / log(1 + 2 * x) + 3 * cos(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(7_s / 2 + 3, limit(f1, x).value());
+
+  auto f2 = (sin(x) - x) / pow(x, 2);
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f2, x).value());
+
+  // exists only from the right
+  auto f3 = log(3 * x * x + 1) / (2 * x * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f3.subs(x, 0));
+  ASSERT_IDENTICAL(3_s / 2, limit(f3, x).value());
+
+  auto f6 = log(cos(x) / 2 + 1_s / 2) / sin(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f6.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f6, x).value());
+
+  auto f7 = x / acos(1 - x * 5);
+  ASSERT_IDENTICAL(Constants::Undefined, f7.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f7, x).value());
+
+  auto f8 = log(x) * tan(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f8.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f8, x).value());
+
+  auto f9 = pow(x / y, 2) * pow(Constants::Euler, x) / pow(tan(z * x), 2);
+  ASSERT_IDENTICAL(Constants::Undefined, f9.subs(x, 0));
+  ASSERT_IDENTICAL(pow(z * y, -2), limit(f9, x).value());
+
+  auto f10 = pow(x * log(x * x * z), 2);
+  ASSERT_IDENTICAL(Constants::Undefined, f10.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f10, x).value());
+}
+
+// Test limits of the form 0^0
+TEST(LimitsTest, TestIndeterminatePowerForms1) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  auto f1 = pow(x, x);
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f1, x).value());
+
+  auto f2 = pow(y * x, x / z);
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f2, x).value());
+
+  auto f3 = pow(sin(x * y), x);
+  ASSERT_IDENTICAL(Constants::Undefined, f3.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f3, x).value());
+
+  auto f4 = pow(x, sin(x)) * 3;
+  ASSERT_IDENTICAL(Constants::Undefined, f4.subs(x, 0));
+  ASSERT_IDENTICAL(3, limit(f4, x).value());
+
+  auto f5 = pow(x * x, x);
+  ASSERT_IDENTICAL(Constants::Undefined, f5.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f5, x).value());
+
+  auto f6 = pow(x * x, x * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f6.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f6, x).value());
+
+  auto f7 = pow(cos(x + Constants::Pi / 2), log(1 + x));
+  ASSERT_IDENTICAL(Constants::Undefined, f7.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f7, x).value());
+}
+
+// Test limits of the form ∞^0
+TEST(LimitsTest, TestIndeterminatePowerForms2) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  // Contains both 0^0 (sin(x)/x) and ∞^0 (1/x)^x
+  auto f1 = pow(sin(x) / x, x);
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f1, x).value());
+
+  auto f2 = pow(log(x * y), z * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f2, x).value());
+
+  auto f3 = pow(1 / x, x);
+  ASSERT_IDENTICAL(Constants::Undefined, f3.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f3, x).value());
+
+  auto f4 = pow(1 / sin(x), 4 * x * x);
+  ASSERT_IDENTICAL(Constants::Undefined, f4.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f4, x).value());
+
+  auto f5 = pow(1 / sqrt(x), -4 * x) + 2 * cos(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f5.subs(x, 0));
+  ASSERT_IDENTICAL(3, limit(f5, x).value());
+
+  auto f6 = pow(1 + 1 / x, x);
+  ASSERT_IDENTICAL(Constants::Undefined, f6.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f6, x).value());
+}
+
+// Test limits of the form 1^∞
+TEST(LimitsTest, TestIndeterminatePowerForms3) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  auto f1 = pow(cos(x * y), 1 / x);
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f1, x).value());
+
+  auto f2 = pow(1 - x, log(x / z));
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f2, x).value());
+
+  auto f3 = pow(log(Constants::Euler - x), 1 / tan(x));
+  ASSERT_IDENTICAL(Constants::Undefined, f3.subs(x, 0));
+  ASSERT_IDENTICAL(pow(Constants::Euler, -1 / Constants::Euler), limit(f3, x).value());
+
+  auto f4 = pow(x * x + 1, 1 / abs(x));
+  ASSERT_IDENTICAL(Constants::Undefined, f4.subs(x, 0));
+  ASSERT_IDENTICAL(1, limit(f4, x).value());
+}
+
+// Test limits of the form ∞ - ∞
+TEST(LimitsTest, TestIndeterminateSubtractiveForms1) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  auto f1 = 1 / x - 1 / log(x + 1);
+  ASSERT_IDENTICAL(Constants::Undefined, f1.subs(x, 0));
+  ASSERT_IDENTICAL(-1_s / 2, limit(f1, x).value());
+
+  auto f2 = 1 / x - 1 / sin(x);
+  ASSERT_IDENTICAL(Constants::Undefined, f2.subs(x, 0));
+  ASSERT_IDENTICAL(0, limit(f2, x).value());
+}
+
+TEST(LimitsTest, TestInvalidForms) {
+  auto [x, y, z] = make_symbols("x", "y", "z");
+
+  // This would recurse indefinitely:
+  const auto e = Constants::Euler;
+  auto f1 = (pow(e, 1 / x) + pow(e, -1 / x)) / (pow(e, 1 / x) - pow(e, -1 / x));
+  ASSERT_FALSE(limit(f1, x).has_value());
+
+  // TODO: for x->0+ we _could_ evaluate this as 1?
+  auto f2 = abs(x) / x;
+  ASSERT_FALSE(limit(f2, x).has_value());
+
+  // We could evaluate this if we specialized logic for tan(x)
+  auto f3 = tan(x + Constants::Pi / 2) / tan(Constants::Pi / 2 - x);
+  ASSERT_FALSE(limit(f3, x).has_value());
+
+  // We don't support affine-extension of real numbers outside of limits, so these do not exist:
+  ASSERT_FALSE(limit(1 / x, x).has_value());
+  ASSERT_FALSE(limit(log(x), x).has_value());
+}
+
+// Test the limit function called on matrices.
+TEST(LimitsTest, TestMatrixLimits) {
+  auto [x, y, z, t] = make_symbols("x", "y", "z", "t");
+
+  auto f1 = make_matrix(2, 2, sin(y * x) / (x * 3), x * log(x * y), x + 2,
+                        3 * (x - 1) * sin(y * x) / (x * z));
+  ASSERT_IDENTICAL(make_matrix(2, 2, y / 3, 0, 2, -3 * y / z), limit(f1, x).value());
+
+  // Create rotation matrix and take limit as angles goes to zero:
+  auto R = Quaternion::from_rotation_vector(x * t, y * t, z * t).to_rotation_matrix();
+  ASSERT_IDENTICAL(make_identity(3), limit(R, t).value());
+
+  // If one term in the matrix is invalid, the whole thing should be none:
+  auto f2 = make_matrix(2, 2, 1 / x, x * x, x + 1, z);
+  ASSERT_FALSE(limit(f2, x).has_value());
+}
+
+}  // namespace math

--- a/test/plain_formatter_test.cc
+++ b/test/plain_formatter_test.cc
@@ -148,4 +148,8 @@ TEST(PlainFormatterTest, TestDerivativeExpression) {
   ASSERT_STR_EQ("Derivative(signum(a), a, 2)", signum(a).diff(a, 2));
 }
 
+TEST(PlainFormatterTest, TestComplexInfinity) { ASSERT_STR_EQ("zoo", Constants::ComplexInfinity); }
+
+TEST(PlainFormatterTest, TestUndefined) { ASSERT_STR_EQ("nan", Constants::Undefined); }
+
 }  // namespace math

--- a/test/quaternion_test.cc
+++ b/test/quaternion_test.cc
@@ -457,6 +457,13 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
   //  S(4) -> SO(3) -> S(4)
   //  For now I'll just test this numerically.
 
+  auto cast_to_float = [](const Expr& expr) -> double {
+    if (expr.is_type<Float>()) {
+      return cast_checked<Float>(expr).get_value();
+    }
+    return static_cast<double>(cast_checked<Integer>(expr).get_value());
+  };
+
   constexpr int num_vectors = 75;
   constexpr int num_angles = 20;
   for (auto [angle_num, axis_num] : generate_angle_axis_test_pairs(num_vectors, num_angles)) {
@@ -466,16 +473,16 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
         Quaternion{q_num.w(), q_num.x(), q_num.y(), q_num.z()}.to_rotation_matrix();
     const Quaternion q = Quaternion::from_rotation_matrix(R);
 
-    ASSERT_NEAR(q_num.w(), cast_checked<Float>(q.w()).get_value(), 1.0e-15)
+    ASSERT_NEAR(q_num.w(), cast_to_float(q.w()), 1.0e-15)
         << fmt::format("q_num = [{}, {}, {}, {}]\nq = {}\nR:\n{}", q_num.w(), q_num.x(), q_num.y(),
                        q_num.z(), q.to_vector_wxyz().transposed(), R);
-    ASSERT_NEAR(q_num.x(), cast_checked<Float>(q.x()).get_value(), 1.0e-15)
+    ASSERT_NEAR(q_num.x(), cast_to_float(q.x()), 1.0e-15)
         << fmt::format("q_num = [{}, {}, {}, {}]\nq = {}\nR:\n{}", q_num.w(), q_num.x(), q_num.y(),
                        q_num.z(), q.to_vector_wxyz().transposed(), R);
-    ASSERT_NEAR(q_num.y(), cast_checked<Float>(q.y()).get_value(), 1.0e-15)
+    ASSERT_NEAR(q_num.y(), cast_to_float(q.y()), 1.0e-15)
         << fmt::format("q_num = [{}, {}, {}, {}]\nq = {}\nR:\n{}", q_num.w(), q_num.x(), q_num.y(),
                        q_num.z(), q.to_vector_wxyz().transposed(), R);
-    ASSERT_NEAR(q_num.z(), cast_checked<Float>(q.z()).get_value(), 1.0e-15)
+    ASSERT_NEAR(q_num.z(), cast_to_float(q.z()), 1.0e-15)
         << fmt::format("q_num = [{}, {}, {}, {}]\nq = {}\nR:\n{}", q_num.w(), q_num.x(), q_num.y(),
                        q_num.z(), q.to_vector_wxyz().transposed(), R);
   }

--- a/test/substitute_test.cc
+++ b/test/substitute_test.cc
@@ -30,7 +30,7 @@ TEST(SubstituteTest, TestFunctions) {
   ASSERT_IDENTICAL(cos(x), cos(z).subs(z, x));
   ASSERT_IDENTICAL(cos(sin(y) * log(z)), cos(z).subs(z, sin(y) * log(z)));
   ASSERT_IDENTICAL(0, cos(x).subs(x, Constants::Pi / 2));
-  ASSERT_IDENTICAL(Constants::Infinity, tan(z).subs(z, Constants::Pi / 2));
+  ASSERT_IDENTICAL(Constants::ComplexInfinity, tan(z).subs(z, Constants::Pi / 2));
 
   // Replacing function expressions:
   ASSERT_IDENTICAL(z + y, cos(x).subs(cos(x), z + y));
@@ -72,7 +72,7 @@ TEST(SubstituteTest, TestPower) {
   // If there is a fraction in the power that can divide w/ an integer part:
   ASSERT_IDENTICAL(w * pow(x, 2_s / 3 * z + 2), pow(x, 5_s / 3 * z + 2).subs(pow(x, z), w));
 
-  // TODO: this simplification seems perhaps not worthwhile and overly compliated?
+  // TODO: this simplification seems perhaps not worthwhile and overly complicated?
   ASSERT_IDENTICAL(pow(w, -3) * pow(log(x * 2), -2_s / 7 * z),
                    pow(log(x * 2), -23_s / 7 * z).subs(pow(log(x * 2), z), w));
 


### PR DESCRIPTION
- This is a V1 of limit evaluation. It can evaluate limits that are solvable by recursively applying hopital's rule
- Rename `Infinity` to `ComplexInfinity`
- Add `Undefined` type and propagate it in operations
- All non-leaf expressions use array-style storage