### PR TITLE
Add jacobian method to quaternion type

### DIFF
--- a/components/math/examples/quaternion_interpolation/quat_interpolation_expressions.h
+++ b/components/math/examples/quaternion_interpolation/quat_interpolation_expressions.h
@@ -20,11 +20,9 @@ auto quaternion_interpolation(ta::StaticMatrix<4, 1> q0_vec, ta::StaticMatrix<4,
       q0 * Quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);
 
   ta::StaticMatrix<3, 3> D_q0 = q_interp.right_local_coordinates_derivative() *
-                                q_interp.to_vector_wxyz().jacobian(q0.wxyz()) *
-                                q0.right_retract_derivative();
+                                q_interp.jacobian(q0) * q0.right_retract_derivative();
   ta::StaticMatrix<3, 3> D_q1 = q_interp.right_local_coordinates_derivative() *
-                                q_interp.to_vector_wxyz().jacobian(q1.wxyz()) *
-                                q1.right_retract_derivative();
+                                q_interp.jacobian(q1) * q1.right_retract_derivative();
 
   return std::make_tuple(OutputArg("q_out", ta::StaticMatrix<4, 1>(q_interp.to_vector_xyzw())),
                          OptionalOutputArg("D_q0", std::move(D_q0)),

--- a/components/math/examples/quaternion_interpolation/quat_interpolation_test.cc
+++ b/components/math/examples/quaternion_interpolation/quat_interpolation_test.cc
@@ -3,7 +3,6 @@
 #include "numeric_testing.h"
 #include "numerical_jacobian.h"
 #include "test_helpers.h"
-#include "type_annotations.h"
 
 #include "quat_interpolation_expressions.h"
 

--- a/components/math/include/operations.h
+++ b/components/math/include/operations.h
@@ -21,9 +21,13 @@ Expr substitute_variables(const Expr& input, absl::Span<const std::tuple<Expr, E
 MatrixExpr substitute_variables(const MatrixExpr& input,
                                 absl::Span<const std::tuple<Expr, Expr>> pairs);
 
-// Take the derivative of `differentiand` wrt `arg`. The derivative is taken `reps` times.
+// Take the derivative of `function` wrt `var`. The derivative is taken `reps` times.
 // Implemented in derivative.cc
-Expr diff(const Expr& differentiand, const Expr& arg, const int reps);
+Expr diff(const Expr& function, const Expr& var, const int reps);
+
+// Compute the jacobian of the vector `functions` wrt the variables in `vars`.
+// If `functions` has length `N` and `vars` length `M`, the result will be NxM.
+MatrixExpr jacobian(absl::Span<const Expr> functions, absl::Span<const Expr> vars);
 
 // Distribute over multiplications in the input expression.
 // Expands terms like: (a + b) * (c * d) --> a*c + a*d + b*c + b*d

--- a/components/math/tests/limits_test.cc
+++ b/components/math/tests/limits_test.cc
@@ -4,6 +4,7 @@
 #include "expressions/addition.h"
 #include "functions.h"
 #include "geometry/quaternion.h"
+#include "matrix_functions.h"
 #include "operations.h"
 
 #include "test_helpers.h"

--- a/components/sym_wrapper/geometry_wrapper.cc
+++ b/components/sym_wrapper/geometry_wrapper.cc
@@ -157,6 +157,22 @@ void wrap_geometry_operations(py::module_& m) {
            py::doc("Convert quaternion to rotation-vector representation."))
       .def_static("from_rotation_matrix", &Quaternion::from_rotation_matrix, py::arg("R"),
                   py::doc("Convert from a rotation matrix via Calley's method."))
+      .def(
+          "jacobian",
+          [](const Quaternion& self, const MatrixExpr& vars) { return self.jacobian(vars); },
+          py::arg("vars"),
+          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
+      .def(
+          "jacobian",
+          [](const Quaternion& self, const std::vector<Expr>& vars) { return self.jacobian(vars); },
+          py::arg("vars"),
+          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
+      .def(
+          "jacobian",
+          [](const Quaternion& self, const Quaternion& vars) { return self.jacobian(vars); },
+          py::arg("vars"),
+          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables in "
+                  "another quaternion."))
       .def("right_retract_derivative", &Quaternion::right_retract_derivative,
            py::doc("Jacobian of q * exp(w) wrt w around w = 0."))
       .def("right_local_coordinates_derivative", &Quaternion::right_local_coordinates_derivative,


### PR DESCRIPTION
- Move jacobian method to `derivative.cc`
- Add `jacobian` method to `Quaternion` as a convenience