### PR TITLE
Implement python bool operator

### DIFF
--- a/components/wrapper/python_test/expression_wrapper_test.py
+++ b/components/wrapper/python_test/expression_wrapper_test.py
@@ -47,6 +47,16 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertReprEqual('where(x < 0, -x, cos(x))', sym.where(x < 0, -x, sym.cos(x)))
         self.assertReprEqual('Derivative(signum(x), x)', sym.signum(x).diff(x))
 
+    def test_bool_conversion(self):
+        """Test that only true and false can be converted to bool."""
+        x, y, z = sym.symbols('x, y, z')
+        self.assertRaises(sym.TypeError, lambda: bool(x + 2))
+        self.assertRaises(sym.TypeError, lambda: bool(2.0 / z))
+        self.assertRaises(sym.TypeError, lambda: 1 if sym.cos(y * z) + x else 0)
+        self.assertTrue(bool(sym.true))
+        self.assertFalse(bool(sym.false))
+        self.assertEqual(2.0, 2.0 if sym.true else 0.0)
+
     def test_basic_scalar_operations(self):
         """Test wrappers for addition, multiplication, subtraction, negation."""
         p, q = sym.symbols('p, q')

--- a/components/wrapper/python_test/matrix_wrapper_test.py
+++ b/components/wrapper/python_test/matrix_wrapper_test.py
@@ -96,6 +96,13 @@ class MatrixWrapperTest(MathTestBase):
         m = sym.matrix([[x * x, -y + 3, x * z], [-2, sym.pi, 5]])
         self.assertEqual('[[x ** 2, 3 - y, x * z],\n [    -2,    pi,     5]]', repr(m))
 
+    def test_bool_conversion(self):
+        """Test that we cannot cast to bool."""
+        x, y, z = sym.symbols('x, y, z')
+        m = sym.matrix([[x * y, -2], [z, sym.pi]])
+        self.assertRaises(sym.TypeError, lambda: bool(m))
+        self.assertRaises(sym.TypeError, lambda: 1 if m else 0)
+
     def test_special_matrices(self):
         """Test convenience constructors for specific matrices."""
         eye = sym.eye(3)

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -384,7 +384,10 @@ void wrap_matrix_operations(py::module_& m) {
            static_cast<MatrixExpr (*)(const Expr&, const MatrixExpr&)>(
                &matrix_operator_overloads::operator*),
            py::is_operator())
-      .def("__neg__", &MatrixExpr::operator-, "Element-wise negation of the matrix.");
+      .def("__neg__", &MatrixExpr::operator-, "Element-wise negation of the matrix.")
+      // Prohibit conversion to bool.
+      .def("__bool__",
+           [](const MatrixExpr&) { throw type_error("MatrixExpr cannot be coerced to boolean."); });
 
   // Matrix constructors:
   m.def("identity", &make_identity, "rows"_a, "Create identity matrix.");


### PR DESCRIPTION
The default implementation of `__bool__` evaluates to true, which produces undesirable behaviors like:
```
In [3]: x = sym.symbols('x')
In [4]: if x: print('true')
true

In [5]: if sym.false: print('uh oh')
uh oh
```

I have implemented the `__bool__` operator with the following behaviors:
- `sym.true` and `sym.false` can be converted, but no other `Expr` types can be converted. I opted not to implement conversion for numeric types, for the sake of type safety.
- Prohibit `MatrixExpr` from being converted to bool.

As an aside, I'm starting to realize that having boolean types mixed into the mathematical expression tree is probably a mistake. For context:
- The current status is that right now booleans do not implicitly convert to int or float. So if you do `(3.0 * (x < 2)).subs(x, 1).eval()` you end up with `(3.0 * true)`.
- It is useful to be able to distinguish a boolean from other numerical expressions. Only some specific operations can produce and accept boolean values (`<` or `&&` for instance).
- For type-safety sake, I would prefer if other mathematical operations like `*` and `+` did not implicitly accept boolean values. Unlike integers and reals, they cannot be added or subtracted.
- This leaves the option of inserting run-time type checks everywhere to catch these cases, but this can be better achieved I think by introducing `boolean_expr`, which would contain types like `relational`, `boolean_value`, `logical_and`, etc. That will eliminate the need for tedious runtime checks.

I'm going to leave this as a TODO for a future change, but I think it's something I'd like to resolve before releasing, time permitting.