### PR TITLE
Add negate operation to the ast

### DIFF
--- a/components/core/wf/code_generation/ast.cc
+++ b/components/core/wf/code_generation/ast.cc
@@ -10,15 +10,8 @@
 
 namespace wf {
 namespace ast {
-function_definition::function_definition(function_signature signature,
-                                         std::vector<ast::variant> body)
-    : signature(std::move(signature)), body(std::move(body)) {}
-
 construct_return_value::construct_return_value(argument_type type, std::vector<ast::variant>&& args)
     : type(type), args(std::move(args)) {}
-
-declaration::declaration(std::string name, code_numeric_type type, variant_ptr value)
-    : name(std::move(name)), type(type), value(std::move(value)) {}
 }  // namespace ast
 
 // Given a starting value `v`, find any downstream conditionals values that equal this value.
@@ -344,6 +337,10 @@ struct ast_from_ir {
 
   ast::variant operator()(const ir::value& val, const ir::mul&) {
     return ast::multiply{make_operation_argument_ptr(val[0]), make_operation_argument_ptr(val[1])};
+  }
+
+  ast::variant operator()(const ir::value& val, const ir::neg&) {
+    return ast::negate{make_operation_argument_ptr(val[0])};
   }
 
   ast::variant operator()(const named_variable& v) const { return ast::variable_ref{v.name()}; }

--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -33,6 +33,7 @@ using variant = std::variant<
     struct input_value,
     struct integer_literal,
     struct multiply,
+    struct negate,
     struct optional_output_branch,
     struct special_constant,
     struct variable_ref
@@ -139,7 +140,8 @@ struct declaration {
   // If a value is assigned, then the result can be presumed to be constant.
   variant_ptr value{};
 
-  declaration(std::string name, code_numeric_type type, variant_ptr value);
+  declaration(std::string name, code_numeric_type type, variant_ptr value)
+      : name(std::move(name)), type(type), value(std::move(value)) {}
 
   // Construct w/ no rhs.
   declaration(std::string name, code_numeric_type type) : name(std::move(name)), type(type) {}
@@ -156,14 +158,6 @@ struct divide {
 // Use a floating-point constant in the output code.
 struct float_literal {
   double value;
-};
-
-// Signature and body of a function.
-struct function_definition {
-  function_signature signature;
-  std::vector<ast::variant> body;
-
-  function_definition(function_signature signature, std::vector<ast::variant> body);
 };
 
 // Access an input argument at a specific index.
@@ -183,6 +177,13 @@ struct multiply {
   variant_ptr right;
 
   multiply(variant_ptr left, variant_ptr right) : left(std::move(left)), right(std::move(right)) {}
+};
+
+// Negate an operand.
+struct negate {
+  variant_ptr arg;
+
+  explicit negate(variant_ptr arg) noexcept : arg(std::move(arg)) {}
 };
 
 // A one-sided branch that assigns to an optional output, after checking for its existence.

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -93,6 +93,11 @@ auto format_ast(Iterator it, const wf::ast::multiply& m) {
 }
 
 template <typename Iterator>
+auto format_ast(Iterator it, const wf::ast::negate& n) {
+  return fmt::format_to(it, "Negate({})", *n.arg);
+}
+
+template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::optional_output_branch& m) {
   return fmt::format_to(it, "OptionalOutputBranch({}, <{} statements>)", m.arg->name(),
                         m.statements.size());

--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -267,6 +267,10 @@ void cpp_code_generator::operator()(code_formatter& formatter, const ast::multip
   formatter.format("{} * {}", make_view(x.left), make_view(x.right));
 }
 
+void cpp_code_generator::operator()(code_formatter& formatter, const ast::negate& x) const {
+  formatter.format("-{}", make_view(x.arg));
+}
+
 void cpp_code_generator::operator()(code_formatter& formatter,
                                     const ast::optional_output_branch& x) const {
   formatter.format("if (static_cast<bool>({}{})) ", x.arg->is_matrix() ? "_" : "", x.arg->name());

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -54,6 +54,8 @@ class cpp_code_generator {
 
   void operator()(code_formatter& formatter, const ast::multiply& x) const;
 
+  void operator()(code_formatter& formatter, const ast::negate& x) const;
+
   void operator()(code_formatter& formatter, const ast::optional_output_branch& x) const;
 
   // Accept ast::variant and delegate formatting of the stored type to our derived class.

--- a/components/core/wf/code_generation/expr_from_ir.cc
+++ b/components/core/wf/code_generation/expr_from_ir.cc
@@ -106,6 +106,10 @@ struct expression_from_ir_visitor {
         load.variant());
   }
 
+  Expr operator()(const ir::neg&, const std::vector<ir::value_ptr>& args) const {
+    return -map_value(args.front());
+  }
+
   Expr operator()(const ir::phi&, const std::vector<ir::value_ptr>& args) const {
     WF_ASSERT_EQUAL(2, args.size());
 

--- a/components/core/wf/code_generation/ir_builder.cc
+++ b/components/core/wf/code_generation/ir_builder.cc
@@ -448,8 +448,13 @@ class ir_form_visitor {
     return result.value();
   }
 
-  ir::value_ptr operator()(const multiplication& mul) {
-    // Extract constants here? Empirically it appears to introduce more expressions, not fewer.
+  ir::value_ptr operator()(const multiplication& mul, const Expr& mul_abstract) {
+    const auto [coeff, multiplicand] = as_coeff_and_mul(mul_abstract);
+    if (is_negative_one(coeff)) {
+      // If the coefficient out front is -1, compute the multiplied expression and then negate it.
+      const ir::value_ptr multiplicand_value = apply(multiplicand);
+      return push_operation(ir::neg{}, multiplicand_value->numeric_type(), multiplicand_value);
+    }
     return convert_addition_or_multiplication(mul);
   }
 

--- a/components/core/wf/code_generation/ir_builder.h
+++ b/components/core/wf/code_generation/ir_builder.h
@@ -42,8 +42,14 @@ class flat_ir {
     return block_->count_operation(std::forward<Func>(func));
   }
 
+  // Count instances of operations of type `T`.
+  template <typename T>
+  std::size_t count_operation() const {
+    return count_operation([](const T&) constexpr { return true; });
+  }
+
   // Count invocations of the specified function.
-  std::size_t count_functions(std_math_function enum_value) const noexcept {
+  std::size_t count_function(std_math_function enum_value) const noexcept {
     return count_operation(
         [&](const ir::call_std_function& func) { return func.name() == enum_value; });
   }
@@ -101,6 +107,12 @@ class output_ir {
                            [&func](std::size_t total, const ir::block::unique_ptr& blk) {
                              return total + blk->count_operation(func);
                            });
+  }
+
+  // Count instances of operations of type `T`.
+  template <typename T>
+  std::size_t count_operation() const {
+    return count_operation([](const T&) constexpr { return true; });
   }
 
   // Count instances of a function call.

--- a/components/core/wf/code_generation/ir_types.h
+++ b/components/core/wf/code_generation/ir_types.h
@@ -207,6 +207,16 @@ class mul {
   constexpr bool is_same(const mul&) const noexcept { return true; }
 };
 
+// Negate the operand.
+class neg {
+ public:
+  constexpr static bool is_commutative() noexcept { return false; }
+  constexpr static int num_value_operands() noexcept { return 1; }
+  constexpr std::string_view to_string() const noexcept { return "neg"; };
+  constexpr std::size_t hash_seed() const noexcept { return 0; }
+  constexpr bool is_same(const neg&) const noexcept { return true; }
+};
+
 // Evaluates to true if the specified output index is required.
 class output_required {
  public:
@@ -260,7 +270,7 @@ class save {
 
 // Different operations are represented by a variant.
 using operation = std::variant<add, call_std_function, cast, compare, cond, copy, div,
-                               jump_condition, load, mul, output_required, phi, save>;
+                               jump_condition, load, mul, neg, output_required, phi, save>;
 
 // A block of operations:
 class block {

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -282,6 +282,10 @@ void rust_code_generator::operator()(code_formatter& formatter, const ast::multi
   formatter.format("{} * {}", make_view(x.left), make_view(x.right));
 }
 
+void rust_code_generator::operator()(wf::code_formatter& formatter, const ast::negate& x) const {
+  formatter.format("-{}", make_view(x.arg));
+}
+
 void rust_code_generator::operator()(code_formatter& formatter,
                                      const ast::optional_output_branch& x) const {
   formatter.format("if let Some({}) = {} ", x.arg->name(), x.arg->name());

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -57,6 +57,8 @@ class rust_code_generator {
 
   void operator()(code_formatter& formatter, const ast::multiply& x) const;
 
+  void operator()(code_formatter& formatter, const ast::negate& x) const;
+
   void operator()(code_formatter& formatter, const ast::optional_output_branch& x) const;
 
   // Accept ast::variant and delegate formatting of the stored type to our derived class.


### PR DESCRIPTION
Previously, negation was emitted as `-1 * x`. Based on inspection of an example in godbolt, `-x` and `-1 * x` are equivalent (at least with O3). That said, it makes the output messier and it is harder to provide the user with a meaningful summary of what operations were generated.

This change causes `-1 * x` to be emitted as `-x` by introducing a negation operation into the output AST. In the process, I improved the specificity of some of the tests in `ir_builder_test.cc` to track counts of specific operations, in order to better detect regressions.

In a follow-up review, I'll add a comment to every generated function providing a summary of operation counts.