### PR TITLE
Fix specification of C++ standard on `span_test`

### DIFF
--- a/components/runtime/tests/CMakeLists.txt
+++ b/components/runtime/tests/CMakeLists.txt
@@ -3,6 +3,18 @@ add_executable(span_test span_test.cc)
 target_link_libraries(span_test gtest_main)
 target_link_libraries(span_test wf-runtime eigen fmt::fmt-header-only)
 target_compile_features(span_test PRIVATE cxx_std_14)
+
+# `cxx_std_14` does not force specification of -std=c++14 on gcc, so manually
+# specify it here. This is to minimize cases of accidentally using features that
+# are not actually supported.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(span_test PRIVATE -std=c++14)
+elseif(MSVC)
+  target_compile_options(span_test PRIVATE /Zc:__cplusplus)
+endif()
 target_compile_options(span_test PRIVATE ${SHARED_WARNING_FLAGS})
+
+# Enable support for Eigen --> span conversion so we can test it.
 target_compile_definitions(span_test PRIVATE -DMATH_SPAN_EIGEN_SUPPORT)
+
 add_test(span_test span_test)

--- a/components/runtime/tests/span_test.cc
+++ b/components/runtime/tests/span_test.cc
@@ -1,6 +1,8 @@
 // Copyright 2023 Gareth Cross
 #include "span_test_assertions.h"
 
+static_assert(__cplusplus == 201402L, "This test should be compiled with C++14");
+
 namespace wf {
 
 // Equality operator for spans of the same type.


### PR DESCRIPTION
It looks like under GCC12 the default is C++17, but cmake does not specify `-std=c++14` or `-std=gnu++14` automatically.

- On MSVC2022, c++14 is the default.
- On AppleClang 15, cmake adds `-std=gnu++14` automatically.

This change forces specification of `-std=c++14` when using GCC so that the correct (older) version is used for this particular test.