### PR TITLE
Split enum used for functions in math vs code generation

### DIFF
--- a/components/math/include/code_generation/ast.h
+++ b/components/math/include/code_generation/ast.h
@@ -189,11 +189,11 @@ struct Branch {
 };
 
 struct Call {
-  BuiltInFunctionName function;
+  StandardLibraryMathFunction function;
   std::vector<Variant> args;
 
   template <typename... Args>
-  explicit Call(BuiltInFunctionName function, Args&&... inputs)
+  explicit Call(StandardLibraryMathFunction function, Args&&... inputs)
       : function(function), args{std::forward<Args>(inputs)...} {}
 };
 

--- a/components/math/include/code_generation/ast_formatters.h
+++ b/components/math/include/code_generation/ast_formatters.h
@@ -51,7 +51,8 @@ auto format_ast(Iterator it, const math::ast::Branch& d) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const math::ast::Call& c) {
-  return fmt::format_to(it, "Call({}, {})", math::to_string(c.function), fmt::join(c.args, ", "));
+  return fmt::format_to(it, "Call({}, {})", string_from_standard_library_function(c.function),
+                        fmt::join(c.args, ", "));
 }
 
 template <typename Iterator>

--- a/components/math/include/derivative.h
+++ b/components/math/include/derivative.h
@@ -34,7 +34,6 @@ class DiffVisitor {
 
  private:
   Expr cached_visit(const Expr& expr);
-  Expr power_diff(const Expr& a, const Expr& b);
 
   // Argument we differentiate with respect to.
   const Expr& argument_;

--- a/components/math/include/enumerations.h
+++ b/components/math/include/enumerations.h
@@ -28,9 +28,9 @@ enum class RelativeOrder : int {
   GreaterThan = 1,
 };
 
-// Types of built-in unary functions.
+// Types of mathematical functions.
 // clang-format off
-enum class BuiltInFunctionName {
+enum class BuiltInFunction {
   // Unary functions.
   Cos = 0,
   Sin,
@@ -39,14 +39,10 @@ enum class BuiltInFunctionName {
   ArcSin,
   ArcTan,
   Log,
-  Sqrt,
   Abs,
   Signum,
   // Binary functions
   Arctan2,
-  Pow,
-  // Just to get the length of the enum:
-  ENUM_SIZE,
 };
 // clang-format on
 
@@ -100,6 +96,28 @@ enum class NumberSet : uint8_t {
   Unknown,
 };
 
+// List of mathematical functions typically found in your standard library.
+// This seems like a duplicate of `BuiltInFunction` at first, but they differ
+// in that this list contains additional specialized cases. In the math
+// expression tree powi, powf, and sqrt are all just instances of `Power`.
+enum class StandardLibraryMathFunction {
+  Cos,
+  Sin,
+  Tan,
+  ArcCos,
+  ArcSin,
+  ArcTan,
+  Log,
+  Sqrt,
+  Abs,
+  Signum,
+  Arctan2,
+  // Integral exponent power.
+  Powi,
+  // Floating point exponent power.
+  Powf,
+};
+
 // True if the set is real numbers, or a constrained subset of the real numbers.
 constexpr inline bool is_real_set(NumberSet set) noexcept {
   if (set == NumberSet::Real || set == NumberSet::RealNonNegative ||
@@ -123,32 +141,28 @@ constexpr std::string_view string_from_relative_order(const RelativeOrder order)
 }
 
 // Convert unary function enum to string.
-constexpr std::string_view to_string(const BuiltInFunctionName name) noexcept {
+constexpr std::string_view string_from_built_in_function(const BuiltInFunction name) noexcept {
   switch (name) {
-    case BuiltInFunctionName::Cos:
+    case BuiltInFunction::Cos:
       return "cos";
-    case BuiltInFunctionName::Sin:
+    case BuiltInFunction::Sin:
       return "sin";
-    case BuiltInFunctionName::Tan:
+    case BuiltInFunction::Tan:
       return "tan";
-    case BuiltInFunctionName::ArcCos:
+    case BuiltInFunction::ArcCos:
       return "acos";
-    case BuiltInFunctionName::ArcSin:
+    case BuiltInFunction::ArcSin:
       return "asin";
-    case BuiltInFunctionName::ArcTan:
+    case BuiltInFunction::ArcTan:
       return "atan";
-    case BuiltInFunctionName::Log:
+    case BuiltInFunction::Log:
       return "ln";
-    case BuiltInFunctionName::Sqrt:
-      return "sqrt";
-    case BuiltInFunctionName::Abs:
+    case BuiltInFunction::Abs:
       return "abs";
-    case BuiltInFunctionName::Signum:
+    case BuiltInFunction::Signum:
       return "signum";
-    case BuiltInFunctionName::Arctan2:
+    case BuiltInFunction::Arctan2:
       return "atan2";
-    case BuiltInFunctionName::Pow:
-      return "pow";
     default:
       break;
   }
@@ -211,6 +225,40 @@ constexpr inline std::string_view string_from_number_set(const NumberSet set) no
       return "Complex";
     case NumberSet::Unknown:
       return "Unknown";
+  }
+  return "<NOT A VALID ENUM VALUE>";
+}
+
+// Convert `StandardLibraryMathFunction` to string.
+constexpr inline std::string_view string_from_standard_library_function(
+    StandardLibraryMathFunction name) noexcept {
+  switch (name) {
+    case StandardLibraryMathFunction::Cos:
+      return "cos";
+    case StandardLibraryMathFunction::Sin:
+      return "sin";
+    case StandardLibraryMathFunction::Tan:
+      return "tan";
+    case StandardLibraryMathFunction::ArcCos:
+      return "acos";
+    case StandardLibraryMathFunction::ArcSin:
+      return "asin";
+    case StandardLibraryMathFunction::ArcTan:
+      return "atan";
+    case StandardLibraryMathFunction::Log:
+      return "log";
+    case StandardLibraryMathFunction::Sqrt:
+      return "sqrt";
+    case StandardLibraryMathFunction::Abs:
+      return "abs";
+    case StandardLibraryMathFunction::Signum:
+      return "signum";
+    case StandardLibraryMathFunction::Arctan2:
+      return "atan2";
+    case StandardLibraryMathFunction::Powi:
+      return "powi";
+    case StandardLibraryMathFunction::Powf:
+      return "powf";
   }
   return "<NOT A VALID ENUM VALUE>";
 }

--- a/components/math/include/expressions/function_expressions.h
+++ b/components/math/include/expressions/function_expressions.h
@@ -16,17 +16,19 @@ class Function {
   using ContainerType = absl::InlinedVector<Expr, 2>;
 
   template <typename... Args>
-  Function(BuiltInFunctionName func, Args&&... args)
+  Function(BuiltInFunction func, Args&&... args)
       : func_(func), args_{std::forward<Args>(args)...} {}
 
   // Create a function. Examines `name`, and then invokes the correct function method.
-  static Expr create(BuiltInFunctionName name, ContainerType&& container);
+  static Expr create(BuiltInFunction name, ContainerType&& container);
 
   // Get the function name.
-  constexpr BuiltInFunctionName enum_value() const noexcept { return func_; }
+  constexpr BuiltInFunction enum_value() const noexcept { return func_; }
 
   // Get name as a string.
-  constexpr std::string_view function_name() const noexcept { return to_string(func_); }
+  constexpr std::string_view function_name() const noexcept {
+    return string_from_built_in_function(func_);
+  }
 
   // Get the function argument.
   constexpr const auto& args() const noexcept { return args_; }
@@ -61,7 +63,7 @@ class Function {
   }
 
  protected:
-  BuiltInFunctionName func_;
+  BuiltInFunction func_;
   ContainerType args_;
 };
 
@@ -74,36 +76,30 @@ struct hash_struct<Function> {
 
 // Call the appropriate creation method for the specified enum value.
 // We need this logic because each type of function has simplifications it applies.
-inline Expr Function::create(BuiltInFunctionName name, Function::ContainerType&& container) {
+inline Expr Function::create(BuiltInFunction name, Function::ContainerType&& container) {
   switch (name) {
-    case BuiltInFunctionName::Cos:
+    case BuiltInFunction::Cos:
       return cos(container.front());
-    case BuiltInFunctionName::Sin:
+    case BuiltInFunction::Sin:
       return sin(container.front());
-    case BuiltInFunctionName::Tan:
+    case BuiltInFunction::Tan:
       return tan(container.front());
-    case BuiltInFunctionName::ArcCos:
+    case BuiltInFunction::ArcCos:
       return acos(container.front());
-    case BuiltInFunctionName::ArcSin:
+    case BuiltInFunction::ArcSin:
       return asin(container.front());
-    case BuiltInFunctionName::ArcTan:
+    case BuiltInFunction::ArcTan:
       return atan(container.front());
-    case BuiltInFunctionName::Log:
+    case BuiltInFunction::Log:
       return log(container.front());
-    case BuiltInFunctionName::Sqrt:
-      return sqrt(container.front());
-    case BuiltInFunctionName::Abs:
+    case BuiltInFunction::Abs:
       return abs(container.front());
-    case BuiltInFunctionName::Signum:
+    case BuiltInFunction::Signum:
       return signum(container.front());
-    case BuiltInFunctionName::Arctan2:
+    case BuiltInFunction::Arctan2:
       return atan2(container[0], container[1]);
-    case BuiltInFunctionName::Pow:
-      return pow(container[0], container[1]);
-    case BuiltInFunctionName::ENUM_SIZE:
-      break;
   }
-  ZEN_ASSERT(false, "Invalid function name: {}", to_string(name));
+  ZEN_ASSERT(false, "Invalid function name: {}", string_from_built_in_function(name));
   return Constants::Zero;  //  Unreachable.
 }
 

--- a/components/math/source/code_generation/ast.cc
+++ b/components/math/source/code_generation/ast.cc
@@ -298,7 +298,7 @@ struct AstBuilder {
     return ast::Add{make_operation_argument_ptr(val[0]), make_operation_argument_ptr(val[1])};
   }
 
-  ast::Variant operator()(const ir::Value& val, const ir::CallBuiltInFunction& func) {
+  ast::Variant operator()(const ir::Value& val, const ir::CallStandardLibraryFunction& func) {
     std::vector<ast::Variant> transformed_args{};
     transformed_args.reserve(val.num_operands());
     for (ir::ValuePtr arg : val.operands()) {
@@ -354,11 +354,6 @@ struct AstBuilder {
         throw TypeError("Invalid type in code generation expression: {}", T::NameStr);
       }
     });
-  }
-
-  ast::Variant operator()(const ir::Value& val, const ir::Pow&) {
-    return ast::Call{BuiltInFunctionName::Pow, make_operation_argument(val[0]),
-                     make_operation_argument(val[1])};
   }
 
  private:

--- a/components/math/source/code_generation/cpp_code_generator.cc
+++ b/components/math/source/code_generation/cpp_code_generator.cc
@@ -152,30 +152,31 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::AssignTem
   formatter.format("{} = {};", x.left, make_view(x.right));
 }
 
-static constexpr std::string_view cpp_string_for_built_in_function_call(
-    const BuiltInFunctionName name) noexcept {
+static constexpr std::string_view cpp_string_for_std_function(
+    const StandardLibraryMathFunction name) noexcept {
   switch (name) {
-    case BuiltInFunctionName::Cos:
+    case StandardLibraryMathFunction::Cos:
       return "std::cos";
-    case BuiltInFunctionName::Sin:
+    case StandardLibraryMathFunction::Sin:
       return "std::sin";
-    case BuiltInFunctionName::Tan:
+    case StandardLibraryMathFunction::Tan:
       return "std::tan";
-    case BuiltInFunctionName::ArcCos:
+    case StandardLibraryMathFunction::ArcCos:
       return "std::acos";
-    case BuiltInFunctionName::ArcSin:
+    case StandardLibraryMathFunction::ArcSin:
       return "std::asin";
-    case BuiltInFunctionName::ArcTan:
+    case StandardLibraryMathFunction::ArcTan:
       return "std::atan";
-    case BuiltInFunctionName::Log:
+    case StandardLibraryMathFunction::Log:
       return "std::log";
-    case BuiltInFunctionName::Sqrt:
+    case StandardLibraryMathFunction::Sqrt:
       return "std::sqrt";
-    case BuiltInFunctionName::Abs:
+    case StandardLibraryMathFunction::Abs:
       return "std::abs";
-    case BuiltInFunctionName::Arctan2:
+    case StandardLibraryMathFunction::Arctan2:
       return "std::atan2";
-    case BuiltInFunctionName::Pow:
+    case StandardLibraryMathFunction::Powi:
+    case StandardLibraryMathFunction::Powf:
       return "std::pow";
     default:
       break;
@@ -184,15 +185,14 @@ static constexpr std::string_view cpp_string_for_built_in_function_call(
 }
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::Call& x) const {
-  if (x.function == BuiltInFunctionName::Signum) {
-    // We need to special-case signum because it doesn't exist as a free-standing function in the
-    // stl.
+  if (x.function == StandardLibraryMathFunction::Signum) {
+    // We need to special-case signum because it doesn't exist as a free-standing function.
     // TODO: This should be an int expression.
     formatter.format(
         "static_cast<Scalar>(static_cast<Scalar>(0) < {}) - ({} < static_cast<Scalar>(0))",
         make_view(x.args[0]), make_view(x.args[0]));
   } else {
-    formatter.format("{}({})", cpp_string_for_built_in_function_call(x.function),
+    formatter.format("{}({})", cpp_string_for_std_function(x.function),
                      make_join_view(*this, ", ", x.args));
   }
 }

--- a/components/math/source/code_generation/rust_code_generator.cc
+++ b/components/math/source/code_generation/rust_code_generator.cc
@@ -164,32 +164,34 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Branch& 
   }
 }
 
-static constexpr std::string_view cpp_string_for_built_in_function_call(
-    const BuiltInFunctionName name) {
+static constexpr std::string_view rust_string_for_std_function(
+    const StandardLibraryMathFunction name) noexcept {
   switch (name) {
-    case BuiltInFunctionName::Cos:
+    case StandardLibraryMathFunction::Cos:
       return "f64::cos";
-    case BuiltInFunctionName::Sin:
+    case StandardLibraryMathFunction::Sin:
       return "f64::sin";
-    case BuiltInFunctionName::Tan:
+    case StandardLibraryMathFunction::Tan:
       return "f64::tan";
-    case BuiltInFunctionName::ArcCos:
+    case StandardLibraryMathFunction::ArcCos:
       return "f64::acos";
-    case BuiltInFunctionName::ArcSin:
+    case StandardLibraryMathFunction::ArcSin:
       return "f64::asin";
-    case BuiltInFunctionName::ArcTan:
+    case StandardLibraryMathFunction::ArcTan:
       return "f64::atan";
-    case BuiltInFunctionName::Log:
+    case StandardLibraryMathFunction::Log:
       return "f64::ln";
-    case BuiltInFunctionName::Sqrt:
+    case StandardLibraryMathFunction::Sqrt:
       return "f64::sqrt";
-    case BuiltInFunctionName::Abs:
+    case StandardLibraryMathFunction::Abs:
       return "f64::abs";
-    case BuiltInFunctionName::Signum:
+    case StandardLibraryMathFunction::Signum:
       return "f64::signum";
-    case BuiltInFunctionName::Arctan2:
+    case StandardLibraryMathFunction::Arctan2:
       return "f64::atan2";
-    case BuiltInFunctionName::Pow:
+    case StandardLibraryMathFunction::Powi:
+      return "f64::powi";
+    case StandardLibraryMathFunction::Powf:
       return "f64::powf";
     default:
       break;
@@ -198,12 +200,13 @@ static constexpr std::string_view cpp_string_for_built_in_function_call(
 }
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Call& x) const {
-  if (x.function == BuiltInFunctionName::Signum) {
-    // TODO: should be an integer rexpression
+  // We have to override signum specially here, because the built-in rust signum does not return 0.
+  if (x.function == StandardLibraryMathFunction::Signum) {
+    // TODO: should be an integer expression:
     formatter.format("((0.0f64 < {}) as i64 - ({} < 0.0f64) as i64) as f64", make_view(x.args[0]),
                      make_view(x.args[0]));
   } else {
-    formatter.format("{}({})", cpp_string_for_built_in_function_call(x.function),
+    formatter.format("{}({})", rust_string_for_std_function(x.function),
                      make_join_view(*this, ", ", x.args));
   }
 }

--- a/components/math/source/functions.cc
+++ b/components/math/source/functions.cc
@@ -42,7 +42,7 @@ Expr log(const Expr& x) {
     return std::move(*f);
   }
   // TODO: Check for negative values.
-  return make_expr<Function>(BuiltInFunctionName::Log, x);
+  return make_expr<Function>(BuiltInFunction::Log, x);
 }
 
 Expr pow(const Expr& x, const Expr& y) { return Power::create(x, y); }
@@ -70,8 +70,7 @@ Expr cos(const Expr& arg) {
       } else if (r_mod_pi == Rational{1, 2} || r_mod_pi == Rational{-1, 2}) {
         return Constants::Zero;
       }
-      return make_expr<Function>(BuiltInFunctionName::Cos,
-                                 Rational::create(r_mod_pi) * Constants::Pi);
+      return make_expr<Function>(BuiltInFunction::Cos, Rational::create(r_mod_pi) * Constants::Pi);
     }
   } else if (is_zero(coeff)) {
     return Constants::One;
@@ -91,7 +90,7 @@ Expr cos(const Expr& arg) {
     return Constants::Undefined;
   }
   // TODO: Check for phase offsets.
-  return make_expr<Function>(BuiltInFunctionName::Cos, arg);
+  return make_expr<Function>(BuiltInFunction::Cos, arg);
 }
 
 Expr sin(const Expr& arg) {
@@ -107,8 +106,7 @@ Expr sin(const Expr& arg) {
       } else if (r_mod_pi == Rational{-1, 2}) {
         return Constants::NegativeOne;
       }
-      return make_expr<Function>(BuiltInFunctionName::Sin,
-                                 Rational::create(r_mod_pi) * Constants::Pi);
+      return make_expr<Function>(BuiltInFunction::Sin, Rational::create(r_mod_pi) * Constants::Pi);
     }
   } else if (is_zero(arg)) {
     return Constants::Zero;
@@ -123,7 +121,7 @@ Expr sin(const Expr& arg) {
   if (arg.is_type<Infinity>() || is_undefined(arg)) {
     return Constants::Undefined;
   }
-  return make_expr<Function>(BuiltInFunctionName::Sin, arg);
+  return make_expr<Function>(BuiltInFunction::Sin, arg);
 }
 
 inline Rational convert_to_tan_range(const Rational& r) {
@@ -154,7 +152,7 @@ Expr tan(const Expr& arg) {
         // Complex infinity.
         return Constants::ComplexInfinity;
       }
-      return make_expr<Function>(BuiltInFunctionName::Tan,
+      return make_expr<Function>(BuiltInFunction::Tan,
                                  Rational::create(r_mod_half_pi) * pi_over_two());
     }
   } else if (is_zero(arg)) {
@@ -170,7 +168,7 @@ Expr tan(const Expr& arg) {
   if (arg.is_type<Infinity>() || is_undefined(arg)) {
     return Constants::Undefined;
   }
-  return make_expr<Function>(BuiltInFunctionName::Tan, arg);
+  return make_expr<Function>(BuiltInFunction::Tan, arg);
 }
 
 // TODO: Support inverting trig operations when the interval is specified, ie. acos(cos(x)) -> x
@@ -185,7 +183,7 @@ Expr acos(const Expr& arg) {
   } else if (is_undefined(arg) || is_complex_infinity(arg)) {
     return Constants::Undefined;
   }
-  return make_expr<Function>(BuiltInFunctionName::ArcCos, arg);
+  return make_expr<Function>(BuiltInFunction::ArcCos, arg);
 }
 
 Expr asin(const Expr& arg) {
@@ -200,7 +198,7 @@ Expr asin(const Expr& arg) {
   } else if (is_undefined(arg) || is_complex_infinity(arg)) {
     return Constants::Undefined;
   }
-  return make_expr<Function>(BuiltInFunctionName::ArcSin, arg);
+  return make_expr<Function>(BuiltInFunction::ArcSin, arg);
 }
 
 inline Expr PiOverFour() {
@@ -220,7 +218,7 @@ Expr atan(const Expr& arg) {
   } else if (is_undefined(arg) || is_complex_infinity(arg)) {
     return Constants::Undefined;
   }
-  return make_expr<Function>(BuiltInFunctionName::ArcTan, arg);
+  return make_expr<Function>(BuiltInFunction::ArcTan, arg);
 }
 
 // Support some very basic simplifications for numerical inputs.
@@ -269,7 +267,7 @@ Expr atan2(const Expr& y, const Expr& x) {
     return std::move(*maybe_simplified);
   }
   // TODO: Implement simplifications for atan2.
-  return make_expr<Function>(BuiltInFunctionName::Arctan2, y, x);
+  return make_expr<Function>(BuiltInFunction::Arctan2, y, x);
 }
 
 Expr sqrt(const Expr& arg) {
@@ -279,7 +277,7 @@ Expr sqrt(const Expr& arg) {
 
 Expr abs(const Expr& arg) {
   if (const Function* func = cast_ptr<Function>(arg);
-      func != nullptr && func->enum_value() == BuiltInFunctionName::Abs) {
+      func != nullptr && func->enum_value() == BuiltInFunction::Abs) {
     // abs(abs(x)) --> abs(x)
     return arg;
   }
@@ -308,7 +306,7 @@ Expr abs(const Expr& arg) {
   }
   // TODO: Add simplifications for real inputs, like powers.
   // TODO: Add simplifications for multiplications.
-  return make_expr<Function>(BuiltInFunctionName::Abs, arg);
+  return make_expr<Function>(BuiltInFunction::Abs, arg);
 }
 
 // TODO: Add simplifications for expressions like:
@@ -336,7 +334,7 @@ struct SignumVisitor {
   }
 
   std::optional<Expr> operator()(const Function& func, const Expr& func_expr) const {
-    if (func.enum_value() == BuiltInFunctionName::Signum) {
+    if (func.enum_value() == BuiltInFunction::Signum) {
       // sgn(sgn(x)) --> sgn(x), valid for real and complex
       return func_expr;
     }
@@ -358,7 +356,7 @@ Expr signum(const Expr& arg) {
   if (maybe_simplified) {
     return std::move(*maybe_simplified);
   }
-  return make_expr<Function>(BuiltInFunctionName::Signum, arg);
+  return make_expr<Function>(BuiltInFunction::Signum, arg);
 }
 
 // Max and min are implemented as conditionals. That way:

--- a/components/math/source/limits.cc
+++ b/components/math/source/limits.cc
@@ -453,7 +453,7 @@ class LimitVisitor {
     }
 
     switch (func.enum_value()) {
-      case BuiltInFunctionName::Log: {
+      case BuiltInFunction::Log: {
         ZEN_ASSERT_EQUAL(1, args.size());
         if (is_zero(args[0])) {
           // In the context of a limit, allow log(0) --> -∞

--- a/components/math/source/number_set.cc
+++ b/components/math/source/number_set.cc
@@ -82,55 +82,42 @@ class DetermineSetVisitor {
     }
 
     switch (func.enum_value()) {
-      case BuiltInFunctionName::Cos:
-      case BuiltInFunctionName::Sin: {
+      case BuiltInFunction::Cos:
+      case BuiltInFunction::Sin: {
         if (is_real_set(args[0])) {
           return NumberSet::Real;
         }
         return NumberSet::Complex;
       }
-      case BuiltInFunctionName::Tan:
+      case BuiltInFunction::Tan:
         // Any real argument could be +/- pi/2, which is unknown
         return NumberSet::Unknown;
-      case BuiltInFunctionName::ArcCos:
-      case BuiltInFunctionName::ArcSin:
-      case BuiltInFunctionName::ArcTan:
+      case BuiltInFunction::ArcCos:
+      case BuiltInFunction::ArcSin:
+      case BuiltInFunction::ArcTan:
         return NumberSet::Unknown;  //  TODO: implement inverse trig functions.
-      case BuiltInFunctionName::Log: {
+      case BuiltInFunction::Log: {
         if (args[0] == NumberSet::RealPositive) {
           return NumberSet::RealPositive;
         }
         // Otherwise could be zero.
         return NumberSet::Unknown;
       }
-      case BuiltInFunctionName::Sqrt: {
-        if (args[0] == NumberSet::RealPositive) {
-          return NumberSet::RealPositive;
-        } else if (args[0] == NumberSet::RealNonNegative) {
-          return NumberSet::RealNonNegative;
-        }
-        return NumberSet::Complex;
-      }
-      case BuiltInFunctionName::Abs: {
+      case BuiltInFunction::Abs: {
         if (args[0] == NumberSet::RealPositive) {
           return NumberSet::RealPositive;
         }
         return NumberSet::RealNonNegative;
       }
-      case BuiltInFunctionName::Signum: {
+      case BuiltInFunction::Signum: {
         if (is_real_set(args[0])) {
           return args[0];
         }
         return NumberSet::Unknown;
       }
-      case BuiltInFunctionName::Arctan2:
+      case BuiltInFunction::Arctan2:
         // Can always be undefined.
         return NumberSet::Unknown;
-      case BuiltInFunctionName::Pow: {
-        throw TypeError("Should not happen.");
-      }
-      case BuiltInFunctionName::ENUM_SIZE:
-        break;
     }
     throw TypeError("Invalid function: {}\n", func.function_name());
   }

--- a/components/math/tests/cpp_generation_gen.cc
+++ b/components/math/tests/cpp_generation_gen.cc
@@ -29,6 +29,7 @@ int main() {
   generate_func(gen, code, &nested_conditionals_1, "nested_conditionals_1", Arg("x"), Arg("y"));
   generate_func(gen, code, &nested_conditionals_2, "nested_conditionals_2", Arg("x"), Arg("y"));
   generate_func(gen, code, &create_rotation_matrix, "create_rotation_matrix", Arg("w"));
+  generate_func(gen, code, &rotation_vector_from_matrix, "rotation_vector_from_matrix", Arg("R"));
 
   code += "} // namespace gen";
 

--- a/components/math/tests/test_expressions.h
+++ b/components/math/tests/test_expressions.h
@@ -68,13 +68,20 @@ inline auto nested_conditionals_2(Expr x, Expr y) {
   return c2;
 }
 
-// Create a rotation matrix from a rodrigues vector, and the 9x3 Jacobian of the rotation matrix
+// Create a rotation matrix from a Rodrigues vector, and the 9x3 Jacobian of the rotation matrix
 // elements with respect to the vector.
 inline auto create_rotation_matrix(ta::StaticMatrix<3, 1> w) {
   MatrixExpr R = Quaternion::from_rotation_vector(w.inner(), 1.0e-16).to_rotation_matrix();
   MatrixExpr R_diff = vectorize_matrix(R).jacobian(w);
   return std::make_tuple(OutputArg("R", ta::StaticMatrix<3, 3>{R}),
                          OptionalOutputArg("R_D_w", ta::StaticMatrix<9, 3>{R_diff}));
+}
+
+// Recover a Rodrigues rotation vector from a 3x3 rotation matrix.
+inline auto rotation_vector_from_matrix(ta::StaticMatrix<3, 3> R) {
+  Quaternion q = Quaternion::from_rotation_matrix(R);
+  ta::StaticMatrix<3, 1> w = q.to_rotation_vector(1.0e-16);
+  return std::make_tuple(OutputArg("w", w));
 }
 
 }  // namespace math

--- a/components/python/sym/code_generation.py
+++ b/components/python/sym/code_generation.py
@@ -122,10 +122,14 @@ class PythonCodeGenerator(CodeGenerator):
 
     def format_Call(self, fmt: CustomStringFormatter, x: codegen.Call) -> str:
         funcs = {
-            codegen.BuiltInFunctionName.Cos: "np.cos", codegen.BuiltInFunctionName.Sin: "np.sin",
-            codegen.BuiltInFunctionName.Log: "np.log", codegen.BuiltInFunctionName.Sqrt: "np.sqrt",
-            codegen.BuiltInFunctionName.Tan: "np.tan", codegen.BuiltInFunctionName.Pow: "np.power",
-            codegen.BuiltInFunctionName.Arctan2: "np.atan2"
+            codegen.StandardLibraryMathFunction.Cos: "np.cos",
+            codegen.StandardLibraryMathFunction.Sin: "np.sin",
+            codegen.StandardLibraryMathFunction.Log: "np.log",
+            codegen.StandardLibraryMathFunction.Sqrt: "np.sqrt",
+            codegen.StandardLibraryMathFunction.Tan: "np.tan",
+            codegen.StandardLibraryMathFunction.Powi: "np.power",
+            codegen.StandardLibraryMathFunction.Powf: "np.power",
+            codegen.StandardLibraryMathFunction.Arctan2: "np.atan2"
         }
         return fmt.format("{}({})", funcs[x.function], ', '.join(fmt.format_ast(v) for v in x.args))
 

--- a/components/sym_wrapper/codegen_wrapper.cc
+++ b/components/sym_wrapper/codegen_wrapper.cc
@@ -102,21 +102,25 @@ void wrap_codegen_operations(py::module_& m) {
            }),
            py::arg("expressions"), py::arg("output_key"));
 
-  py::enum_<BuiltInFunctionName>(m, "BuiltInFunctionName")
-      .value("Cos", BuiltInFunctionName::Cos)
-      .value("Sin", BuiltInFunctionName::Sin)
-      .value("Tan", BuiltInFunctionName::Tan)
-      .value("ArcCos", BuiltInFunctionName::ArcCos)
-      .value("ArcSin", BuiltInFunctionName::ArcSin)
-      .value("ArcTan", BuiltInFunctionName::ArcTan)
-      .value("Log", BuiltInFunctionName::Log)
-      .value("Sqrt", BuiltInFunctionName::Sqrt)
-      .value("Abs", BuiltInFunctionName::Abs)
-      .value("Signum", BuiltInFunctionName::Signum)
-      .value("Arctan2", BuiltInFunctionName::Arctan2)
-      .value("Pow", BuiltInFunctionName::Pow)
+  py::enum_<StandardLibraryMathFunction>(m, "StandardLibraryMathFunction")
+      .value("Cos", StandardLibraryMathFunction::Cos)
+      .value("Sin", StandardLibraryMathFunction::Sin)
+      .value("Tan", StandardLibraryMathFunction::Tan)
+      .value("ArcCos", StandardLibraryMathFunction::ArcCos)
+      .value("ArcSin", StandardLibraryMathFunction::ArcSin)
+      .value("ArcTan", StandardLibraryMathFunction::ArcTan)
+      .value("Log", StandardLibraryMathFunction::Log)
+      .value("Sqrt", StandardLibraryMathFunction::Sqrt)
+      .value("Abs", StandardLibraryMathFunction::Abs)
+      .value("Signum", StandardLibraryMathFunction::Signum)
+      .value("Arctan2", StandardLibraryMathFunction::Arctan2)
+      .value("Powi", StandardLibraryMathFunction::Powi)
+      .value("Powf", StandardLibraryMathFunction::Powf)
       .def(
-          "to_string", [](BuiltInFunctionName name) { return to_string(name); },
+          "to_string",
+          [](StandardLibraryMathFunction name) {
+            return string_from_standard_library_function(name);
+          },
           py::doc("Convert to string."));
 
   py::enum_<NumericType>(m, "NumericType")

--- a/components/sym_wrapper/expression_wrapper.cc
+++ b/components/sym_wrapper/expression_wrapper.cc
@@ -177,7 +177,24 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
   m.attr("true") = Constants::True;
   m.attr("false") = Constants::False;
 
+  // Function enums.
+  py::enum_<BuiltInFunction>(m, "BuiltInFunction")
+      .value("Cos", BuiltInFunction::Cos)
+      .value("Sin", BuiltInFunction::Sin)
+      .value("Tan", BuiltInFunction::Tan)
+      .value("ArcCos", BuiltInFunction::ArcCos)
+      .value("ArcSin", BuiltInFunction::ArcSin)
+      .value("ArcTan", BuiltInFunction::ArcTan)
+      .value("Log", BuiltInFunction::Log)
+      .value("Abs", BuiltInFunction::Abs)
+      .value("Signum", BuiltInFunction::Signum)
+      .value("Arctan2", BuiltInFunction::Arctan2)
+      .def(
+          "to_string", [](BuiltInFunction name) { return string_from_built_in_function(name); },
+          py::doc("Convert to string."));
+
   // Exceptions:
+  py::register_exception<AssertionError>(m, "AssertionError");
   py::register_exception<DimensionError>(m, "DimensionError");
   py::register_exception<TypeError>(m, "TypeError");
 


### PR DESCRIPTION
Using `BuiltInFunction` for both of these did not make sense since the code-generation functions have more specialized cases to consider.

Also eliminate redundant `Pow` operation from the IR. This is just a function call like any other.