### PR TITLE
Fix assertion macros

### DIFF
--- a/components/core/wf/assertions.h
+++ b/components/core/wf/assertions.h
@@ -4,33 +4,39 @@
 #include "wf/fmt_imports.h"
 
 namespace wf {
+namespace detail {
 
 // Generates an exception w/ a formatted string.
 template <typename... Ts>
-void raise_assert(const char* const condition, const char* const file, const int line,
-                  const char* const reason_fmt = nullptr, Ts&&... args) {
-  const std::string details =
-      reason_fmt ? fmt::format(reason_fmt, std::forward<Ts>(args)...) : "None";
-  std::string err = fmt::format("Assertion failed: {}\nFile: {}\nLine: {}\nDetails: {}\n",
-                                condition, file, line, details);
-  throw assertion_error(std::move(err));
+std::string format_assert(const char* const condition, const char* const file, const int line,
+                          const char* const reason_fmt = nullptr, Ts&&... args) {
+  std::string err = fmt::format("Assertion failed: {}\nFile: {}\nLine: {}", condition, file, line);
+  if (reason_fmt != nullptr) {
+    err.append("\nDetails: ");
+    fmt::format_to(std::back_inserter(err), reason_fmt, std::forward<Ts>(args)...);
+  }
+  return err;
 }
 
 // Version that prints args A & B as well. For binary comparisons.
 template <typename A, typename B, typename... Ts>
-void raise_assert_binary_op(const char* const condition, const char* const file, const int line,
-                            const char* const a_name, A&& a, const char* const b_name, B&& b,
-                            const char* const reason_fmt = nullptr, Ts&&... args) {
-  const std::string details =
-      reason_fmt ? fmt::format(reason_fmt, std::forward<Ts>(args)...) : "None";
+std::string format_assert_binary(const char* const condition, const char* const file,
+                                 const int line, const char* const a_name, A&& a,
+                                 const char* const b_name, B&& b,
+                                 const char* const reason_fmt = nullptr, Ts&&... args) {
   std::string err = fmt::format(
       "Assertion failed: {}\n"
-      "Operands are: {} = {}, {} = {}\n"
-      "File: {}\nLine: {}\nDetails: {}\n",
-      condition, a_name, std::forward<A>(a), b_name, std::forward<B>(b), file, line, details);
-  throw assertion_error(std::move(err));
+      "Operands are: `{}` = {}, `{}` = {}\n"
+      "File: {}\nLine: {}",
+      condition, a_name, std::forward<A>(a), b_name, std::forward<B>(b), file, line);
+  if (reason_fmt != nullptr) {
+    err.append("\nDetails: ");
+    fmt::format_to(std::back_inserter(err), reason_fmt, std::forward<Ts>(args)...);
+  }
+  return err;
 }
 
+}  // namespace detail
 }  // namespace wf
 
 #ifdef __clang__
@@ -40,39 +46,47 @@ void raise_assert_binary_op(const char* const condition, const char* const file,
 
 // Assertion macros.
 // Based on: http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert
-#define WF_ASSERT_IMPL(cond, file, line, handler, ...) \
-  do {                                                 \
-    if (!static_cast<bool>(cond)) {                    \
-      handler(#cond, file, line, ##__VA_ARGS__);       \
-    }                                                  \
+#define WF_ASSERT_IMPL(cond, file, line, handler, ...)                      \
+  do {                                                                      \
+    if (!static_cast<bool>(cond)) {                                         \
+      throw wf::assertion_error(handler(#cond, file, line, ##__VA_ARGS__)); \
+    }                                                                       \
+  } while (false)
+
+#define WF_ASSERT_ALWAYS_IMPL(file, line, handler, ...)                             \
+  do {                                                                              \
+    throw wf::assertion_error(handler("Assert always", file, line, ##__VA_ARGS__)); \
   } while (false)
 
 // Macro to use when defining an assertion.
 #define WF_ASSERT(cond, ...) \
-  WF_ASSERT_IMPL(cond, __FILE__, __LINE__, wf::raise_assert, ##__VA_ARGS__)
+  WF_ASSERT_IMPL(cond, __FILE__, __LINE__, wf::detail::format_assert, ##__VA_ARGS__)
 
-#define WF_ASSERT_EQUAL(a, b, ...)                                                         \
-  WF_ASSERT_IMPL((a) == (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_ALWAYS(...) \
+  WF_ASSERT_ALWAYS_IMPL(__FILE__, __LINE__, wf::detail::format_assert, ##__VA_ARGS__)
+
+#define WF_ASSERT_EQUAL(a, b, ...)                                                               \
+  WF_ASSERT_IMPL((a) == (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
-#define WF_ASSERT_NOT_EQUAL(a, b, ...)                                                     \
-  WF_ASSERT_IMPL((a) != (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_NOT_EQUAL(a, b, ...)                                                           \
+  WF_ASSERT_IMPL((a) != (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
-#define WF_ASSERT_LESS(a, b, ...)                                                         \
-  WF_ASSERT_IMPL((a) < (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_LESS(a, b, ...)                                                               \
+  WF_ASSERT_IMPL((a) < (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
-#define WF_ASSERT_GREATER(a, b, ...)                                                      \
-  WF_ASSERT_IMPL((a) > (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_GREATER(a, b, ...)                                                            \
+  WF_ASSERT_IMPL((a) > (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
-#define WF_ASSERT_LESS_OR_EQ(a, b, ...)                                                    \
-  WF_ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_LESS_OR_EQ(a, b, ...)                                                          \
+  WF_ASSERT_IMPL((a) <= (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
-#define WF_ASSERT_GREATER_OR_EQ(a, b, ...)                                                 \
-  WF_ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, wf::raise_assert_binary_op, #a, a, #b, b, \
+#define WF_ASSERT_GREATER_OR_EQ(a, b, ...)                                                       \
+  WF_ASSERT_IMPL((a) >= (b), __FILE__, __LINE__, wf::detail::format_assert_binary, #a, a, #b, b, \
                  ##__VA_ARGS__)
 
 #ifdef __clang__

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -178,8 +178,7 @@ Expr derivative_visitor::operator()(const function& func) {
       return -(args[0] * x_diff) / sum_squared + (args[1] * y_diff) / sum_squared;
     }
   }
-  WF_ASSERT(false, "Invalid unary function: {}", func.function_name());
-  return constants::zero;
+  WF_ASSERT_ALWAYS("Invalid unary function: {}", func.function_name());
 }
 
 Expr derivative_visitor::operator()(const complex_infinity&) const { return constants::zero; }

--- a/components/core/wf/error_types.h
+++ b/components/core/wf/error_types.h
@@ -8,7 +8,7 @@
 namespace wf {
 
 // Base type for errors.
-struct exception_base : public std::exception {
+struct exception_base : std::exception {
   // Construct with moved message.
   explicit exception_base(std::string&& message) noexcept : message_(std::move(message)) {}
 
@@ -23,29 +23,27 @@ struct exception_base : public std::exception {
   // Implement std::exception
   const char* what() const noexcept override { return message_.c_str(); }
 
-  virtual ~exception_base() = default;
-
  private:
   std::string message_;
 };
 
 // Thrown when assertions fire.
-struct assertion_error : public exception_base {
+struct assertion_error final : exception_base {
   using exception_base::exception_base;
 };
 
 // Throw when an invalid type conversion occurs.
-struct type_error : public exception_base {
+struct type_error final : exception_base {
   using exception_base::exception_base;
 };
 
 // Thrown when accessing invalid matrix dimensions.
-struct dimension_error : public exception_base {
+struct dimension_error final : exception_base {
   using exception_base::exception_base;
 };
 
 // Thrown when function is provided with input outside its domain.
-struct domain_error : public exception_base {
+struct domain_error final : exception_base {
   using exception_base::exception_base;
 };
 

--- a/components/core/wf/expressions/function_expressions.h
+++ b/components/core/wf/expressions/function_expressions.h
@@ -99,8 +99,7 @@ inline Expr function::create(built_in_function name, function::container_type&& 
     case built_in_function::arctan2:
       return atan2(container[0], container[1]);
   }
-  WF_ASSERT(false, "Invalid function name: {}", string_from_built_in_function(name));
-  return constants::zero;  //  Unreachable.
+  WF_ASSERT_ALWAYS("Invalid function name: {}", string_from_built_in_function(name));
 }
 
 }  // namespace wf


### PR DESCRIPTION
Fix assertion macros so that the `throw` is part of the macro, which makes it visible to the compiler at the invocation site of the macro.