### PR TITLE
Bump the minimum cmake version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.19)
 project(
   wrenfold-codegen
   VERSION 0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.2.2",
-    "pybind11",
-    "cmake>=3.18",
+    "cmake>=3.19",
+    "mypy",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -18,7 +18,7 @@ license = { text = "MIT" }
 readme = "README.md"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.18"
+cmake.minimum-version = "3.19"
 cmake.args = ["-G", "Ninja", "-Wno-deprecated"]
 cmake.verbose = true
 cmake.build-type = "RelWithDebInfo"


### PR DESCRIPTION
Realized that 3.18 is insufficient. Raising it to 3.19.

- Added `mypy` as a dependency in the pyproject.
- Remove `pybind11` as a dependency, since it is vendored in the repo.