### PR TITLE
Add `reshape()` to MatrixExpr

### DIFF
--- a/components/core/tests/matrix_operations_test.cc
+++ b/components/core/tests/matrix_operations_test.cc
@@ -115,6 +115,20 @@ TEST(MatrixOperationsTest, TestTranspose) {
   ASSERT_IDENTICAL(m, m.transposed().transposed());
 }
 
+TEST(MatrixOperationsTest, TestReshape) {
+  const auto [a, b, c] = make_symbols("a", "b", "c");
+  const MatrixExpr m = make_matrix(2, 4, a * 2, -b, cos(c), 5, c / a, 8 * a, b * c, c / 2);
+
+  const MatrixExpr m_reshape = m.reshape(4, 2);
+  ASSERT_EQ(4, m_reshape.rows());
+  ASSERT_EQ(2, m_reshape.cols());
+
+  const auto old_contents = m.to_vector();
+  const auto new_contents = m_reshape.to_vector();
+  ASSERT_TRUE(std::equal(old_contents.begin(), old_contents.end(), new_contents.begin(),
+                         new_contents.end(), is_identical_struct<Expr>{}));
+}
+
 TEST(MatrixOperationsTest, TestVec) {
   const Expr a{"a"};
   const Expr b{"b"};

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -49,6 +49,18 @@ MatrixExpr MatrixExpr::get_block(index_t row, index_t col, index_t nrows, index_
 
 MatrixExpr MatrixExpr::transposed() const { return MatrixExpr{as_matrix().transposed()}; }
 
+MatrixExpr MatrixExpr::reshape(index_t nrows, index_t ncols) const {
+  if (nrows < 0 || ncols < 0) {
+    throw dimension_error("Dimensions must be non-negative. Received [{}, {}]", nrows, ncols);
+  }
+  if (static_cast<std::size_t>(nrows * ncols) != size()) {
+    throw dimension_error(
+        "Reshaped dimensions [{} x {} = {}] does not match number of input elements [{} x {} = {}]",
+        nrows, ncols, nrows * ncols, rows(), cols(), size());
+  }
+  return MatrixExpr::create(nrows, ncols, to_vector());
+}
+
 Expr MatrixExpr::squared_norm() const {
   const matrix& m = as_matrix();
   std::vector<Expr> operands{};

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -89,6 +89,9 @@ class MatrixExpr {
   // Transpose the matrix.
   [[nodiscard]] MatrixExpr transposed() const;
 
+  // Reshape the matrix (returns a copy).
+  [[nodiscard]] MatrixExpr reshape(index_t nrows, index_t ncols) const;
+
   // Get the squared norm of the matrix.
   Expr squared_norm() const;
 

--- a/components/wrapper/python_test/matrix_wrapper_test.py
+++ b/components/wrapper/python_test/matrix_wrapper_test.py
@@ -237,6 +237,19 @@ class MatrixWrapperTest(MathTestBase):
             sym.matrix([m[0, :].transpose(), m[1, :].transpose(), m[2, :].transpose()]),
             sym.vec(m_t))
 
+    def test_reshape(self):
+        """Test calling reshape on a matrix."""
+        x, y, z, a, b, c = sym.symbols('x, y, z, a, b, c')
+        self.assertIdentical(
+            sym.matrix([[x, y, z], [a, b, c]]),
+            sym.matrix([x, y, z, a, b, c]).reshape(2, 3))
+        self.assertIdentical(
+            sym.matrix([[x, y], [z, a], [b, c]]),
+            sym.matrix([x, y, z, a, b, c]).reshape((3, 2)))
+        self.assertRaises(sym.DimensionError, lambda: sym.eye(2).reshape(4, 5))
+        self.assertRaises(sym.DimensionError, lambda: sym.eye(4).reshape(-2, 8))
+        self.assertRaises(sym.DimensionError, lambda: sym.eye(4).reshape(2, -8))
+
     def test_matrix_operations(self):
         """Check that add/mul/sub operations are wrapped."""
         m0 = sym.matrix_of_symbols('x', 4, 3)

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -368,6 +368,15 @@ void wrap_matrix_operations(py::module_& m) {
              return py::make_iterator(row_iterator::begin(expr), row_iterator::end(expr));
            })
       .def("unary_map", &unary_map_matrix, py::arg("func"), "Perform element-wise map operation.")
+      .def("reshape", &MatrixExpr::reshape, py::arg("rows"), py::arg("cols"),
+           "Reshape a matrix while preserving the number of elements. Returns a copy.")
+      .def(
+          "reshape",
+          [](const MatrixExpr& self, std::tuple<index_t, index_t> row_and_col) {
+            return self.reshape(std::get<0>(row_and_col), std::get<1>(row_and_col));
+          },
+          py::arg("shape"),
+          py::doc("Reshape a matrix while preserving the number of elements. Returns a copy."))
       // Convert to list
       .def("to_list", &list_from_matrix, "Convert to list of lists.")
       .def("transpose", &MatrixExpr::transposed, "Transpose the matrix.")


### PR DESCRIPTION
Adds a `reshape` method to `MatrixExpr` that can reshape a matrix (provided # of elements stays the same). Unlike numpy reshape, this creates a copy because we have no "view" concept yet.