### PR TITLE
Remove argh from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ The following tools are required to build from source:
 - mypy (required for [stubgen](https://mypy.readthedocs.io/en/stable/stubgen.html))
 
 Additionally, to build and run tests you will need:
-- argh
 - numpy
 - The rust compiler toolchain (`cargo` and `rustc`)
 
 The following command will configure a `conda` environment suitable for building:
 ```bash
-conda create -n wf_test python=3.8 cmake ninja mypy numpy argh
+conda create -n wf_test python=3.8 cmake ninja mypy numpy
 conda activate wf_test
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
   - ninja
   - mypy
   - numpy
-  - argh

--- a/examples/imu_integration/imu_integration.py
+++ b/examples/imu_integration/imu_integration.py
@@ -9,7 +9,7 @@ In practice, there is a larger space of design choices you could make. For insta
 - Incorporating rotational effects of the earth.
 - Higher-order numerical integration schemes.
 """
-import argh
+import argparse
 import typing as T
 
 from wrenfold.type_annotations import RealScalar, Vector4, Vector3
@@ -299,7 +299,7 @@ def integration_test_sequence(t: RealScalar):
     ]
 
 
-def main(output: str):
+def main(args: argparse.Namespace):
     descriptions = [
         code_generation.create_function_description(integrate_imu),
         code_generation.create_function_description(unweighted_imu_preintegration_error),
@@ -309,11 +309,14 @@ def main(output: str):
     code = CppGenerator().generate(definitions=definitions)
     code = code_generation.apply_cpp_preamble(code, namespace="gen")
 
-    if output is not None:
-        code_generation.mkdir_and_write_file(code=code, path=output)
-    else:
-        print(code)
+    code_generation.mkdir_and_write_file(code=code, path=args.output)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=str, help="Output path")
+    return parser.parse_args()
 
 
 if __name__ == '__main__':
-    argh.dispatch_command(main)
+    main(parse_args())

--- a/examples/rotation_error/rotation_error.py
+++ b/examples/rotation_error/rotation_error.py
@@ -4,7 +4,7 @@ Example: Tangent-space delta between two quaternions, with tangent-space jacobia
 This is an example of a relatively simple factor one might implement for a rotation
 averaging optimization.
 """
-import argh
+import argparse
 import typing as T
 
 from wrenfold.type_annotations import RealScalar, Vector4
@@ -33,17 +33,19 @@ def rotation_error(q0_xyzw: Vector4, q1_xyzw: Vector4, weight: RealScalar):
     ]
 
 
-def main(output: str):
+def main(args: argparse.Namespace):
     description = code_generation.create_function_description(rotation_error)
     definition = code_generation.transpile(description=description)
     code = CppGenerator().generate(definition=definition)
     code = code_generation.apply_cpp_preamble(code, namespace="gen")
+    code_generation.mkdir_and_write_file(code=code, path=args.output)
 
-    if output is not None:
-        code_generation.mkdir_and_write_file(code=code, path=output)
-    else:
-        print(code)
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=str, help="Output path")
+    return parser.parse_args()
 
 
 if __name__ == '__main__':
-    argh.dispatch_command(main)
+    main(parse_args())


### PR DESCRIPTION
Finding argh to be a somewhat annoying dependency - it looks like the interface changed from  `0.29` to `0.30.4`, and again in `0.31.0`. Going to remove it for now, given that `argparse` is built in and more stable.