### PR TITLE
Support finding openblas on linux

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -45,11 +45,13 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.prefix }}
-          key: ${{ matrix.os }}-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          key: ${{ matrix.os }}-conda-${{ hashFiles('environment.yml') }}-${{ hashFiles('test-environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment
-        run: mamba env update -n ${{ env.env_name }} -f environment.yml
+        run: |
+          mamba env update -n ${{ env.env_name }} -f environment.yml
+          mamba env update -n ${{ env.env_name }} --file test-environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Dump conda environment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ find_package(
 message(STATUS "Python_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}")
 message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")
 
+# Find optional PkgConfig. This is to build certain tests+examples.
+if(NOT DEFINED SKBUILD_PROJECT_NAME)
+  find_package(PkgConfig)
+endif()
+
 # Add third party code
 add_subdirectory(dependencies)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following tools are required to build from source:
 Additionally, to build and run tests you will need:
 - numpy
 - The rust compiler toolchain (`cargo` and `rustc`)
+- On linux: `pkg-config`, `openblas`, and `openssl`
 
 The following command will configure a `conda` environment suitable for building:
 ```bash

--- a/examples/motion_planning/CMakeLists.txt
+++ b/examples/motion_planning/CMakeLists.txt
@@ -1,14 +1,51 @@
 add_py_code_generator(py_motion_planning problem.py OUTPUT_FILE_NAME
                       generated.rs)
 
-add_rust_test(
-  motion_planning_test
-  CRATE_NAME
-  motion_planning_test
-  GENERATOR_TARGET
-  py_motion_planning
-  CRATE_SOURCES
-  motion_planning_test/src/lib.rs
-  motion_planning_test/src/gen.rs
-  motion_planning_test/src/problem.rs
-  motion_planning_test/build.rs)
+set(BUILD_MOTION_PLANNING ON)
+set(MOTION_PLANNING_ENV_VARIABLES "")
+
+if(WIN32)
+  # TODO(gareth): Enable this to build on Windows, ideally without vcpkg.
+  # https://github.com/gareth-cross/wrenfold/pull/77#issuecomment-1879299785
+  set(BUILD_MOTION_PLANNING OFF)
+endif()
+
+# A gross hack for linux. openblas-build has a couple of issues: - It pulls in
+# TLS/SSL (even when not required). - It fails to set the rpath correctly (so
+# does the openssl-src crate). We find both of these with pkg-config, then set
+# the `RUSTFLAGS` env variable appropriately. I would rather just fork and fix
+# openblas-src.
+if(UNIX AND NOT APPLE)
+  set(BUILD_MOTION_PLANNING OFF)
+  # Check if we have pkg-config:
+  if(${PKG_CONFIG_FOUND})
+    pkg_check_modules(BLAS openblas)
+    pkg_check_modules(SSL openssl)
+    if(${BLAS_FOUND} AND ${SSL_FOUND})
+      message(STATUS "Found OpenBLAS: ${BLAS_LIBRARY_DIRS}")
+      message(STATUS "Found OpenSSL: ${SSL_LIBRARY_DIRS}")
+      set(BUILD_MOTION_PLANNING ON)
+      set(MOTION_PLANNING_ENV_VARIABLES
+          "RUSTFLAGS=-C link-arg=-L${BLAS_LIBRARY_DIRS} \
+           -C link-arg=-Wl,-rpath,${BLAS_LIBRARY_DIRS} \
+           -C link-arg=-L${SSL_LIBRARY_DIRS} \
+           -C link-arg=-Wl,-rpath,${SSL_LIBRARY_DIRS}")
+    endif()
+  endif()
+endif()
+
+if(${BUILD_MOTION_PLANNING})
+  add_rust_test(
+    motion_planning_test
+    CRATE_NAME
+    motion_planning_test
+    GENERATOR_TARGET
+    py_motion_planning
+    CRATE_SOURCES
+    motion_planning_test/src/lib.rs
+    motion_planning_test/src/gen.rs
+    motion_planning_test/src/problem.rs
+    motion_planning_test/build.rs
+    ENV_VARIABLES
+    ${MOTION_PLANNING_ENV_VARIABLES})
+endif()

--- a/examples/motion_planning/motion_planning_test/build.rs
+++ b/examples/motion_planning/motion_planning_test/build.rs
@@ -4,6 +4,9 @@ fn main() {
         "macos" => {
             println!("cargo:rustc-link-lib=framework=Accelerate");
         }
+        "linux" => {
+            println!("cargo:rustc-link-arg=-lopenblas");
+        }
         _ => {}
     }
 }

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,0 +1,8 @@
+# This file specifies additional dependencies required to build tests+examples.
+channels:
+  - conda-forge
+
+dependencies:
+  - pkg-config
+  - openblas
+  - openssl


### PR DESCRIPTION
Some supporting changes to make `motion_planning` example work on linux (just waiting to see if CI accepts this):
- Use `pkg-config` on linux to find `openblas`
- Add `test-environment.yml` to specify additional dependencies of tests (things not required to build a pip package)
- `add_rust_test` supports passing environment variables
- Disable `motion_planning` example on windows
- Use `motion_planning/CMakeLists.txt` to specify `-L` and `-rpath` when linking on linux