### PR TITLE
Fix bug in substitute (denominator integers incorrectly simplified)

### DIFF
--- a/components/core/tests/substitute_test.cc
+++ b/components/core/tests/substitute_test.cc
@@ -116,6 +116,13 @@ TEST(SubstituteTest, TestMultiplications) {
   ASSERT_IDENTICAL(pow(y, 2), (x * w * y).subs(x * w, y));
   ASSERT_IDENTICAL(pow(x, 2) * y, (x * w * z * y).subs(w * z, x));
 
+  // Test expressions that feature negative powers of integers:
+  ASSERT_IDENTICAL(x / 5, (y / 25).subs(y / 5, x));
+  ASSERT_IDENTICAL(z / 105, (cos(x) * y / 1155).subs(cos(x) * y / 11, z));
+  ASSERT_IDENTICAL(sin(z) / 3, (w * x / 3).subs(w * x, sin(z)));
+  ASSERT_IDENTICAL(pow(x, 2) * 35 / (y * 143),
+                   ((pow(x, 3) * sin(z) * 105) / 2431).subs(x * sin(z) * 3 / 17, 1 / y));
+
   // Substitute higher powers:
   ASSERT_IDENTICAL(1, (x * x * x * y * y * z).subs(x * x * x, 1 / (y * y * z)));
   ASSERT_IDENTICAL(pow(z, 3) / pow(y, 2), (x * x * x * x * z).subs(x * x, z / y));

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -64,17 +64,13 @@ template <bool FactorizeIntegers>
 struct multiply_visitor {
   explicit multiply_visitor(multiplication_parts& builder) : builder(builder) {}
 
-  void insert_integer_factors(const std::vector<prime_factor>& factors, bool positive) {
+  void insert_integer_factors(const std::vector<prime_factor>& factors, const bool positive) const {
     for (const prime_factor& factor : factors) {
-      Expr base = Expr(factor.base);
-      Expr exponent = Expr(factor.exponent);
-      const auto [it, was_inserted] = builder.terms.emplace(std::move(base), exponent);
-      if (!was_inserted) {
-        if (positive) {
-          it->second = it->second + exponent;
-        } else {
-          it->second = it->second - exponent;
-        }
+      Expr base{factor.base};
+      Expr exponent{positive ? factor.exponent : -factor.exponent};
+      if (const auto [it, was_inserted] = builder.terms.emplace(std::move(base), exponent);
+          !was_inserted) {
+        it->second = it->second + exponent;
       }
     }
   }


### PR DESCRIPTION
There was a bug where non-repeated integer factors with negative exponents would have the sign of their exponents flipped during calls to `subs()`. So for example:
```
(sin(x) / 3).subs(sin(x), y) --> y * 3 # wrong, should be y / 3
```
This change resolves this issue and adds a few more test cases. (This issue did not affect calls to `subs_variables`, which is used more often and goes through a much simpler code path).

I've been meaning to do a pass through `multiply_visitor` and `substitute_visitor` for a while now - it could do with a second pass, for sure. I'll make a note to do this soon, I'd really like to clean up some of the details of `multiplication` and `addition`.