### PR TITLE
Pin compilers package on linux 

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -45,13 +45,13 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.prefix }}
-          key: ${{ matrix.os }}-conda-${{ hashFiles('environment.yml') }}-${{ hashFiles('test-environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          key: ${{ matrix.os }}-conda-${{ hashFiles('environment.yml') }}-${{ hashFiles('linux-environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment
         run: |
           mamba env update -n ${{ env.env_name }} -f environment.yml
-          mamba env update -n ${{ env.env_name }} --file test-environment.yml
+          mamba env update -n ${{ env.env_name }} --file linux-environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Dump conda environment

--- a/linux-environment.yml
+++ b/linux-environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - pkg-config
   - openblas
   - openssl
+  - compilers=1.7.0


### PR DESCRIPTION
This change causes the linux CI build to use the `compilers=1.7.0` package, instead of the default compiler specified by the OS package.

On Ubuntu-20.04, the GCC version is fairly old (`gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0`) and was crashing with `Internal compiler error` on some of the pybind11 code. This will pin both Ubuntu-20 and Ubuntu-latest to use `gcc (conda-forge gcc 12.3.0-3) 12.3.0`.

For now I'm only doing this for linux builds, since my current assumption is that windows/mac consumers will already have the vendor-provided toolchain installed. (And no issues have arisen with those so far).