### PR TITLE
Remove the example python code generator

### DIFF
--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -251,7 +251,7 @@ static constexpr std::string_view cpp_string_for_symbolic_constant(
 }
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::SpecialConstant& x) const {
-  formatter.format("{}", cpp_string_for_symbolic_constant(x.value));
+  formatter.format("static_cast<Scalar>({})", cpp_string_for_symbolic_constant(x.value));
 }
 
 void CppCodeGenerator::operator()(CodeFormatter& formatter, const ast::InputValue& x) const {

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -37,7 +37,7 @@ class CppCodeGenerator {
   void operator()(CodeFormatter& formatter, const ast::Divide& x) const;
 
   void operator()(CodeFormatter& formatter, const ast::FloatConstant& x) const {
-    formatter.format("{}", x.value);
+    formatter.format("static_cast<Scalar>({})", x.value);
   }
 
   void operator()(CodeFormatter& formatter, const ast::SpecialConstant& x) const;

--- a/components/python/examples/imu_integration/imu_integration.py
+++ b/components/python/examples/imu_integration/imu_integration.py
@@ -14,9 +14,9 @@ import typing as T
 from wrenfold.type_annotations import RealScalar, Vector4, Vector3
 from wrenfold.code_generation import codegen_function
 from wrenfold.code_generation import OutputArg
+from wrenfold.code_generation import generate_cpp
 
 from wrenfold.geometry import Quaternion, left_jacobian_of_so3
-from wrenfold.codegen import generate_cpp
 from wrenfold import sym
 
 

--- a/components/python/examples/rotation_error/rotation_error.py
+++ b/components/python/examples/rotation_error/rotation_error.py
@@ -9,7 +9,7 @@ from wrenfold.code_generation import codegen_function
 from wrenfold.code_generation import OutputArg
 
 from wrenfold.geometry import Quaternion
-from wrenfold.codegen import generate_cpp
+from wrenfold.code_generation import generate_cpp
 
 
 def rotation_error(q0_xyzw: Vector4, q1_xyzw: Vector4, weight: RealScalar):

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -1,221 +1,19 @@
 """Utility functions to support code-generation."""
-import collections
 import dataclasses
 import inspect
-import string
 import typing as T
 
-import numpy as np
-
 from . import sym
-from . import codegen
 
-AstVariantTuple = (codegen.Add, codegen.AssignTemporary, codegen.AssignOutputArgument,
-                   codegen.Branch, codegen.Call, codegen.Cast, codegen.Compare,
-                   codegen.ConstructReturnValue, codegen.Declaration, codegen.FloatConstant,
-                   codegen.InputValue, codegen.IntegerConstant, codegen.Multiply,
-                   codegen.OptionalOutputBranch, codegen.VariableRef, codegen.FunctionSignature)
-
-AstTypeTuple = (codegen.ScalarType, codegen.MatrixType)
+# Import the C++ code-generation module into this file.
+from pywrenfold.wf_wrapper import codegen
+from pywrenfold.wf_wrapper.codegen import generate_cpp, generate_rust
 
 AstVariantAnnotation = T.Union[codegen.Add, codegen.AssignTemporary, codegen.AssignOutputArgument,
                                codegen.Branch, codegen.Call, codegen.Cast, codegen.Compare,
                                codegen.ConstructReturnValue, codegen.Declaration,
                                codegen.FloatConstant, codegen.InputValue, codegen.IntegerConstant,
                                codegen.Multiply, codegen.OptionalOutputBranch, codegen.VariableRef,]
-
-
-class CustomStringFormatter(string.Formatter):
-
-    def __init__(self, generator: 'CodeGenerator') -> None:
-        super().__init__()
-        self._generator = generator
-        self._type_to_method: T.Dict[type, T.Callable] = dict()
-
-    def _get_formatter(self, arg_type: T.Type) -> T.Callable:
-        if arg_type not in self._type_to_method:
-            format_method_name = f'format_{arg_type.__name__}'
-            if not hasattr(self._generator, format_method_name):
-                raise KeyError(f"Code generator is missing formatting method: {format_method_name}")
-            self._type_to_method[arg_type] = getattr(self._generator, format_method_name)
-        return self._type_to_method[arg_type]
-
-    def format_field(self, value: T.Any, format_spec: str) -> T.Any:
-        """Override Formatter.format_field so we can intercept code-gen types."""
-        if isinstance(value, AstVariantTuple) or isinstance(value, AstTypeTuple):
-            return self.format_ast(value=value)
-        return super().format_field(value=value, format_spec=format_spec)
-
-    def format_ast(
-            self, value: T.Union[AstVariantAnnotation, codegen.ScalarType,
-                                 codegen.MatrixType]) -> str:
-        format_method = self._get_formatter(arg_type=type(value))
-        return format_method(self, value)
-
-    @staticmethod
-    def indent(input_string: str, amount: int = 2) -> str:
-        """Indent the provided string by `amount` spaces."""
-        assert amount >= 0, f'amount = {amount}'
-        return (' ' * amount) + input_string.replace('\n', '\n' + ' ' * amount).rstrip(' ')
-
-
-class CodeGenerator:
-
-    def __init__(self) -> None:
-        self._type_to_method: T.Dict[type, T.Callable] = dict()
-
-    def get_formatter(self, arg_type: T.Type) -> T.Callable:
-        if arg_type not in self._type_to_method:
-            format_method_name = f'format_{arg_type.__name__}'
-            if not hasattr(self, format_method_name):
-                raise KeyError(f"Code generator is missing formatting method: {format_method_name}")
-            self._type_to_method[arg_type] = getattr(self, format_method_name)
-        return self._type_to_method[arg_type]
-
-    def generate(self, signature: codegen.FunctionSignature,
-                 body: T.List[AstVariantAnnotation]) -> str:
-        formatter = CustomStringFormatter(generator=self)
-        result = formatter.format('{}\n', signature)
-        reshape_statements = []
-        for arg in signature.arguments:
-            if isinstance(arg.type, codegen.MatrixType):
-                statement = f'{arg.name} = {arg.name}.reshape(({arg.type.num_rows}, {arg.type.num_cols}))'
-                reshape_statements.append(statement)
-        if reshape_statements:
-            result += formatter.indent('\n'.join(reshape_statements))
-            result += '\n'
-        result += formatter.indent('\n'.join(formatter.format_ast(v) for v in body))
-        return result
-
-
-class PythonCodeGenerator(CodeGenerator):
-
-    def __init__(self) -> None:
-        super(PythonCodeGenerator, self).__init__()
-
-    def format_ScalarType(self, fmt: CustomStringFormatter, x: codegen.ScalarType) -> str:
-        if x.numeric_type == codegen.NumericType.Bool:
-            return 'bool'
-        elif x.numeric_type == codegen.NumericType.Integer:
-            return 'int'
-        elif x.numeric_type == codegen.NumericType.Real:
-            return 'float'
-        elif x.numeric_type == codegen.NumericType.Complex:
-            raise TypeError("Complex is not supported here")
-
-    def format_MatrixType(self, fmt: CustomStringFormatter, x: codegen.MatrixType) -> str:
-        return 'np.ndarray'
-
-    def format_Add(self, fmt: CustomStringFormatter, x: codegen.Add) -> str:
-        """Format one of the AST types to python."""
-        return fmt.format('{} + {}', x.left, x.right)
-
-    def format_AssignTemporary(self, fmt: CustomStringFormatter, x: codegen.AssignTemporary) -> str:
-        return fmt.format('{} = {}', x.left, x.right)
-
-    def format_Branch(self, fmt: CustomStringFormatter, x: codegen.Branch) -> str:
-        result = fmt.format('if {}:\n', x.condition) + fmt.indent('\n'.join(
-            fmt.format_ast(v) for v in x.if_branch))
-        if len(x.else_branch) > 0:
-            result += '\nelse:\n' + fmt.indent('\n'.join(fmt.format_ast(v) for v in x.else_branch))
-        return result
-
-    def format_Call(self, fmt: CustomStringFormatter, x: codegen.Call) -> str:
-        funcs = {
-            codegen.StdMathFunction.Cos: "np.cos", codegen.StdMathFunction.Sin: "np.sin",
-            codegen.StdMathFunction.Log: "np.log", codegen.StdMathFunction.Sqrt: "np.sqrt",
-            codegen.StdMathFunction.Tan: "np.tan", codegen.StdMathFunction.Powi: "np.power",
-            codegen.StdMathFunction.Powf: "np.power", codegen.StdMathFunction.Arctan2: "np.atan2"
-        }
-        return fmt.format("{}({})", funcs[x.function], ', '.join(fmt.format_ast(v) for v in x.args))
-
-    def format_Cast(self, fmt: CustomStringFormatter, x: codegen.Cast) -> str:
-        if x.destination_type == codegen.NumericType.Bool:
-            type_name = 'bool'
-        elif x.destination_type == codegen.NumericType.Integer:
-            type_name = 'int'
-        elif x.destination_type == codegen.NumericType.Real:
-            type_name = 'float'
-        elif x.destination_type == codegen.NumericType.Complex:
-            raise TypeError("Complex is not supported here")
-        else:
-            type_name = f'<INVALID ENUM VALUE: {x.destination_type}>'
-        return fmt.format("{}({})", type_name, x.arg)
-
-    def format_Compare(self, fmt: CustomStringFormatter, x: codegen.Compare) -> str:
-        if x.operation == codegen.RelationalOperation.LessThan:
-            op = '<'
-        elif x.operation == codegen.RelationalOperation.LessThanOrEqual:
-            op = '<='
-        else:
-            assert x.operation == codegen.RelationalOperation.Equal
-            op = '=='
-        return fmt.format('{} {} {}', x.left, op, x.right)
-
-    def format_ConstructReturnValue(self, fmt: CustomStringFormatter,
-                                    x: codegen.ConstructReturnValue) -> str:
-        values = x.args
-        if len(values) > 1:
-            return fmt.format('return {}', values[0])
-        else:
-            joined = ', '.join(fmt.format_ast(v) for v in values)
-            return f'return {joined}'
-
-    def format_Declaration(self, fmt: CustomStringFormatter, x: codegen.Declaration) -> str:
-        """Format declaration."""
-        if x.value is not None:
-            return fmt.format('{name}: {type} = {value}', name=x.name, type=x.type, value=x.value)
-        else:
-            return str()
-
-    def format_FloatConstant(self, fmt: CustomStringFormatter, x: codegen.FloatConstant) -> str:
-        return '{:.16}'.format(x.value)
-
-    def format_FunctionSignature(self, fmt: CustomStringFormatter,
-                                 x: codegen.FunctionSignature) -> str:
-        args = []
-        for arg in x.arguments:
-            if arg.is_optional:
-                args.append(fmt.format('{}: T.Optional[{}]', arg.name, arg.type))
-            else:
-                args.append(fmt.format('{}: {}', arg.name, arg.type))
-
-        return_type = x.return_type
-        if return_type is None:
-            return_type_str = 'None'
-        else:
-            return_type_str = fmt.format('{}', return_type)
-
-        return f'def {x.name}({", ".join(args)}) -> {return_type_str}:'
-
-    def format_InputValue(self, fmt: CustomStringFormatter, x: codegen.InputValue) -> str:
-        argument = x.argument
-        if isinstance(argument.type, codegen.ScalarType):
-            return argument.name
-        elif isinstance(argument.type, codegen.MatrixType):
-            return fmt.format('{}[{}, {}]', argument.name,
-                              *argument.type.compute_indices(x.element))
-        else:
-            raise TypeError(f'Unsupported type: {argument.type}')
-
-    def format_IntegerConstant(self, fmt: CustomStringFormatter, x: codegen.IntegerConstant) -> str:
-        return str(x.value)
-
-    def format_Multiply(self, fmt: CustomStringFormatter, x: codegen.Multiply) -> str:
-        return fmt.format('{} * {}', x.left, x.right)
-
-    def format_OptionalOutputBranch(self, fmt: CustomStringFormatter,
-                                    x: codegen.OptionalOutputBranch) -> str:
-        import ipdb
-        ipdb.set_trace()
-        assert x.argument.is_optional, 'Argument must be optional'
-
-        result = fmt.format('if {} is not None:\n', x.argument.name) + fmt.indent('\n'.join(
-            fmt.format_ast(v) for v in x.statements))
-        return result
-
-    def format_VariableRef(self, fmt: CustomStringFormatter, x: codegen.VariableRef) -> str:
-        return x.name
 
 
 @dataclasses.dataclass
@@ -232,8 +30,10 @@ class OutputArg:
     is_optional: bool = False
 
 
+# Union of ReturnValue and OutputArg
 ReturnValueOrOutputArg = T.Union[ReturnValue, OutputArg]
 
+# Things that can be returned from symbolic python functions.
 CodegenFuncInvocationResult = T.Union[sym.Expr, sym.MatrixExpr, T.Iterable[ReturnValueOrOutputArg]]
 
 
@@ -241,7 +41,28 @@ def codegen_function(
     func: T.Callable[..., CodegenFuncInvocationResult],
     name: T.Optional[str] = None
 ) -> T.Tuple[codegen.FunctionSignature, T.List[AstVariantAnnotation]]:
-    """Code-generate the provided function."""
+    """
+    Accept a python function that manipulates symbolic mathematical expressions, and convert it
+    to an abstract syntax tree (AST) representation suitable for code-generation. After AST
+    construction, you can invoke a suitable code-generator:
+
+    >>> def foo(x: RealScalar, y: RealScalar):
+    >>>     return [OutputArg(x + y, "z")]
+    >>>
+    >>> signature, ast = codegen_function(func=foo)
+    >>> cpp_code = generate_cpp(signature=signature, ast=ast)
+
+    TODO: Add support saving and emitting the docstring.
+
+    :param func: A python function whose arguments are type-annotated (see type_annotations.py) so
+      that we may extract type signatures. The function should return a list of ReturnValue or
+      OutputArg objects. These indicate how outputs are passed out of the function.
+
+    :param name: String name of the function.
+    :return: A tuple containing two items:
+      (1) The `FunctionSignature` object, which describes input and output arguments and their types.
+      (2) An iterable of AST types that descibe how the resulting code should be emitted.
+    """
     spec = inspect.getfullargspec(func=func)
     kwargs = dict()
     for arg_index, arg_name in enumerate(spec.args):
@@ -316,71 +137,3 @@ def codegen_function(
     # Convert to ast that we can emit:
     ast = codegen.generate_func(signature=signature, expressions=output_expressions)
     return signature, ast
-
-
-def create_numeric_evaluator(func: T.Callable) -> T.Callable:
-    spec = inspect.getfullargspec(func=func)
-    function_args = collections.OrderedDict()
-    for arg_index, arg_name in enumerate(spec.args):
-        if arg_name not in spec.annotations:
-            raise KeyError(f'Missing type annotation for argument: {arg_name}')
-        type_annotation = spec.annotations[arg_name]
-        if issubclass(type_annotation, sym.Expr):
-            function_args[arg_name] = codegen.create_function_argument(arg_index)
-        elif issubclass(type_annotation, sym.MatrixExpr):
-            function_args[arg_name] = codegen.create_matrix_function_argument(
-                arg_index, *type_annotation.SHAPE)
-        else:
-            raise TypeError(f'Invalid type used in annotation: {type_annotation}')
-
-    # run the function
-    symbolic_return_values = func(**function_args)
-    if not isinstance(symbolic_return_values, tuple):
-        symbolic_return_values = (symbolic_return_values,)
-
-    def subs(
-        name: str, output: T.Union[sym.Expr, sym.MatrixExpr], symbolic: T.Union[sym.Expr,
-                                                                                sym.MatrixExpr],
-        numeric: T.Union[float,
-                         np.ndarray]) -> T.Union[sym.Expr, sym.MatrixExpr, float, np.ndarray]:
-        if isinstance(symbolic, sym.MatrixExpr):
-            assert isinstance(numeric, np.ndarray), f'Input {name} must be an array'
-            numeric = numeric.reshape(symbolic.shape)
-            result = output
-            for i in range(0, symbolic.shape[0]):
-                for j in range(0, symbolic.shape[1]):
-                    result = result.subs(target=symbolic[i, j], substitute=numeric[i, j])
-            return result.eval()
-        else:
-            assert isinstance(numeric, (int, float)), f'Input {name} must be integer or float'
-            return output.subs(target=symbolic, substitute=numeric).eval()
-
-    # Create a function that substitutes the appropriate values
-    def evaluator(*args, **kwargs):
-        # Put any position args into kwargs:
-        num_args = len(args) + len(kwargs)
-        assert num_args <= len(
-            function_args), f'Expected {len(function_args)} arguments, received {num_args}'
-        for func_arg_name, arg_val in zip(function_args, args):
-            assert func_arg_name not in kwargs, f'Specified argument twice: {func_arg_name}'
-            kwargs[func_arg_name] = arg_val
-
-        numeric_return_values: T.List[T.Union[float, np.ndarray]] = []
-        # iterate over all return values and substitute all args (This is inefficient)
-        for return_val in symbolic_return_values:
-            for func_arg_name in kwargs:
-                symbolic_arg = function_args[func_arg_name]
-                numeric_value = kwargs[func_arg_name]
-                return_val = subs(
-                    name=func_arg_name,
-                    output=return_val,
-                    symbolic=symbolic_arg,
-                    numeric=numeric_value)
-
-            numeric_return_values.append(return_val)
-
-        if len(numeric_return_values) == 1:
-            return numeric_return_values[0]
-        return tuple(numeric_return_values)
-
-    return evaluator

--- a/components/python/wrenfold/codegen.py
+++ b/components/python/wrenfold/codegen.py
@@ -1,1 +1,0 @@
-from pywrenfold.wf_wrapper.codegen import *

--- a/components/python/wrenfold/geometry.py
+++ b/components/python/wrenfold/geometry.py
@@ -1,1 +1,2 @@
+"""Alias module for the C++ wrapped geometry utils."""
 from pywrenfold.wf_wrapper.geometry import *

--- a/components/wrapper/python_test/codegen_wrapper_test.py
+++ b/components/wrapper/python_test/codegen_wrapper_test.py
@@ -1,17 +1,16 @@
 """
 Test of code-generation functionality.
+
+Most of this logic is actually tested by the python examples, which are executed as tests. This
+test just evaluates that we can call the wrapper methods without crashing.
+
+In future when I add back python code-generation we can import some outputs directly and invoke them.
 """
-import importlib.util
-import numpy as np
-import os
-import shutil
-import tempfile
-import typing as T
 import unittest
 
 from wrenfold import sym
 from wrenfold.type_annotations import RealScalar, Vector2
-from wrenfold.code_generation import codegen_function, PythonCodeGenerator, create_numeric_evaluator
+from wrenfold.code_generation import codegen_function, generate_cpp, generate_rust, ReturnValue, OutputArg
 
 from test_base import MathTestBase
 
@@ -26,56 +25,37 @@ def func2(x: RealScalar, y: RealScalar):
     return sym.where(x > y / 2, sym.cos(x - y), sym.sin(x + y * 2))
 
 
+def func3(x: Vector2, y: Vector2, z: RealScalar):
+    """Another test function."""
+    m = sym.where(z > x[1], (x * y.transpose() + sym.eye(2) * sym.cos(z / x[0])).squared_norm(),
+                  z * 5)
+    diff_x = sym.vector(m).jacobian(x)
+    diff_y = sym.vector(m).jacobian(y)
+    diff_z = sym.vector(m).jacobian([z])
+    return [
+        ReturnValue(m),
+        OutputArg(diff_x, name='diff_x', is_optional=False),
+        OutputArg(diff_y, name='diff_y', is_optional=False),
+        OutputArg(diff_z, name='diff_z', is_optional=True),
+    ]
+
+
 class CodeGenerationWrapperTest(MathTestBase):
-
-    def __init__(self, methodName: str = "runTest") -> None:
-        super().__init__(methodName)
-        self._tmp_dir: T.Optional[str] = None
-
-    def setUp(self) -> None:
-        self._tmp_dir = tempfile.mkdtemp(prefix='code_gen_wrapper_test_')
-        print(f'Temporary directory: {self._tmp_dir}')
-        return super().setUp()
-
-    def tearDown(self) -> None:
-        if self._tmp_dir is not None:
-            shutil.rmtree(self._tmp_dir, ignore_errors=True)
-        return super().tearDown()
-
-    def load_code(self, code: str, name: str) -> T.Callable:
-        """Write out generated code into a module, and import it for use."""
-        fd, file_path = tempfile.mkstemp(prefix=name + "_", suffix='.py', dir=self._tmp_dir)
-        with os.fdopen(fd, 'w') as handle:
-            handle.write('import numpy as np\n\n')
-            handle.write(code)
-            handle.flush()
-
-        module_name, _ = os.path.splitext(os.path.basename(file_path))
-        spec = importlib.util.spec_from_file_location(module_name, file_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return getattr(mod, name)
 
     def test_code_generation_1(self):
         signature, ast = codegen_function(func1)
-        code = PythonCodeGenerator().generate(signature=signature, body=ast)
-
-        generated_func = self.load_code(code=code, name=func1.__name__)
-        numeric_func = create_numeric_evaluator(func=func1)
-
-        val_generated = generated_func(0.5, 1.2, np.array([0., 1.2]))
-        val_subs = numeric_func(0.5, 1.2, np.array([0., 1.2]))
-        self.assertAlmostEqual(val_subs, val_generated, places=16)
+        generate_cpp(signature, ast)
+        generate_rust(signature, ast)
 
     def test_code_generation_2(self):
         signature, ast = codegen_function(func2)
-        code = PythonCodeGenerator().generate(signature=signature, body=ast)
+        generate_cpp(signature, ast)
+        generate_rust(signature, ast)
 
-        generated_func = self.load_code(code=code, name=func2.__name__)
-        numeric_func = create_numeric_evaluator(func=func2)
-
-        self.assertAlmostEqual(numeric_func(1.6, 0.4), generated_func(1.6, 0.4), places=16)
-        self.assertAlmostEqual(numeric_func(0.2, 2.1), generated_func(0.2, 2.1), places=16)
+    def test_code_generation_3(self):
+        signature, ast = codegen_function(func3)
+        generate_cpp(signature, ast)
+        generate_rust(signature, ast)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- This needs a little more thought. The code generation should probably live in C++, with the possibility of overriding specific methods from python for convenience. Will take another stab at it in future.
- Squeeze in a fix for a minor issue where C++ code generation did not explicitly wrap doubles in `static_cast`