### PR TITLE
Add missing functionality for `cast_int_from_bool` operation

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -186,11 +186,16 @@ TEST(DerivativesTest, TestRelational) {
 TEST(DerivativesTest, TestCastBool) {
   const auto [x, y] = make_symbols("x", "y");
 
+  ASSERT_IDENTICAL(0, cast_int_from_bool(x < y).diff(x));
+  ASSERT_IDENTICAL(0, cast_int_from_bool(x < y).diff(x).diff(y));
+
   // Check that this produces a `derivative` expression:
   ASSERT_IDENTICAL(derivative::create(cast_int_from_bool(x < y), x, 1),
-                   cast_int_from_bool(x < y).diff(x));
+                   cast_int_from_bool(x < y).diff(x, 1, non_differentiable_behavior::abstract));
   ASSERT_IDENTICAL(derivative::create(derivative::create(cast_int_from_bool(x < y), x, 1), y, 1),
-                   cast_int_from_bool(x < y).diff(x).diff(y));
+                   cast_int_from_bool(x < y)
+                       .diff(x, 1, non_differentiable_behavior::abstract)
+                       .diff(y, 1, non_differentiable_behavior::abstract));
 }
 
 TEST(DerivativesTest, TestDerivativeExpression) {

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -59,7 +59,11 @@ Expr derivative_visitor::operator()(const addition& add) {
 }
 
 Expr derivative_visitor::operator()(const cast_bool&, const Expr& expr) {
-  return derivative::create(expr, argument_, 1);
+  if (non_diff_behavior_ == non_differentiable_behavior::abstract) {
+    return derivative::create(expr, argument_, 1);
+  } else {
+    return constants::zero;
+  }
 }
 
 // TODO: This is not strictly correct. If the condition is a function of `x` (where x is the

--- a/components/wrapper/python_test/expression_wrapper_test.py
+++ b/components/wrapper/python_test/expression_wrapper_test.py
@@ -172,6 +172,11 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(x, sym.where(0 < sym.Expr(1), x, y))
         self.assertIdentical(y - 3, sym.where(sym.pi >= sym.euler, y - 3, x * 5))
 
+    def test_cast_bool_to_int(self):
+        """Test converting boolean values to integer."""
+        self.assertIdentical(1, sym.cast_int_from_bool(sym.one < 10.2))
+        self.assertIdentical(0, sym.cast_int_from_bool(sym.one == sym.zero))
+
     def test_subs(self):
         """Test calling subs() on expressions."""
         x, y, z = sym.symbols('x, y, z')

--- a/components/wrapper/pywrenfold/expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/expression_wrapper.cc
@@ -193,6 +193,9 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
   m.def("where", static_cast<Expr (*)(const Expr&, const Expr&, const Expr&)>(&wf::where),
         "condition"_a, "if_true"_a, "if_false"_a, "If-else statement.");
 
+  m.def("cast_int_from_bool", &wf::cast_int_from_bool, "arg"_a,
+        "Convert a boolean expression to an integer.");
+
   // Special constants:
   m.attr("euler") = constants::euler;
   m.attr("zoo") = constants::complex_infinity;


### PR DESCRIPTION
There were a couple of missing operations on the `cast_int_from_bool` operation:
- The derivative behavior did not respect the `non_diff_behavior_ ` flag.
- The python wrapper was missing.