### PR TITLE
Add flag for handling derivatives of non-differentiable functions

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -139,8 +139,14 @@ TEST(DerivativesTest, TestAbs) {
 TEST(DerivativesTest, TestSignum) {
   const auto [x, y] = make_symbols("x", "y");
   ASSERT_IDENTICAL(0, signum(x).diff(y));
-  ASSERT_IDENTICAL(derivative::create(signum(2 * x), x, 1), signum(x * 2).diff(x));
-  ASSERT_IDENTICAL(derivative::create(signum(x), x, 2), signum(x).diff(x, 2));
+
+  ASSERT_IDENTICAL(0, signum(x).diff(x, 1));
+  ASSERT_IDENTICAL(0, signum(x * x - y).diff(x, 1));
+
+  ASSERT_IDENTICAL(derivative::create(signum(2 * x), x, 1),
+                   signum(x * 2).diff(x, 1, non_differentiable_behavior::abstract));
+  ASSERT_IDENTICAL(derivative::create(signum(x), x, 2),
+                   signum(x).diff(x, 2, non_differentiable_behavior::abstract));
 }
 
 TEST(DerivativesTest, TestMaxMin) {
@@ -169,8 +175,12 @@ TEST(DerivativesTest, TestMatrix) {
 TEST(DerivativesTest, TestRelational) {
   // Cannot diff a relational:
   const auto [x, y] = make_symbols("x", "y");
-  ASSERT_IDENTICAL(derivative::create(x < y, x, 1), (x < y).diff(x));
-  ASSERT_IDENTICAL(derivative::create(x == y, x, 1), (x == y).diff(x));
+  ASSERT_IDENTICAL(0, (x < y).diff(x));
+  ASSERT_IDENTICAL(0, (x == y).diff(x));
+  ASSERT_IDENTICAL(derivative::create(x < y, x, 1),
+                   (x < y).diff(x, 1, non_differentiable_behavior::abstract));
+  ASSERT_IDENTICAL(derivative::create(x == y, x, 1),
+                   (x == y).diff(x, 1, non_differentiable_behavior::abstract));
 }
 
 TEST(DerivativesTest, TestCastBool) {

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -145,8 +145,10 @@ TEST(PlainFormatterTest, TestMatrix) {
 
 TEST(PlainFormatterTest, TestDerivativeExpression) {
   const Expr a{"a"};
-  ASSERT_STR_EQ("Derivative(signum(a), a)", signum(a).diff(a));
-  ASSERT_STR_EQ("Derivative(signum(a), a, 2)", signum(a).diff(a, 2));
+  ASSERT_STR_EQ("Derivative(signum(a), a)",
+                signum(a).diff(a, 1, non_differentiable_behavior::abstract));
+  ASSERT_STR_EQ("Derivative(signum(a), a, 2)",
+                signum(a).diff(a, 2, non_differentiable_behavior::abstract));
 }
 
 TEST(PlainFormatterTest, TestComplexInfinity) { ASSERT_STR_EQ("zoo", constants::complex_infinity); }

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -6,14 +6,13 @@
 #include "wf/hashing.h"
 
 namespace wf {
-class variable;  //  Fwd declare.
 
 // Visitor that takes the derivative of an input expression.
 class derivative_visitor {
  public:
   // Construct w/ const reference to the variable to differentiate wrt to.
   // Must remain in scope for the duration of evaluation.
-  explicit derivative_visitor(const Expr& argument);
+  derivative_visitor(const Expr& argument, non_differentiable_behavior behavior);
 
   // Apply this visitor to the specified expression.
   Expr apply(const Expr& expression);
@@ -35,10 +34,11 @@ class derivative_visitor {
   Expr operator()(const variable& var) const;
 
  private:
-  Expr cached_visit(const Expr& expr);
-
   // Argument we differentiate with respect to.
   const Expr& argument_;
+
+  // See `non_differentiable_behavior` - how we handle non-differentiable functions.
+  non_differentiable_behavior non_diff_behavior_;
 
   // Cache of f(x) --> df(x)/dx.
   std::unordered_map<Expr, Expr, hash_struct<Expr>, is_identical_struct<Expr>> cache_;

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -69,7 +69,10 @@ class Expr {
   Expr operator-() const;
 
   // Differentiate wrt a single variable. Reps defines how many derivatives to take.
-  Expr diff(const Expr& var, int reps = 1) const { return wf::diff(*this, var, reps); }
+  Expr diff(const Expr& var, int reps = 1,
+            non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
+    return wf::diff(*this, var, reps, behavior);
+  }
 
   // Distribute terms in this expression.
   Expr distribute() const { return wf::distribute(*this); }

--- a/components/core/wf/geometry/quaternion.cc
+++ b/components/core/wf/geometry/quaternion.cc
@@ -172,13 +172,14 @@ quaternion quaternion::from_rotation_matrix(const MatrixExpr& R_in) {
   return {sqrt(a) / 4, sign_21 * sqrt(b) / 4, sign_02 * sqrt(c) / 4, sign_10 * sqrt(d) / 4};
 }
 
-MatrixExpr quaternion::jacobian(const wf::MatrixExpr& vars) const {
+MatrixExpr quaternion::jacobian(const wf::MatrixExpr& vars,
+                                non_differentiable_behavior behavior) const {
   if (vars.rows() != 1 && vars.cols() != 1) {
     throw dimension_error("Variables must be a row or column vector. Received dimensions: [{}, {}]",
                           vars.rows(), vars.cols());
   }
   const auto& m = vars.as_matrix();
-  return jacobian(m.data());
+  return jacobian(m.data(), behavior);
 }
 
 MatrixExpr quaternion::right_retract_derivative() const {

--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -142,16 +142,24 @@ class quaternion {
 
   // Compute 4xN jacobian of this quaternion with respect to the `N` input variables `vars`.
   // The rows of the jacobian are ordered in the storage order of the quaternion: [w,x,y,z].
-  MatrixExpr jacobian(absl::Span<const Expr> vars) const { return wf::jacobian(wxyz(), vars); }
+  MatrixExpr jacobian(
+      absl::Span<const Expr> vars,
+      non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
+    return wf::jacobian(wxyz(), vars, behavior);
+  }
 
   // Compute the 4xN jacobian of this quaternion with respect to the `Nx1` column vector `vars`.
   // The rows of the jacobian are ordered in the storage order of the quaternion: [w,x,y,z].
-  MatrixExpr jacobian(const MatrixExpr& vars) const;
+  MatrixExpr jacobian(const MatrixExpr& vars, non_differentiable_behavior behavior =
+                                                  non_differentiable_behavior::constant) const;
 
   // Compute the 4x4 jacobian of this quaternion with respect to the variables in quaternion `vars`.
   // The rows and columns of the output jacobian are ordered in the storage order of the quaternion:
   // [w,x,y,z].
-  MatrixExpr jacobian(const quaternion& vars) const { return jacobian(vars.wxyz()); }
+  MatrixExpr jacobian(const quaternion& vars, non_differentiable_behavior behavior =
+                                                  non_differentiable_behavior::constant) const {
+    return jacobian(vars.wxyz(), behavior);
+  }
 
   // Compute the 4x3 tangent-space derivative of this quaternion with respect to a right-multiplied
   // perturbation. This is the derivative:

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -42,15 +42,19 @@ class MatrixExpr {
 
   // Differentiate with respect to a single variable. Reps defines how many derivatives to take.
   // The returned matrix is the element-wise derivative.
-  MatrixExpr diff(const Expr& var, int reps = 1) const;
+  MatrixExpr diff(
+      const Expr& var, int reps = 1,
+      non_differentiable_behavior behavior = non_differentiable_behavior::constant) const;
 
   // Differentiate a vector with respect to another vector, producing a Jacobian.
   // If the input is an [N,1] vector and `vars` has M expressions, the result will be an NxM matrix.
   // Throws if `this` is not a column vector.
-  MatrixExpr jacobian(absl::Span<const Expr> vars) const;
+  MatrixExpr jacobian(absl::Span<const Expr> vars, non_differentiable_behavior behavior =
+                                                       non_differentiable_behavior::constant) const;
 
   // Version of `jacobian` that accepts `MatrixExpr` directly.
-  MatrixExpr jacobian(const MatrixExpr& vars) const;
+  MatrixExpr jacobian(const MatrixExpr& vars, non_differentiable_behavior behavior =
+                                                  non_differentiable_behavior::constant) const;
 
   // Distribute terms in this expression.
   MatrixExpr distribute() const;

--- a/components/wrapper/python_test/expression_wrapper_test.py
+++ b/components/wrapper/python_test/expression_wrapper_test.py
@@ -45,7 +45,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertReprEqual('atan2(y, x)', sym.atan2(y, x))
         self.assertReprEqual('abs(x)', sym.abs(x))
         self.assertReprEqual('where(x < 0, -x, cos(x))', sym.where(x < 0, -x, sym.cos(x)))
-        self.assertReprEqual('Derivative(signum(x), x)', sym.signum(x).diff(x))
+        self.assertReprEqual('Derivative(signum(x), x)', sym.signum(x).diff(x, use_abstract=True))
 
     def test_bool_conversion(self):
         """Test that only true and false can be converted to bool."""

--- a/components/wrapper/pywrenfold/expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/expression_wrapper.cc
@@ -107,8 +107,15 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
           "other"_a, "Test if two expressions have identical expression trees.")
       .def_property_readonly("type_name", &Expr::type_name)
       // Operations:
-      .def("diff", &Expr::diff, "var"_a, py::arg("order") = 1,
-           "Differentiate the expression with respect to the specified variable.")
+      .def(
+          "diff",
+          [](const Expr& self, const Expr& var, int order, bool use_abstract) {
+            return self.diff(var, order,
+                             use_abstract ? non_differentiable_behavior::abstract
+                                          : non_differentiable_behavior::constant);
+          },
+          "var"_a, py::arg("order") = 1, py::arg("use_abstract") = false,
+          "Differentiate the expression with respect to the specified variable.")
       .def("distribute", &Expr::distribute, "Expand products of additions and subtractions.")
       .def("subs", &Expr::subs, py::arg("target"), py::arg("substitute"),
            "Replace the `target` expression with `substitute` in the expression tree.")
@@ -195,6 +202,8 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
   m.attr("true") = constants::boolean_true;
   m.attr("false") = constants::boolean_false;
 
+  // TODO: This is unused - can probably be removed unless we want to expose the `function` type
+  // in python.
   // Function enums.
   py::enum_<built_in_function>(m, "BuiltInFunction")
       .value("Cos", built_in_function::cos)

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -160,18 +160,27 @@ void wrap_geometry_operations(py::module_& m) {
                   py::doc("Convert from a rotation matrix via Calley's method."))
       .def(
           "jacobian",
-          [](const quaternion& self, const MatrixExpr& vars) { return self.jacobian(vars); },
-          py::arg("vars"),
+          [](const quaternion& self, const MatrixExpr& vars, bool use_abstract) {
+            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
+                                                    : non_differentiable_behavior::constant);
+          },
+          py::arg("vars"), py::arg("use_abstract") = false,
           py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
       .def(
           "jacobian",
-          [](const quaternion& self, const std::vector<Expr>& vars) { return self.jacobian(vars); },
-          py::arg("vars"),
+          [](const quaternion& self, const std::vector<Expr>& vars, bool use_abstract) {
+            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
+                                                    : non_differentiable_behavior::constant);
+          },
+          py::arg("vars"), py::arg("use_abstract") = false,
           py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
       .def(
           "jacobian",
-          [](const quaternion& self, const quaternion& vars) { return self.jacobian(vars); },
-          py::arg("vars"),
+          [](const quaternion& self, const quaternion& vars, bool use_abstract) {
+            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
+                                                    : non_differentiable_behavior::constant);
+          },
+          py::arg("vars"), py::arg("use_abstract") = false,
           py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables in "
                   "another quaternion."))
       .def("right_retract_derivative", &quaternion::right_retract_derivative,

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -298,17 +298,30 @@ void wrap_matrix_operations(py::module_& m) {
           "other"_a, "Test if two matrix expressions have identical expression trees.")
       .def_property_readonly("type_name", &MatrixExpr::type_name)
       // Operations:
-      .def("diff", &MatrixExpr::diff, "var"_a, py::arg("order") = 1,
-           "Differentiate the expression with respect to the specified variable.")
+      .def(
+          "diff",
+          [](const MatrixExpr& self, const Expr& var, int order, bool use_abstract) {
+            return self.diff(var, order,
+                             use_abstract ? non_differentiable_behavior::abstract
+                                          : non_differentiable_behavior::constant);
+          },
+          "var"_a, py::arg("order") = 1, py::arg("use_abstract") = false,
+          "Differentiate the expression with respect to the specified variable.")
       .def(
           "jacobian",
-          [](const MatrixExpr& self, const MatrixExpr& vars) { return self.jacobian(vars); },
-          "vars"_a,
+          [](const MatrixExpr& self, const MatrixExpr& vars, bool use_abstract) {
+            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
+                                                    : non_differentiable_behavior::constant);
+          },
+          "vars"_a, py::arg("use_abstract") = false,
           "Compute the jacobian of a vector-valued function with respect to vector of arguments.")
       .def(
           "jacobian",
-          [](const MatrixExpr& self, const std::vector<Expr>& vars) { return self.jacobian(vars); },
-          "vars"_a,
+          [](const MatrixExpr& self, const std::vector<Expr>& vars, bool use_abstract) {
+            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
+                                                    : non_differentiable_behavior::constant);
+          },
+          "vars"_a, py::arg("use_abstract") = false,
           "Compute the jacobian of a vector-valued function with respect to a list of arguments.")
       .def("distribute", &MatrixExpr::distribute, "Expand products of additions and subtractions.")
       .def("subs", &MatrixExpr::subs, py::arg("target"), py::arg("substitute"),


### PR DESCRIPTION
One issue that arises when taking derivatives is that some functions don't admit practical derivatives. An example:
- The `round` function is non-differentiable for non-integer arguments. For other arguments it is undefined.
- The heaviside step function has the dirac delta function as a derivative. This is straighforward enough to represent mathematically, but impossible to implement in code.

There's a bit of a tension between producing mathematically correct outputs vs. things we can evaluate computationally. Since the goal of this framework is ultimately code-generation, I think having numerically useful outputs is more helpful as a default.

That said, I think there is still some utility in being able to optionally ask for the safer behavior. That way, the user can call `diff` and then `subs` to replace the `derivative` expression with something of their own choosing.

With this change, I have added a mode flag to the derivative method that controls how non-differentiable functions are handled. The default will be the simpler behavior (substitute appropriate constants).

This change resolves an issue with the b-spline example, where we differentiate a relational operation `x < y`.

I considered adding a python wrapper of the `non_differentiable_behavior` type. Unfortunately it seems like pybind11 enums are not type safe, and can be implicitly converted to integers. As such, it doesn't provide that much additional type-safety when calling `diff`. For now I opted to expose this behavior via a boolean argument in python.