### PR TITLE
Fix ambiguity that MSVC ignores, but which fails on gcc

### DIFF
--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -178,7 +178,7 @@ struct assign_temporary {
 
 // Assign values to an output argument. All output values are written in one operation.
 struct assign_output_argument {
-  std::shared_ptr<const argument> argument;
+  std::shared_ptr<const argument> arg;
   std::vector<variant> values;
 };
 
@@ -272,7 +272,7 @@ struct function_definition {
 
 // Access an input argument at a specific index.
 struct input_value {
-  std::shared_ptr<const argument> argument;
+  std::shared_ptr<const argument> arg;
   index_t element;
 };
 

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -34,7 +34,7 @@ auto format_ast(Iterator it, const wf::ast::add& v) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::assign_output_argument& v) {
-  return fmt::format_to(it, "AssignOutputArgument({} = {})", v.argument->name(),
+  return fmt::format_to(it, "AssignOutputArgument({} = {})", v.arg->name(),
                         fmt::join(v.values, ", "));
 }
 
@@ -94,7 +94,7 @@ auto format_ast(Iterator it, const wf::ast::float_literal& c) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::input_value& v) {
-  return fmt::format_to(it, "{}[{}]", v.argument->name(), v.element);
+  return fmt::format_to(it, "{}[{}]", v.arg->name(), v.element);
 }
 
 template <typename Iterator>

--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -125,8 +125,8 @@ void cpp_code_generator::operator()(code_formatter& formatter, const ast::add& x
 
 void cpp_code_generator::operator()(code_formatter& formatter,
                                     const ast::assign_output_argument& assignment) const {
-  const auto& dest_name = assignment.argument->name();
-  const ast::argument_type& type = assignment.argument->type();
+  const auto& dest_name = assignment.arg->name();
+  const ast::argument_type& type = assignment.arg->type();
 
   if (std::holds_alternative<ast::matrix_type>(type)) {
     const ast::matrix_type mat = std::get<ast::matrix_type>(type);
@@ -136,8 +136,8 @@ void cpp_code_generator::operator()(code_formatter& formatter,
     formatter.join(
         [&](code_formatter& fmt, std::size_t i) {
           const auto [row, col] = mat.compute_indices(i);
-          fmt.format("{}{}({}, {}) = {};", assignment.argument->is_matrix() ? "_" : "", dest_name,
-                     row, col, make_view(assignment.values[i]));
+          fmt.format("{}{}({}, {}) = {};", assignment.arg->is_matrix() ? "_" : "", dest_name, row,
+                     col, make_view(assignment.values[i]));
         },
         "\n", range);
 
@@ -258,13 +258,13 @@ void cpp_code_generator::operator()(code_formatter& formatter,
 }
 
 void cpp_code_generator::operator()(code_formatter& formatter, const ast::input_value& x) const {
-  WF_ASSERT(x.argument);
-  if (std::holds_alternative<ast::scalar_type>(x.argument->type())) {
-    formatter.format(x.argument->name());
+  WF_ASSERT(x.arg);
+  if (std::holds_alternative<ast::scalar_type>(x.arg->type())) {
+    formatter.format(x.arg->name());
   } else {
-    const ast::matrix_type& mat = std::get<ast::matrix_type>(x.argument->type());
+    const ast::matrix_type& mat = std::get<ast::matrix_type>(x.arg->type());
     const auto [r, c] = mat.compute_indices(x.element);
-    formatter.format("_{}({}, {})", x.argument->name(), r, c);
+    formatter.format("_{}({}, {})", x.arg->name(), r, c);
   }
 }
 

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -130,8 +130,8 @@ void rust_code_generator::operator()(code_formatter& formatter, const ast::add& 
 
 void rust_code_generator::operator()(code_formatter& formatter,
                                      const ast::assign_output_argument& assignment) const {
-  const auto& dest_name = assignment.argument->name();
-  const ast::argument_type& type = assignment.argument->type();
+  const auto& dest_name = assignment.arg->name();
+  const ast::argument_type& type = assignment.arg->type();
 
   if (std::holds_alternative<ast::matrix_type>(type)) {
     const ast::matrix_type mat = std::get<ast::matrix_type>(type);
@@ -245,13 +245,13 @@ void rust_code_generator::operator()(wf::code_formatter& formatter, const ast::d
 }
 
 void rust_code_generator::operator()(code_formatter& formatter, const ast::input_value& x) const {
-  WF_ASSERT(x.argument);
-  if (x.argument->is_matrix()) {
-    const ast::matrix_type mat = std::get<ast::matrix_type>(x.argument->type());
+  WF_ASSERT(x.arg);
+  if (x.arg->is_matrix()) {
+    const ast::matrix_type mat = std::get<ast::matrix_type>(x.arg->type());
     const auto [r, c] = mat.compute_indices(x.element);
-    formatter.format("{}.get({}, {})", x.argument->name(), r, c);
+    formatter.format("{}.get({}, {})", x.arg->name(), r, c);
   } else {
-    formatter.format(x.argument->name());
+    formatter.format(x.arg->name());
   }
 }
 

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -208,8 +208,8 @@ void wrap_codegen_operations(py::module_& m) {
   py::class_<ast::assign_output_argument>(m, "AssignOutputArgument")
       .def_property_readonly("argument",
                              [](const ast::assign_output_argument& x) {
-                               WF_ASSERT(x.argument);
-                               return *x.argument;
+                               WF_ASSERT(x.arg);
+                               return *x.arg;
                              })
       .def_property_readonly("values",
                              [](const ast::assign_output_argument& x) { return x.values; })
@@ -273,7 +273,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def("__repr__", &format_ast<ast::float_literal>);
 
   py::class_<ast::input_value>(m, "InputValue")
-      .def_property_readonly("argument", [](const ast::input_value& v) { return v.argument; })
+      .def_property_readonly("argument", [](const ast::input_value& v) { return v.arg; })
       .def_property_readonly("element", [](const ast::input_value& v) { return v.element; })
       .def("__repr__", &format_ast<ast::input_value>);
 


### PR DESCRIPTION
MSVC can handle the type/variable ambiguity here, but it is probably not valid C++ outside of that compiler.