### PR TITLE
Rename assertion macros to match project name

### DIFF
--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -73,8 +73,8 @@ template <index_t Rows, index_t Cols>
 struct apply_numeric_evaluator_impl<ta::StaticMatrix<Rows, Cols>> {
   Eigen::Matrix<double, Rows, Cols> operator()(NumericFunctionEvaluator& evaluator,
                                                const MatrixExpr& input) const {
-    ZEN_ASSERT_EQUAL(input.rows(), Rows);
-    ZEN_ASSERT_EQUAL(input.cols(), Cols);
+    WF_ASSERT_EQUAL(input.rows(), Rows);
+    WF_ASSERT_EQUAL(input.cols(), Cols);
     Eigen::Matrix<double, Rows, Cols> output;
     for (index_t i = 0; i < Rows; ++i) {
       for (index_t j = 0; j < Cols; ++j) {

--- a/components/core/tests/ir_builder_test.cc
+++ b/components/core/tests/ir_builder_test.cc
@@ -42,7 +42,7 @@ struct OptionalArgPermutations {
         scatter_.emplace(it->key.name, scatter_.size());
       }
     }
-    ZEN_ASSERT_LESS(scatter_.size(), MaxOptionalArgs);
+    WF_ASSERT_LESS(scatter_.size(), MaxOptionalArgs);
   }
 
   std::size_t num_permutations() const {
@@ -55,7 +55,7 @@ struct OptionalArgPermutations {
   // Get the n'th permutation of optional arguments.
   // The returned map is a mapping from `arg name` --> whether the argument is to be computed.
   std::unordered_map<std::string, bool> get_permutation(std::size_t n) const {
-    ZEN_ASSERT_LESS(n, num_permutations());
+    WF_ASSERT_LESS(n, num_permutations());
     const std::bitset<MaxOptionalArgs> permutation{n};
 
     std::unordered_map<std::string, bool> output{};

--- a/components/core/wf/assertions.h
+++ b/components/core/wf/assertions.h
@@ -40,40 +40,40 @@ void raise_assert_binary_op(const char* const condition, const char* const file,
 
 // Assertion macros.
 // Based on: http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert
-#define ZEN_ASSERT_IMPL(cond, file, line, handler, ...) \
-  do {                                                  \
-    if (!static_cast<bool>(cond)) {                     \
-      handler(#cond, file, line, ##__VA_ARGS__);        \
-    }                                                   \
+#define WF_ASSERT_IMPL(cond, file, line, handler, ...) \
+  do {                                                 \
+    if (!static_cast<bool>(cond)) {                    \
+      handler(#cond, file, line, ##__VA_ARGS__);       \
+    }                                                  \
   } while (false)
 
 // Macro to use when defining an assertion.
-#define ZEN_ASSERT(cond, ...) \
-  ZEN_ASSERT_IMPL(cond, __FILE__, __LINE__, math::raise_assert, ##__VA_ARGS__)
+#define WF_ASSERT(cond, ...) \
+  WF_ASSERT_IMPL(cond, __FILE__, __LINE__, math::raise_assert, ##__VA_ARGS__)
 
-#define ZEN_ASSERT_EQUAL(a, b, ...)                                                           \
-  ZEN_ASSERT_IMPL((a) == (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_EQUAL(a, b, ...)                                                           \
+  WF_ASSERT_IMPL((a) == (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
-#define ZEN_ASSERT_NOT_EQUAL(a, b, ...)                                                       \
-  ZEN_ASSERT_IMPL((a) != (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_NOT_EQUAL(a, b, ...)                                                       \
+  WF_ASSERT_IMPL((a) != (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
-#define ZEN_ASSERT_LESS(a, b, ...)                                                           \
-  ZEN_ASSERT_IMPL((a) < (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_LESS(a, b, ...)                                                           \
+  WF_ASSERT_IMPL((a) < (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
-#define ZEN_ASSERT_GREATER(a, b, ...)                                                        \
-  ZEN_ASSERT_IMPL((a) > (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_GREATER(a, b, ...)                                                        \
+  WF_ASSERT_IMPL((a) > (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
-#define ZEN_ASSERT_LESS_OR_EQ(a, b, ...)                                                      \
-  ZEN_ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_LESS_OR_EQ(a, b, ...)                                                      \
+  WF_ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
-#define ZEN_ASSERT_GREATER_OR_EQ(a, b, ...)                                                   \
-  ZEN_ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
-                  ##__VA_ARGS__)
+#define WF_ASSERT_GREATER_OR_EQ(a, b, ...)                                                   \
+  WF_ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, math::raise_assert_binary_op, #a, a, #b, b, \
+                 ##__VA_ARGS__)
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/components/core/wf/code_generation/ast.cc
+++ b/components/core/wf/code_generation/ast.cc
@@ -67,7 +67,7 @@ struct AstBuilder {
       }
 
       if (key.usage == ExpressionUsage::ReturnValue) {
-        ZEN_ASSERT(block->descendants.empty(), "Must be the final block");
+        WF_ASSERT(block->descendants.empty(), "Must be the final block");
         emplace_operation<ast::ConstructReturnValue>(signature_.return_value.value(),
                                                      std::move(args));
       } else {
@@ -106,7 +106,7 @@ struct AstBuilder {
   }
 
   void process_block(ir::BlockPtr block) {
-    ZEN_ASSERT(!block->is_empty());
+    WF_ASSERT(!block->is_empty());
     if (non_traversable_blocks_.count(block)) {
       // Don't recurse too far - we are waiting on one of the ancestors of this block to get
       // processed.
@@ -195,11 +195,11 @@ struct AstBuilder {
     const ir::ValuePtr last_op = block->operations.back();
     if (!last_op->is_type<ir::JumpCondition>()) {
       // just keep appending:
-      ZEN_ASSERT_EQUAL(1, block->descendants.size());
+      WF_ASSERT_EQUAL(1, block->descendants.size());
       process_block(block->descendants.front());
     } else {
-      ZEN_ASSERT(last_op->is_type<ir::JumpCondition>());
-      ZEN_ASSERT_EQUAL(2, block->descendants.size());
+      WF_ASSERT(last_op->is_type<ir::JumpCondition>());
+      WF_ASSERT_EQUAL(2, block->descendants.size());
 
       // Figure out where this if-else statement will terminate:
       const ir::BlockPtr merge_point = find_merge_point(

--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -35,7 +35,7 @@ class MatrixType {
 
   // Convert to [row, col] indices (assuming row major order).
   std::pair<index_t, index_t> compute_indices(std::size_t element) const {
-    ZEN_ASSERT_LESS(element, static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_));
+    WF_ASSERT_LESS(element, static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_));
     return std::make_pair(static_cast<index_t>(element) / cols_,
                           static_cast<index_t>(element) % cols_);
   }
@@ -98,7 +98,7 @@ struct FunctionSignature {
   const std::shared_ptr<const ast::Argument>& get_argument(const std::string_view str) const {
     auto it = std::find_if(arguments.begin(), arguments.end(),
                            [&](const auto& arg) { return arg->name() == str; });
-    ZEN_ASSERT(it != arguments.end(), "Argument does not exist: {}", str);
+    WF_ASSERT(it != arguments.end(), "Argument does not exist: {}", str);
     return *it;
   }
 

--- a/components/core/wf/code_generation/code_formatter.h
+++ b/components/core/wf/code_generation/code_formatter.h
@@ -44,7 +44,7 @@ class CodeFormatter {
   template <typename Callable>
   void with_indentation(const int indent, const std::string_view open, const std::string_view close,
                         Callable&& callable) {
-    ZEN_ASSERT_GREATER_OR_EQ(indent, 0);
+    WF_ASSERT_GREATER_OR_EQ(indent, 0);
     // Move output_ -> appended
     std::string appended{};
     std::swap(output_, appended);

--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -143,7 +143,7 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter,
 
   } else {
     // Otherwise it is a scalar, so just assign it:
-    ZEN_ASSERT_EQUAL(1, assignment.values.size());
+    WF_ASSERT_EQUAL(1, assignment.values.size());
     formatter.format("{} = {};", dest_name, assignment.values.front());
   }
 }
@@ -217,8 +217,8 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::Branch& x
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter,
                                   const ast::ConstructReturnValue& x) const {
-  ZEN_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
-  ZEN_ASSERT_EQUAL(1, x.args.size());
+  WF_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
+  WF_ASSERT_EQUAL(1, x.args.size());
   formatter.format("return {};", make_view(x.args[0]));
 }
 
@@ -255,7 +255,7 @@ void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::SpecialCo
 }
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::InputValue& x) const {
-  ZEN_ASSERT(x.argument);
+  WF_ASSERT(x.argument);
   if (std::holds_alternative<ast::ScalarType>(x.argument->type())) {
     formatter.format(x.argument->name());
   } else {

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -65,13 +65,13 @@ class CppCodeGenerator {
 
   // Accept ast::VariantPtr
   void operator()(CodeFormatter& formatter, const ast::VariantPtr& var) const {
-    ZEN_ASSERT(var);
+    WF_ASSERT(var);
     operator()(formatter, *var);
   }
 
   // Format ptr to argument.
   void operator()(CodeFormatter& formatter, const std::shared_ptr<const ast::Argument>& var) const {
-    ZEN_ASSERT(var);
+    WF_ASSERT(var);
     formatter.format(var->name());
   }
 

--- a/components/core/wf/code_generation/expr_from_ir.cc
+++ b/components/core/wf/code_generation/expr_from_ir.cc
@@ -75,7 +75,7 @@ struct ExprFromIrVisitor {
   }
 
   Expr operator()(const ir::Cast&, const std::vector<ir::ValuePtr>& args) const {
-    ZEN_ASSERT(!args.empty());
+    WF_ASSERT(!args.empty());
     return map_value(args[0]);
   }
 
@@ -105,24 +105,24 @@ struct ExprFromIrVisitor {
   }
 
   Expr operator()(const ir::Phi&, const std::vector<ir::ValuePtr>& args) const {
-    ZEN_ASSERT_EQUAL(2, args.size());
+    WF_ASSERT_EQUAL(2, args.size());
 
     // We find to find the condition for this jump:
     const ir::BlockPtr jump_block =
         find_merge_point(args.front()->parent(), args.back()->parent(), SearchDirection::Upwards);
 
     // Determine the condition:
-    ZEN_ASSERT(!jump_block->is_empty());
+    WF_ASSERT(!jump_block->is_empty());
 
     const ir::ValuePtr jump_val = jump_block->operations.back();
-    ZEN_ASSERT(jump_val->is_type<ir::JumpCondition>());
+    WF_ASSERT(jump_val->is_type<ir::JumpCondition>());
 
     return where(map_value(jump_val->first_operand()), map_value(args[0]), map_value(args[1]));
   }
 
   Expr map_value(ir::ValuePtr value) const {
     const auto arg_it = value_to_expression_.find(value);
-    ZEN_ASSERT(arg_it != value_to_expression_.end(), "Missing value: {}", value->name());
+    WF_ASSERT(arg_it != value_to_expression_.end(), "Missing value: {}", value->name());
     return arg_it->second;
   }
 
@@ -169,7 +169,7 @@ create_output_expression_map(ir::BlockPtr starting_block,
             output_expressions.reserve(code->num_operands());
             for (const ir::ValuePtr operand : code->operands()) {
               auto it = value_to_expression.find(operand);
-              ZEN_ASSERT(it != value_to_expression.end(), "Missing value: {}", operand->name());
+              WF_ASSERT(it != value_to_expression.end(), "Missing value: {}", operand->name());
               output_expressions.push_back(it->second);
             }
             output_map.emplace(save.key(), std::move(output_expressions));

--- a/components/core/wf/code_generation/ir_builder.h
+++ b/components/core/wf/code_generation/ir_builder.h
@@ -90,7 +90,7 @@ struct OutputIr {
     const auto it =
         std::find_if(blocks_.begin(), blocks_.end(),
                      [](const ir::Block::unique_ptr& block) { return block->has_no_ancestors(); });
-    ZEN_ASSERT(it != blocks_.end(), "Must be an entry block");
+    WF_ASSERT(it != blocks_.end(), "Must be an entry block");
     return ir::BlockPtr{*it};
   }
 

--- a/components/core/wf/code_generation/ir_types.h
+++ b/components/core/wf/code_generation/ir_types.h
@@ -409,13 +409,13 @@ class Value {
 
   // Get the first operand.
   const ValuePtr& first_operand() const {
-    ZEN_ASSERT(!operands_.empty());
+    WF_ASSERT(!operands_.empty());
     return operands_.front();
   }
 
   // Access i'th operand:
   ValuePtr operator[](std::size_t i) const {
-    ZEN_ASSERT_LESS(i, operands_.size());
+    WF_ASSERT_LESS(i, operands_.size());
     return operands_[i];
   }
 
@@ -448,7 +448,7 @@ class Value {
 
   // Access the underlying numeric type.
   NumericType numeric_type() const {
-    ZEN_ASSERT(numeric_type_.has_value());
+    WF_ASSERT(numeric_type_.has_value());
     return *numeric_type_;
   }
 
@@ -466,7 +466,7 @@ class Value {
   void check_num_operands() {
     constexpr int expected_num_args = OpType::num_value_operands();
     if constexpr (expected_num_args >= 0) {
-      ZEN_ASSERT_EQUAL(static_cast<std::size_t>(expected_num_args), operands_.size());
+      WF_ASSERT_EQUAL(static_cast<std::size_t>(expected_num_args), operands_.size());
     }
   }
 

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -144,7 +144,7 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter,
         "\n", range);
   } else {
     // Otherwise it is a scalar, so just assign it:
-    ZEN_ASSERT_EQUAL(1, assignment.values.size());
+    WF_ASSERT_EQUAL(1, assignment.values.size());
     formatter.format("*{} = {};", dest_name, assignment.values.front());
   }
 }
@@ -154,7 +154,7 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::AssignTe
 }
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Branch& x) const {
-  ZEN_ASSERT(x.condition);
+  WF_ASSERT(x.condition);
   formatter.format("if {} ", make_view(x.condition));
   formatter.with_indentation(2, "{\n", "\n}", [&] { formatter.join(*this, "\n", x.if_branch); });
 
@@ -225,8 +225,8 @@ void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::Compare&
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter,
                                    const ast::ConstructReturnValue& x) const {
-  ZEN_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
-  ZEN_ASSERT_EQUAL(1, x.args.size());
+  WF_ASSERT(std::holds_alternative<ast::ScalarType>(x.type), "We cannot return matrices");
+  WF_ASSERT_EQUAL(1, x.args.size());
   formatter.format("{}", make_view(x.args[0]));
 }
 
@@ -244,7 +244,7 @@ void RustCodeGenerator::operator()(math::CodeFormatter& formatter, const ast::Di
 }
 
 void RustCodeGenerator::operator()(CodeFormatter& formatter, const ast::InputValue& x) const {
-  ZEN_ASSERT(x.argument);
+  WF_ASSERT(x.argument);
   if (x.argument->is_matrix()) {
     const ast::MatrixType mat = std::get<ast::MatrixType>(x.argument->type());
     const auto [r, c] = mat.compute_indices(x.element);

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -68,7 +68,7 @@ class RustCodeGenerator {
 
   // Accept ast::VariantPtr
   void operator()(CodeFormatter& formatter, const ast::VariantPtr& var) const {
-    ZEN_ASSERT(var);
+    WF_ASSERT(var);
     operator()(formatter, *var);
   }
 

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -170,7 +170,7 @@ Expr DiffVisitor::operator()(const Function& func) {
       return -(args[0] * x_diff) / sum_squared + (args[1] * y_diff) / sum_squared;
     }
   }
-  ZEN_ASSERT(false, "Invalid unary function: {}", func.function_name());
+  WF_ASSERT(false, "Invalid unary function: {}", func.function_name());
   return Constants::Zero;
 }
 
@@ -206,7 +206,7 @@ Expr DiffVisitor::operator()(const Variable& var) const {
 }
 
 Expr diff(const Expr& function, const Expr& var, const int reps) {
-  ZEN_ASSERT_GREATER_OR_EQ(reps, 0);
+  WF_ASSERT_GREATER_OR_EQ(reps, 0);
   DiffVisitor visitor{var};
   Expr result = function;
   for (int i = 0; i < reps; ++i) {

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -46,8 +46,8 @@ struct DistributeVisitor {
     for (const Expr& expr : children) {
       if (const Addition* add = cast_ptr<Addition>(expr); add != nullptr) {
         // For additions, first update the step by dividing by the size of this addition:
-        ZEN_ASSERT_EQUAL(0, step % add->arity());
-        ZEN_ASSERT_GREATER_OR_EQ(step / add->arity(), 1);
+        WF_ASSERT_EQUAL(0, step % add->arity());
+        WF_ASSERT_GREATER_OR_EQ(step / add->arity(), 1);
         step /= add->arity();
         // Now multiply terms in the addition:
         for (std::size_t out = 0; out < total_terms;) {

--- a/components/core/wf/evaluate.cc
+++ b/components/core/wf/evaluate.cc
@@ -27,8 +27,8 @@ Expr EvaluateVisitor::operator()(const Rational& x) const {
 Expr EvaluateVisitor::operator()(const Constant& c) const {
   const auto c_enum = c.name();
   const double value = double_from_symbolic_constant(c_enum);
-  ZEN_ASSERT(!std::isnan(value), "Invalid symbolic constant: {}",
-             string_from_symbolic_constant(c_enum));
+  WF_ASSERT(!std::isnan(value), "Invalid symbolic constant: {}",
+            string_from_symbolic_constant(c_enum));
   return Float::create(value);
 }
 

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -12,7 +12,7 @@
 namespace math {
 
 Expr Addition::from_operands(absl::Span<const Expr> args) {
-  ZEN_ASSERT(!args.empty(), "Cannot call from_operands with an empty span.");
+  WF_ASSERT(!args.empty(), "Cannot call from_operands with an empty span.");
   if (args.size() < 2) {
     return args.front();
   }

--- a/components/core/wf/expressions/addition.h
+++ b/components/core/wf/expressions/addition.h
@@ -19,7 +19,7 @@ class Addition {
 
   // Move-construct.
   explicit Addition(ContainerType&& terms) : terms_(std::move(terms)) {
-    ZEN_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
+    WF_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
     // Place into a deterministic (but otherwise mostly arbitrary) order.
     std::sort(terms_.begin(), terms_.end(), [](const Expr& a, const Expr& b) {
       if (a.get_hash() < b.get_hash()) {

--- a/components/core/wf/expressions/derivative_expression.cc
+++ b/components/core/wf/expressions/derivative_expression.cc
@@ -6,7 +6,7 @@
 namespace math {
 
 Expr Derivative::create(Expr differentiand, Expr arg, int order) {
-  ZEN_ASSERT_GREATER_OR_EQ(order, 1, "Order of the derivative must >= 1");
+  WF_ASSERT_GREATER_OR_EQ(order, 1, "Order of the derivative must >= 1");
 
   if (!arg.is_type<Variable>()) {
     throw TypeError("Derivatives can only be taken with respect to variables. Arg = {}",

--- a/components/core/wf/expressions/derivative_expression.h
+++ b/components/core/wf/expressions/derivative_expression.h
@@ -17,7 +17,7 @@ class Derivative {
 
   Derivative(Expr differentiand, Expr arg, int order = 1)
       : children_{std::move(differentiand), std::move(arg)}, order_(order) {
-    ZEN_ASSERT_GREATER_OR_EQ(order_, 1);
+    WF_ASSERT_GREATER_OR_EQ(order_, 1);
   }
 
   // The function we are taking the derivative of:

--- a/components/core/wf/expressions/function_expressions.h
+++ b/components/core/wf/expressions/function_expressions.h
@@ -99,7 +99,7 @@ inline Expr Function::create(BuiltInFunction name, Function::ContainerType&& con
     case BuiltInFunction::Arctan2:
       return atan2(container[0], container[1]);
   }
-  ZEN_ASSERT(false, "Invalid function name: {}", string_from_built_in_function(name));
+  WF_ASSERT(false, "Invalid function name: {}", string_from_built_in_function(name));
   return Constants::Zero;  //  Unreachable.
 }
 

--- a/components/core/wf/expressions/matrix.h
+++ b/components/core/wf/expressions/matrix.h
@@ -24,8 +24,8 @@ class Matrix {
       throw DimensionError("Mismatch between shape and # of elements. size = {}, shape = [{}, {}]",
                            data_.size(), rows_, cols_);
     }
-    ZEN_ASSERT_GREATER_OR_EQ(rows_, 0);
-    ZEN_ASSERT_GREATER_OR_EQ(cols_, 0);
+    WF_ASSERT_GREATER_OR_EQ(rows_, 0);
+    WF_ASSERT_GREATER_OR_EQ(cols_, 0);
   }
 
   // All elements must match.

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -30,7 +30,7 @@ static inline Expr multiply_into_addition(const Addition& add, const Expr& numer
 }
 
 Expr Multiplication::from_operands(absl::Span<const Expr> args) {
-  ZEN_ASSERT(!args.empty());
+  WF_ASSERT(!args.empty());
   if (args.size() < 2) {
     return args.front();
   }

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -20,7 +20,7 @@ class Multiplication {
 
   // Move-construct.
   explicit Multiplication(ContainerType&& terms) : terms_(std::move(terms)) {
-    ZEN_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
+    WF_ASSERT_GREATER_OR_EQ(terms_.size(), 2);
     sort_terms();
   }
 

--- a/components/core/wf/expressions/numeric_expressions.h
+++ b/components/core/wf/expressions/numeric_expressions.h
@@ -182,7 +182,7 @@ class Float {
   // Create floating point expression.
   static Expr create(Float f) { return make_expr<Float>(f); }
   static Expr create(FloatType f) {
-    ZEN_ASSERT(std::isfinite(f), "Float values must be finite: {}", f);
+    WF_ASSERT(std::isfinite(f), "Float values must be finite: {}", f);
     return create(Float{f});
   }
 

--- a/components/core/wf/expressions/power.cc
+++ b/components/core/wf/expressions/power.cc
@@ -84,7 +84,7 @@ struct PowerNumerics {
 
   // If the left operand is integer, and the right is rational:
   Expr apply_int_and_rational(const Integer& a, const Rational& b) {
-    ZEN_ASSERT_GREATER(b.denominator(), 0, "Rational must have positive denominator");
+    WF_ASSERT_GREATER(b.denominator(), 0, "Rational must have positive denominator");
     if (a.get_value() == 1) {
       return Constants::One;
     } else if (a.get_value() == 0) {
@@ -100,9 +100,9 @@ struct PowerNumerics {
 
     // Factorize the integer into primes:
     const std::vector<PrimeFactor> factors = compute_prime_factors(a.get_value());
-    ZEN_ASSERT(std::is_sorted(factors.begin(), factors.end(),
-                              [](const auto& x, const auto& y) { return x.base < y.base; }),
-               "Factors should be sorted");
+    WF_ASSERT(std::is_sorted(factors.begin(), factors.end(),
+                             [](const auto& x, const auto& y) { return x.base < y.base; }),
+              "Factors should be sorted");
 
     // Next we will create expressions.
     std::vector<Expr> operands{};
@@ -119,7 +119,7 @@ struct PowerNumerics {
     for (const PrimeFactor& f : factors) {
       // Multiply the power by the rational to get the exponent applied to this prime factor:
       const Rational actual_exp = b * static_cast<Rational>(Integer{f.exponent});
-      ZEN_ASSERT_GREATER(f.exponent, 0);  //  Exponents must be >= 1 in this context.
+      WF_ASSERT_GREATER(f.exponent, 0);  //  Exponents must be >= 1 in this context.
 
       // Factorize the exponent: x^(int_part + frac_part) --> x^int_part * x^frac_part
       // Both of these should have the same sign as actual_exp.

--- a/components/core/wf/expressions/relational.cc
+++ b/components/core/wf/expressions/relational.cc
@@ -46,13 +46,13 @@ struct CompareNumerics {
   // Integer and float:
   bool operator()(const Integer& a, const Float& b) const {
     const auto result = compare_int_float(a.get_value(), b.get_value());
-    ZEN_ASSERT(result.has_value(), "Invalid float value: {}", b);
+    WF_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == RelativeOrder::LessThan;
   }
 
   bool operator()(const Float& a, const Integer& b) const {
     const auto result = compare_int_float(b.get_value(), a.get_value());
-    ZEN_ASSERT(result.has_value(), "Invalid float value: {}", b);
+    WF_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == RelativeOrder::GreaterThan;
   }
 };
@@ -82,8 +82,8 @@ struct RelationalSimplification {
       } else if (operation_ == RelationalOperation::Equal) {
         return (!a_lt_b && !b_lt_a) ? TriState::True : TriState::False;
       }
-      ZEN_ASSERT(operation_ == RelationalOperation::LessThanOrEqual,
-                 "Invalid relational operation: {}", string_from_relational_operation(operation_));
+      WF_ASSERT(operation_ == RelationalOperation::LessThanOrEqual,
+                "Invalid relational operation: {}", string_from_relational_operation(operation_));
       // either `a` < `b`, or: `a` >= `b` and `b` is not less than `a`, so `a` == `b`
       return a_lt_b || !b_lt_a ? TriState::True : TriState::False;
     } else {

--- a/components/core/wf/expressions/variable.cc
+++ b/components/core/wf/expressions/variable.cc
@@ -9,7 +9,7 @@ std::size_t UniqueVariable::next_unique_variable_index() noexcept {
   // create thread-safe unique variable index:
   static std::atomic_size_t next_index{1};
   const std::size_t next = next_index.fetch_add(1);
-  ZEN_ASSERT_NOT_EQUAL(0, next);
+  WF_ASSERT_NOT_EQUAL(0, next);
   return next;
 }
 

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -284,7 +284,7 @@ Expr abs(const Expr& arg) {
   if (const std::optional<Rational> r = try_cast_to_rational(arg); r.has_value()) {
     // If the inner argument is a negative integer or rational, just flip it.
     if (r->numerator() >= 0) {
-      ZEN_ASSERT_GREATER(r->denominator(), 0);
+      WF_ASSERT_GREATER(r->denominator(), 0);
       return arg;
     }
     return Rational::create(-r->numerator(), r->denominator());
@@ -323,7 +323,7 @@ struct SignumVisitor {
   std::optional<Expr> operator()(const Integer& i) const { return Expr{sign(i.get_value())}; }
   std::optional<Expr> operator()(const Rational& r) const { return Expr{sign(r.numerator())}; }
   std::optional<Expr> operator()(const Float& f) const {
-    ZEN_ASSERT(!std::isnan(f.get_value()));
+    WF_ASSERT(!std::isnan(f.get_value()));
     return Expr{sign(f.get_value())};
   }
 

--- a/components/core/wf/limits.cc
+++ b/components/core/wf/limits.cc
@@ -149,7 +149,7 @@ class LimitVisitor {
     std::vector<Integer> powers{};
 
     bool are_all_identical_up_to_sign() const {
-      ZEN_ASSERT(!powers.empty());
+      WF_ASSERT(!powers.empty());
       const auto first = powers.begin();
       return std::all_of(std::next(first), powers.end(),
                          [&](const Integer& i) { return first->abs() == i.abs(); });
@@ -237,7 +237,7 @@ class LimitVisitor {
     Multiplication::ContainerType f_funcs{}, g_funcs{};
     for (const Expr& expr : mul) {
       std::optional<Expr> child = visit(expr);
-      ZEN_ASSERT(child.has_value(), "Already checked this expression is valid: {}", expr);
+      WF_ASSERT(child.has_value(), "Already checked this expression is valid: {}", expr);
       if (is_zero(*child)) {
         // Collect the powers of `x_` as we extract terms, in the hope that the expression will
         // simplify:
@@ -367,7 +367,7 @@ class LimitVisitor {
       return std::nullopt;
     }
 
-    ZEN_ASSERT(!exp_sub.is_identical_to(Constants::False));
+    WF_ASSERT(!exp_sub.is_identical_to(Constants::False));
 
     if (is_zero(exp_sub) && (is_inf(base_sub) || is_zero(base_sub))) {
       // 0 ^ 0 is an indeterminate form, and ∞ ^ 0
@@ -410,7 +410,7 @@ class LimitVisitor {
         if (is_numeric_or_constant(exp_sub) && is_negative_number(exp_sub)) {
           return Constants::Zero;  // (-∞)^u where u < 0
         } else if (const Integer* exp_int = cast_ptr<Integer>(exp_sub); exp_int != nullptr) {
-          ZEN_ASSERT(!exp_int->is_zero() && !exp_int->is_negative(), "value = {}", *exp_int);
+          WF_ASSERT(!exp_int->is_zero() && !exp_int->is_negative(), "value = {}", *exp_int);
           if (exp_int->is_even()) {
             return positive_inf_;
           } else {
@@ -454,7 +454,7 @@ class LimitVisitor {
 
     switch (func.enum_value()) {
       case BuiltInFunction::Log: {
-        ZEN_ASSERT_EQUAL(1, args.size());
+        WF_ASSERT_EQUAL(1, args.size());
         if (is_zero(args[0])) {
           // In the context of a limit, allow log(0) --> -∞
           return negative_inf_;

--- a/components/core/wf/matrix_functions.cc
+++ b/components/core/wf/matrix_functions.cc
@@ -178,7 +178,7 @@ struct PermutationMatrix {
     }
     p_.insert(p_.begin(), 0);
     if (row != 0) {
-      ZEN_ASSERT_LESS(static_cast<std::size_t>(row), p_.size());
+      WF_ASSERT_LESS(static_cast<std::size_t>(row), p_.size());
       std::swap(p_[0], p_[row]);
       ++num_swaps_;
     }
@@ -191,7 +191,7 @@ struct PermutationMatrix {
     }
     p_.insert(p_.begin(), 0);
     auto it = std::find(p_.begin(), p_.end(), row);
-    ZEN_ASSERT(it != p_.end());
+    WF_ASSERT(it != p_.end());
     if (it != p_.begin()) {
       std::swap(*it, p_[0]);
       ++num_swaps_;
@@ -259,12 +259,12 @@ static inline std::optional<std::tuple<std::size_t, std::size_t>> find_pivot(
 static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_internal(
     dynamic_row_major_span L, dynamic_row_major_span U) {
   if (L.rows() == 1) {
-    ZEN_ASSERT_EQUAL(1, L.cols());
+    WF_ASSERT_EQUAL(1, L.cols());
     L(0, 0) = Constants::One;
     return std::make_tuple(PermutationMatrix(1), PermutationMatrix(U.cols()));
   }
 
-  ZEN_ASSERT_GREATER_OR_EQ(U.rows(), 2);
+  WF_ASSERT_GREATER_OR_EQ(U.rows(), 2);
 
   // Search for a non-zero pivot.
   auto pivot_indices = find_pivot(U);
@@ -314,7 +314,7 @@ static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_in
   L(0, 0) = Constants::One;
 
   // then the column underneath it:
-  ZEN_ASSERT_EQUAL(static_cast<std::size_t>(P.rows()), c.rows());
+  WF_ASSERT_EQUAL(static_cast<std::size_t>(P.rows()), c.rows());
   for (std::size_t i = 0; i < c.rows(); ++i) {
     L(i + 1, 0) = c(P.permuted_row_transposed(static_cast<index_t>(i)), 0) / pivot;
   }
@@ -327,7 +327,7 @@ static std::tuple<PermutationMatrix, PermutationMatrix> factorize_full_piv_lu_in
   }
 
   // Permute the top-right row of U:
-  ZEN_ASSERT_EQUAL(static_cast<std::size_t>(Q.rows()), r_t.cols());
+  WF_ASSERT_EQUAL(static_cast<std::size_t>(Q.rows()), r_t.cols());
   for (std::size_t j = 0; j < r_t.cols(); ++j) {
     U(0, j + 1) = r_t_copied[Q.PermutedRow(static_cast<index_t>(j))];
   }
@@ -353,10 +353,10 @@ factorize_full_piv_lu_internal(const Matrix& A) {
     Matrix U_out = L.transposed();
     Matrix L_out = U.transposed();
 
-    ZEN_ASSERT_EQUAL(L_out.rows(), A.rows());
-    ZEN_ASSERT_EQUAL(L_out.cols(), A.cols());
-    ZEN_ASSERT_EQUAL(U_out.rows(), A.cols());
-    ZEN_ASSERT_EQUAL(U_out.rows(), U_out.cols());
+    WF_ASSERT_EQUAL(L_out.rows(), A.rows());
+    WF_ASSERT_EQUAL(L_out.cols(), A.cols());
+    WF_ASSERT_EQUAL(U_out.rows(), A.cols());
+    WF_ASSERT_EQUAL(U_out.rows(), U_out.cols());
 
     // Then we need to normalize the diagonal of L
     for (index_t col = 0; col < L_out.cols(); ++col) {

--- a/components/core/wf/non_null_ptr.h
+++ b/components/core/wf/non_null_ptr.h
@@ -7,7 +7,7 @@ namespace math {
 template <typename T>
 class non_null_ptr {
  public:
-  explicit non_null_ptr(T* ptr) : ptr_(ptr) { ZEN_ASSERT(ptr_, "Cannot be constructed null"); }
+  explicit non_null_ptr(T* ptr) : ptr_(ptr) { WF_ASSERT(ptr_, "Cannot be constructed null"); }
 
   // Construct from unique_ptr.
   explicit non_null_ptr(const std::unique_ptr<T>& ptr) : non_null_ptr(ptr.get()) {}

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -32,7 +32,7 @@ class DetermineSetVisitor {
  public:
   template <typename Container, typename Callable>
   NumberSet handle_add_or_mul(const Container& container, Callable callable) const {
-    ZEN_ASSERT_GREATER_OR_EQ(container.arity(), 1);
+    WF_ASSERT_GREATER_OR_EQ(container.arity(), 1);
     auto it = container.begin();
     NumberSet set = determine_numeric_set(*it);
     for (it = std::next(it); it != container.end(); ++it) {
@@ -75,7 +75,7 @@ class DetermineSetVisitor {
   NumberSet operator()(const Function& func) {
     absl::InlinedVector<NumberSet, 4> args{};
     std::transform(func.begin(), func.end(), std::back_inserter(args), &determine_numeric_set);
-    ZEN_ASSERT_GREATER_OR_EQ(args.size(), 1);
+    WF_ASSERT_GREATER_OR_EQ(args.size(), 1);
 
     if (std::count(args.begin(), args.end(), NumberSet::Unknown) > 0) {
       return NumberSet::Unknown;

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -11,7 +11,7 @@
 namespace math {
 
 void PlainFormatter::operator()(const Addition& expr) {
-  ZEN_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
+  WF_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
 
   // Sort into canonical order:
   absl::InlinedVector<std::pair<Expr, Expr>, 16> terms;
@@ -105,8 +105,8 @@ void PlainFormatter::operator()(const Float& expr) {
 }
 
 void PlainFormatter::operator()(const Matrix& mat) {
-  ZEN_ASSERT_GREATER_OR_EQ(mat.rows(), 0);
-  ZEN_ASSERT_GREATER_OR_EQ(mat.cols(), 0);
+  WF_ASSERT_GREATER_OR_EQ(mat.rows(), 0);
+  WF_ASSERT_GREATER_OR_EQ(mat.cols(), 0);
 
   if (mat.size() == 0) {
     // Empty matrix:
@@ -155,7 +155,7 @@ void PlainFormatter::operator()(const Matrix& mat) {
 }
 
 void PlainFormatter::operator()(const Multiplication& expr) {
-  ZEN_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
+  WF_ASSERT_GREATER_OR_EQ(expr.arity(), 2);
   using BaseExp = MultiplicationFormattingInfo::BaseExp;
 
   // Break multiplication up into numerator and denominator:

--- a/components/core/wf/substitute.cc
+++ b/components/core/wf/substitute.cc
@@ -191,7 +191,7 @@ struct SubstituteMulVisitor : public SubstituteVisitorBase<SubstituteMulVisitor,
     const Integer max_valid_exponent = max_valid_integer_exponent.value();
     for (const auto& [base, exponent] : target_parts.terms) {
       auto it = input_parts.terms.find(base);
-      ZEN_ASSERT(it != input_parts.terms.end());
+      WF_ASSERT(it != input_parts.terms.end());
       it->second = it->second - (exponent * max_valid_exponent.get_value());
     }
 
@@ -355,8 +355,8 @@ void SubstituteVariablesVisitor::add_substitution(Variable variable, Expr replac
   cache_.clear();  //  No longer valid when new expressions are added.
   const auto [_, was_inserted] =
       substitutions_.emplace(std::move(variable), std::move(replacement));
-  ZEN_ASSERT(was_inserted, "Variable already exists in the substitution list: {}",
-             variable.to_string());
+  WF_ASSERT(was_inserted, "Variable already exists in the substitution list: {}",
+            variable.to_string());
 }
 
 Expr SubstituteVariablesVisitor::apply(const Expr& expression) {

--- a/components/core/wf/type_annotations.h
+++ b/components/core/wf/type_annotations.h
@@ -23,8 +23,8 @@ template <index_t Rows, index_t Cols>
 struct StaticMatrix {
   // Allow implicit construction from MatrixExpr.
   StaticMatrix(MatrixExpr expr) : expr_(std::move(expr)) {  // NOLINT(google-explicit-constructor)
-    ZEN_ASSERT_EQUAL(Rows, expr_.rows());
-    ZEN_ASSERT_EQUAL(Cols, expr_.cols());
+    WF_ASSERT_EQUAL(Rows, expr_.rows());
+    WF_ASSERT_EQUAL(Cols, expr_.cols());
   }
 
   constexpr index_t rows() const noexcept { return Rows; }
@@ -44,8 +44,8 @@ struct StaticMatrix {
 
   // Assign from MatrixExpr
   StaticMatrix& operator=(const MatrixExpr& other) {
-    ZEN_ASSERT_EQUAL(Rows, other.rows());
-    ZEN_ASSERT_EQUAL(Cols, other.cols());
+    WF_ASSERT_EQUAL(Rows, other.rows());
+    WF_ASSERT_EQUAL(Cols, other.cols());
     expr_ = other;
     return *this;
   }

--- a/components/core/wf/visitor_impl.h
+++ b/components/core/wf/visitor_impl.h
@@ -46,8 +46,8 @@ auto visit(const Expr& expr, VisitorType&& visitor) {
   } else if (expr.is_type<Undefined>()) {
     return visitor(cast_unchecked<Undefined>(expr));
   } else {
-    ZEN_ASSERT(expr.is_type<Variable>(), "Neglected to implement if-else switch for type: {}",
-               expr.type_name());
+    WF_ASSERT(expr.is_type<Variable>(), "Neglected to implement if-else switch for type: {}",
+              expr.type_name());
     return visitor(cast_unchecked<Variable>(expr));
   }
 }

--- a/components/python/examples/imu_integration/py_imu_integration_test.cc
+++ b/components/python/examples/imu_integration/py_imu_integration_test.cc
@@ -58,8 +58,8 @@ template <typename Function>
 std::vector<TestSample> generate_samples(const double duration, const double dt,
                                          const Vector3d& gyro_bias,
                                          const Vector3d& accelerometer_bias, Function&& func) {
-  ZEN_ASSERT_GREATER(dt, 0);
-  ZEN_ASSERT_GREATER(duration, dt);
+  WF_ASSERT_GREATER(dt, 0);
+  WF_ASSERT_GREATER(duration, dt);
 
   std::vector<TestSample> samples;
   samples.push_back(func(0.0));

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -199,7 +199,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def_property_readonly("left", [](const ast::AssignTemporary& x) { return x.left; })
       .def_property_readonly("right",
                              [](const ast::AssignTemporary& x) {
-                               ZEN_ASSERT(x.right);
+                               WF_ASSERT(x.right);
                                return *x.right;
                              })
       .def("__repr__", &format_ast<ast::AssignTemporary>);
@@ -207,7 +207,7 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::AssignOutputArgument>(m, "AssignOutputArgument")
       .def_property_readonly("argument",
                              [](const ast::AssignOutputArgument& x) {
-                               ZEN_ASSERT(x.argument);
+                               WF_ASSERT(x.argument);
                                return *x.argument;
                              })
       .def_property_readonly("values", [](const ast::AssignOutputArgument& x) { return x.values; })
@@ -229,7 +229,7 @@ void wrap_codegen_operations(py::module_& m) {
                              [](const ast::Cast& c) { return c.destination_type; })
       .def_property_readonly("arg",
                              [](const ast::Cast& c) {
-                               ZEN_ASSERT(c.arg);
+                               WF_ASSERT(c.arg);
                                return *c.arg;
                              })
       .def("__repr__", &format_ast<ast::Cast>);
@@ -237,12 +237,12 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::Compare>(m, "Compare")
       .def_property_readonly("left",
                              [](const ast::Compare& c) {
-                               ZEN_ASSERT(c.left);
+                               WF_ASSERT(c.left);
                                return *c.left;
                              })
       .def_property_readonly("right",
                              [](const ast::Compare& c) {
-                               ZEN_ASSERT(c.right);
+                               WF_ASSERT(c.right);
                                return *c.right;
                              })
       .def_property_readonly("operation", [](const ast::Compare& c) { return c.operation; })
@@ -282,12 +282,12 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::Multiply>(m, "Multiply")
       .def_property_readonly("left",
                              [](const ast::Multiply& x) {
-                               ZEN_ASSERT(x.left);
+                               WF_ASSERT(x.left);
                                return *x.left;
                              })
       .def_property_readonly("right",
                              [](const ast::Multiply& x) {
-                               ZEN_ASSERT(x.right);
+                               WF_ASSERT(x.right);
                                return *x.right;
                              })
       .def("__repr__", &format_ast<ast::Multiply>);

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -217,7 +217,7 @@ inline MatrixExpr stack_iterables(const std::vector<py::object>& rows) {
   }
 
   // Figure out how many rows we extracted:
-  ZEN_ASSERT_EQUAL(0, converted.size() % expected_num_cols);
+  WF_ASSERT_EQUAL(0, converted.size() % expected_num_cols);
   const auto total_rows = static_cast<index_t>(converted.size() / expected_num_cols);
   return MatrixExpr::create(total_rows, static_cast<index_t>(expected_num_cols),
                             std::move(converted));


### PR DESCRIPTION
Rename all the assertion macros to match the new project name.