### PR TITLE
Rename MatrixExpr -> matrix_expr

### DIFF
--- a/components/core/benchmarks/bench_code_generation.cc
+++ b/components/core/benchmarks/bench_code_generation.cc
@@ -21,7 +21,7 @@ auto quaternion_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<
 
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
-  const MatrixExpr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
   const quaternion q_interp =
       q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);
 

--- a/components/core/benchmarks/bench_jacobian.cc
+++ b/components/core/benchmarks/bench_jacobian.cc
@@ -12,12 +12,12 @@ static void BM_QuaternionInterpolateJacobian(benchmark::State& state) {
   const quaternion q0 = quaternion::from_name_prefix("q0");
   const quaternion q1 = quaternion::from_name_prefix("q1");
   const Expr alpha{"alpha"};
-  const MatrixExpr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
   const quaternion q_interp =
       q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);
 
   for (auto _ : state) {
-    MatrixExpr output = q_interp.to_vector_wxyz().jacobian(q0.to_vector_wxyz());
+    matrix_expr output = q_interp.to_vector_wxyz().jacobian(q0.to_vector_wxyz());
     benchmark::DoNotOptimize(output);
   }
 }

--- a/components/core/test_support/wf_test_support/eigen_test_macros.h
+++ b/components/core/test_support/wf_test_support/eigen_test_macros.h
@@ -57,8 +57,8 @@ testing::AssertionResult expect_eigen_near(const std::string_view name_a,
 }
 
 // Construct an eigen matrix from a matrix expr by evaluating and converting to floats.
-inline Eigen::MatrixXd eigen_matrix_from_matrix_expr(const MatrixExpr& m) {
-  MatrixExpr m_eval = m.eval();
+inline Eigen::MatrixXd eigen_matrix_from_matrix_expr(const matrix_expr& m) {
+  matrix_expr m_eval = m.eval();
   Eigen::MatrixXd result{m_eval.rows(), m_eval.cols()};
   for (index_t i = 0; i < result.rows(); ++i) {
     for (index_t j = 0; j < result.cols(); ++j) {

--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -88,7 +88,7 @@ struct compute_function_output_struct<Expr> {
 template <index_t Rows, index_t Cols>
 struct compute_function_output_struct<ta::static_matrix<Rows, Cols>> {
   Eigen::Matrix<double, Rows, Cols> operator()(numeric_function_evaluator& evaluator,
-                                               const MatrixExpr& input, const matrix_type&) const {
+                                               const matrix_expr& input, const matrix_type&) const {
     WF_ASSERT_EQUAL(input.rows(), Rows);
     WF_ASSERT_EQUAL(input.cols(), Cols);
     Eigen::Matrix<double, Rows, Cols> output;
@@ -147,7 +147,7 @@ struct collect_function_input<Expr> {
   }
 };
 
-// Convert eigen matrices to MatrixExpr.
+// Convert eigen matrices to matrix_expr.
 template <index_t Rows, index_t Cols>
 struct collect_function_input<type_annotations::static_matrix<Rows, Cols>> {
   static_assert(Rows > 0);

--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -44,8 +44,8 @@ struct convert_assertion_argument<T, std::enable_if_t<std::is_convertible_v<T, E
   Expr operator()(const T& arg) const { return static_cast<Expr>(arg); }
 };
 template <>
-struct convert_assertion_argument<MatrixExpr> {
-  MatrixExpr operator()(const MatrixExpr& arg) const { return arg; }
+struct convert_assertion_argument<matrix_expr> {
+  matrix_expr operator()(const matrix_expr& arg) const { return arg; }
 };
 template <>
 struct convert_assertion_argument<compound_expr> {

--- a/components/core/tests/ir_builder_test.cc
+++ b/components/core/tests/ir_builder_test.cc
@@ -458,7 +458,7 @@ TEST(IrTest, TestMatrixExpressions2) {
         for (int i = 0; i < 16; ++i) {
           expressions.push_back(where(x > 0, pow(y, i), pow(z, 16 - z)));
         }
-        return ta::static_matrix<4, 4>{MatrixExpr::create(4, 4, std::move(expressions))};
+        return ta::static_matrix<4, 4>{matrix_expr::create(4, 4, std::move(expressions))};
       },
       "func", arg("x"), arg("y"), arg("z"));
 
@@ -572,7 +572,7 @@ TEST(IrTest, TestExternalFunction2) {
   auto [expected_expressions, ir] = create_ir(
       [](Expr x, Expr y) {
         using namespace matrix_operator_overloads;
-        const MatrixExpr m = custom_func_2::call(x + 2, y / 3);
+        const matrix_expr m = custom_func_2::call(x + 2, y / 3);
         return ta::static_matrix<2, 4>(
             m + make_matrix(2, 4, x * y, cos(y), 0, -2, -5 * x - sin(y), 1, 0, x * y));
       },

--- a/components/core/tests/limits_test.cc
+++ b/components/core/tests/limits_test.cc
@@ -267,10 +267,10 @@ TEST(LimitsTest, TestMatrixLimitsQuaternion) {
   ASSERT_IDENTICAL(make_vector(1, 0, 0, 0), limit(Q_subbed.to_vector_wxyz(), t).value());
 
   // Take the derivative wrt the rotation vector params:
-  const MatrixExpr Q_diff_subbed =
+  const matrix_expr Q_diff_subbed =
       Q.to_vector_wxyz().jacobian({x0, y0, z0}).subs(x0, x * t).subs(y0, y * t).subs(z0, z * t);
 
-  const MatrixExpr Q_diff_subbed_expected =
+  const matrix_expr Q_diff_subbed_expected =
       make_matrix(4, 3, 0, 0, 0, 1 / 2_s, 0, 0, 0, 1 / 2_s, 0, 0, 0, 1 / 2_s);
   ASSERT_IDENTICAL(Q_diff_subbed_expected, limit(Q_diff_subbed, t).value());
 }
@@ -282,19 +282,19 @@ TEST(LimitsTest, TestMatrixLimitsRotation) {
   const Expr t{"t", number_set::real_non_negative};
 
   const quaternion Q = quaternion::from_rotation_vector(x0, y0, z0, std::nullopt);
-  const MatrixExpr R = Q.to_rotation_matrix();
+  const matrix_expr R = Q.to_rotation_matrix();
 
-  const MatrixExpr R_subbed = R.subs(x0, x * t).subs(y0, y * t).subs(z0, z * t);
+  const matrix_expr R_subbed = R.subs(x0, x * t).subs(y0, y * t).subs(z0, z * t);
   ASSERT_IDENTICAL(make_identity(3), limit(R_subbed, t).value());
 
   // Do the derivative of the rotation elements wrt the rotation vector:
-  const MatrixExpr R_diff =
+  const matrix_expr R_diff =
       vectorize_matrix(R).jacobian({x0, y0, z0}).subs(x0, x * t).subs(y0, y * t).subs(z0, z * t);
 
   // clang-format off
   // Section 10.3.1.1 of "A tutorial on SE(3) transformation parameterizations
   //   and on-manifold optimization", J.L. Blanco
-  const MatrixExpr R_diff_expected = make_matrix(9, 3,
+  const matrix_expr R_diff_expected = make_matrix(9, 3,
                                                  0,  0,  0,
                                                  0,  0,  1,
                                                  0, -1,  0,
@@ -313,16 +313,16 @@ TEST(LimitsTest, TestMatrixLimitsQuaternionToVector) {
   const Expr t{"t", number_set::real_non_negative};
 
   // Take the limit as the quaternion approaches identity:
-  const MatrixExpr J = quaternion{w, x, y, z}
-                           .to_rotation_vector(std::nullopt)
-                           .jacobian({w, x, y, z})
-                           .subs(w, 1 - w * t)
-                           .subs(x, x * t)
-                           .subs(y, y * t)
-                           .subs(z, z * t)
-                           .collect({t});
+  const matrix_expr J = quaternion{w, x, y, z}
+                            .to_rotation_vector(std::nullopt)
+                            .jacobian({w, x, y, z})
+                            .subs(w, 1 - w * t)
+                            .subs(x, x * t)
+                            .subs(y, y * t)
+                            .subs(z, z * t)
+                            .collect({t});
 
-  const std::optional<MatrixExpr> J_lim = limit(J, t);
+  const std::optional<matrix_expr> J_lim = limit(J, t);
   ASSERT_TRUE(J_lim.has_value());
   ASSERT_IDENTICAL(make_matrix(3, 4, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2), *J_lim);
 }
@@ -331,8 +331,8 @@ TEST(LimitsTest, TestJacobianSo3) {
   const auto [x, y, z] = make_symbols("x", "y", "z");
   const Expr t{"t", number_set::real_non_negative};
   // Should converge to identify as norm of `w` goes to zero:
-  const MatrixExpr J = left_jacobian_of_so3(make_vector(x * t, y * t, z * t), std::nullopt);
-  const std::optional<MatrixExpr> J_lim = limit(J, t);
+  const matrix_expr J = left_jacobian_of_so3(make_vector(x * t, y * t, z * t), std::nullopt);
+  const std::optional<matrix_expr> J_lim = limit(J, t);
   ASSERT_TRUE(J_lim.has_value());
   ASSERT_IDENTICAL(make_identity(3), *J_lim);
 }

--- a/components/core/tests/substitute_test.cc
+++ b/components/core/tests/substitute_test.cc
@@ -164,7 +164,7 @@ TEST(SubstituteTest, TestMultiplications) {
 
 TEST(SubstituteTest, TestMatrix) {
   const auto [a, b, c] = make_symbols("a", "b", "c");
-  const MatrixExpr m0 = make_vector(a + b, c + sin(b), 22 + c);
+  const matrix_expr m0 = make_vector(a + b, c + sin(b), 22 + c);
   ASSERT_IDENTICAL(make_vector(a - log(c), c - sin(log(c)), 22 + c), m0.subs(b, -log(c)));
 }
 

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -22,7 +22,7 @@ inline Expr simple_multiply_add(Expr x, Expr y, Expr z) { return x * y + z; }
 // to the angle.
 inline auto vector_rotation_2d(Expr theta, ta::static_matrix<2, 1> v) {
   using namespace matrix_operator_overloads;
-  MatrixExpr R = make_matrix(2, 2, cos(theta), -sin(theta), sin(theta), cos(theta));
+  matrix_expr R = make_matrix(2, 2, cos(theta), -sin(theta), sin(theta), cos(theta));
   ta::static_matrix<2, 1> v_rot{R * v};
   ta::static_matrix<2, 1> v_dot_D_theta{v_rot.inner().diff(theta)};
   return std::make_tuple(output_arg("v_rot", v_rot), optional_output_arg("D_theta", v_dot_D_theta));
@@ -76,8 +76,8 @@ inline auto nested_conditionals_2(Expr x, Expr y) {
 // Create a rotation matrix from a Rodrigues vector, and the 9x3 Jacobian of the rotation matrix
 // elements with respect to the vector.
 inline auto create_rotation_matrix(ta::static_matrix<3, 1> w) {
-  MatrixExpr R = quaternion::from_rotation_vector(w.inner(), 1.0e-16).to_rotation_matrix();
-  MatrixExpr R_diff = vectorize_matrix(R).jacobian(w);
+  matrix_expr R = quaternion::from_rotation_vector(w.inner(), 1.0e-16).to_rotation_matrix();
+  matrix_expr R_diff = vectorize_matrix(R).jacobian(w);
   return std::make_tuple(output_arg("R", ta::static_matrix<3, 3>{R}),
                          optional_output_arg("R_D_w", ta::static_matrix<9, 3>{R_diff}));
 }
@@ -173,7 +173,7 @@ struct external_function_2
 
 inline auto external_function_call_2(ta::static_matrix<2, 1> u, ta::static_matrix<2, 1> v) {
   // clang-format off
-  const MatrixExpr m = make_matrix(2, 3,
+  const matrix_expr m = make_matrix(2, 3,
     u[0] - 2.0, pow(u[1], 2), 1,
     v[0], pow(v[1] + 1.0, 2), 1);
   // clang-format on

--- a/components/core/wf/code_generation/declare_external_function.h
+++ b/components/core/wf/code_generation/declare_external_function.h
@@ -38,7 +38,7 @@ class declare_external_function {
     zip_tuples(
         [&captured_args](auto arg, const auto& arg_type) {
           using T = std::decay_t<decltype(arg)>;
-          if constexpr (std::is_same_v<T, Expr> || std::is_same_v<T, MatrixExpr> ||
+          if constexpr (std::is_same_v<T, Expr> || std::is_same_v<T, matrix_expr> ||
                         type_annotations::is_static_matrix_v<T>) {
             captured_args.emplace_back(std::move(arg));
           } else if constexpr (std::is_constructible_v<Expr, T>) {
@@ -60,9 +60,9 @@ class declare_external_function {
     if constexpr (std::is_same_v<ReturnType, Expr>) {
       // Get single element from the compound expression:
       return ReturnType{std::get<Expr>(invoke_result)};
-    } else if constexpr (std::is_same_v<ReturnType, MatrixExpr> ||
+    } else if constexpr (std::is_same_v<ReturnType, matrix_expr> ||
                          type_annotations::is_static_matrix_v<ReturnType>) {
-      return ReturnType{std::get<MatrixExpr>(invoke_result)};
+      return ReturnType{std::get<matrix_expr>(invoke_result)};
     } else if constexpr (implements_custom_type_registrant_v<ReturnType>) {
       const custom_type& type = description.return_type_as<custom_type>();
       const std::vector<Expr> elements =

--- a/components/core/wf/code_generation/expr_from_ir.cc
+++ b/components/core/wf/code_generation/expr_from_ir.cc
@@ -37,7 +37,7 @@ class castable_variant {
 // Convert the IR operations back to expressions.
 // This is supported so we can do round-trip tests.
 struct expression_from_ir_visitor {
-  using expr_variant = castable_variant<Expr, MatrixExpr, compound_expr>;
+  using expr_variant = castable_variant<Expr, matrix_expr, compound_expr>;
 
   explicit expression_from_ir_visitor(std::unordered_map<std::string, bool>&& output_arg_exists)
       : output_arg_exists_(std::move(output_arg_exists)) {
@@ -143,7 +143,7 @@ struct expression_from_ir_visitor {
     return overloaded_visit(
         construct.type(),
         [&](const matrix_type& mat) -> expr_variant {
-          return MatrixExpr::create(mat.rows(), mat.cols(), std::move(args_converted));
+          return matrix_expr::create(mat.rows(), mat.cols(), std::move(args_converted));
         },
         [&](const custom_type& custom) -> expr_variant {
           return custom_type_construction::create(custom, std::move(args_converted));

--- a/components/core/wf/code_generation/function_description.cc
+++ b/components/core/wf/code_generation/function_description.cc
@@ -23,11 +23,11 @@ bool is_identical_struct<argument>::operator()(const argument& a, const argument
 function_description::function_description(std::string name) noexcept
     : impl_(std::make_shared<impl>(std::move(name))) {}
 
-std::variant<Expr, MatrixExpr, compound_expr> function_description::add_input_argument(
+std::variant<Expr, matrix_expr, compound_expr> function_description::add_input_argument(
     const std::string_view name, type_variant type) {
   const argument& arg = add_argument(name, std::move(type), argument_direction::input);
 
-  using return_type = std::variant<Expr, MatrixExpr, compound_expr>;
+  using return_type = std::variant<Expr, matrix_expr, compound_expr>;
   return std::visit(
       [&](const auto& type_concrete) -> return_type {
         return detail::create_function_input(type_concrete, arg.index());

--- a/components/core/wf/code_generation/function_description.h
+++ b/components/core/wf/code_generation/function_description.h
@@ -100,8 +100,8 @@ class function_description {
   // Returns the argument that the python side should pass to the user method.
   // For custom types, we return a vector of expressions and the python side must map these to
   // fields on the user's custom type.
-  std::variant<Expr, MatrixExpr, compound_expr> add_input_argument(std::string_view name,
-                                                                   type_variant type);
+  std::variant<Expr, matrix_expr, compound_expr> add_input_argument(std::string_view name,
+                                                                    type_variant type);
 
   // Record an output.
   void add_output_argument(std::string_view name, type_variant type, bool is_optional,

--- a/components/core/wf/code_generation/function_evaluator.h
+++ b/components/core/wf/code_generation/function_evaluator.h
@@ -89,7 +89,7 @@ auto invoke_with_symbolic_inputs(Callable&& callable, const std::tuple<ArgTypes.
 
   if constexpr (is_tuple_v<return_type>) {
     return return_expr;
-  } else if constexpr (is_return_value<return_type>::value) {
+  } else if constexpr (is_output_arg_or_return_value_v<return_type>) {
     return std::make_tuple(std::move(return_expr));
   } else {
     return std::make_tuple(return_value(std::move(return_expr)));

--- a/components/core/wf/code_generation/ir_builder.cc
+++ b/components/core/wf/code_generation/ir_builder.cc
@@ -296,7 +296,7 @@ struct mul_add_count_visitor {
   }
 
   void operator()(const Expr& x) { return visit(x, *this); }
-  void operator()(const MatrixExpr& m) {
+  void operator()(const matrix_expr& m) {
     for (const Expr& x : m.as_matrix()) {
       visit(x, *this);
     }
@@ -596,7 +596,7 @@ class ir_form_visitor {
     return push_operation(ir::load{f}, code_numeric_type::floating_point);
   }
 
-  ir::value_ptr operator()(const MatrixExpr& m) {
+  ir::value_ptr operator()(const matrix_expr& m) {
     return push_operation(
         ir::construct(matrix_type{m.rows(), m.cols()}), matrix_type{m.rows(), m.cols()},
         transform_map<ir::value::operands_container>(m.as_matrix(), [this](const Expr& arg) {

--- a/components/core/wf/code_generation/type_registry.cc
+++ b/components/core/wf/code_generation/type_registry.cc
@@ -18,8 +18,8 @@ static std::vector<Expr> create_function_args(const std::size_t arg_index, const
   return expressions;
 }
 
-MatrixExpr create_function_input(const matrix_type& mat, const std::size_t arg_index) {
-  return MatrixExpr::create(mat.rows(), mat.cols(), create_function_args(arg_index, mat.size()));
+matrix_expr create_function_input(const matrix_type& mat, const std::size_t arg_index) {
+  return matrix_expr::create(mat.rows(), mat.cols(), create_function_args(arg_index, mat.size()));
 }
 
 // TODO: The numeric type information needs to be propagate to the IR here.
@@ -27,7 +27,7 @@ std::vector<Expr> extract_function_output(const scalar_type&, const Expr& value)
   return std::vector(1, value);
 }
 
-std::vector<Expr> extract_function_output(const matrix_type&, const MatrixExpr& value) {
+std::vector<Expr> extract_function_output(const matrix_type&, const matrix_expr& value) {
   return value.to_vector();
 }
 

--- a/components/core/wf/code_generation/type_registry.h
+++ b/components/core/wf/code_generation/type_registry.h
@@ -85,7 +85,7 @@ class native_field_accessor_member_ptr final : public native_field_accessor_type
 
 namespace detail {
 // The purpose of record_type is to convert from actual C++ types to our runtime representations.
-// For example, Expr -> scalar_type, MatrixExpr -> matrix_type.
+// For example, Expr -> scalar_type, matrix_expr -> matrix_type.
 // We use this to scrape a c++ function signature and record type information for code-generation.
 template <typename T, typename = void>
 struct record_type;
@@ -234,7 +234,7 @@ auto record_arg_types(custom_type_registry& registry, type_list<Ts...>) {
 Expr create_function_input(const scalar_type& scalar, std::size_t arg_index);
 
 // Create matrix input required to evalute a symbolic function.
-MatrixExpr create_function_input(const matrix_type& mat, std::size_t arg_index);
+matrix_expr create_function_input(const matrix_type& mat, std::size_t arg_index);
 
 // Determine the size of a custom type, and create enough variables to fill it.
 inline compound_expr create_function_input(const custom_type& custom, const std::size_t arg_index) {
@@ -256,7 +256,7 @@ T create_function_input(const annotated_custom_type<T>& custom, const std::size_
 std::vector<Expr> extract_function_output(const scalar_type& scalar, const Expr& value);
 
 // Copy output from matrix expression into a vector.
-std::vector<Expr> extract_function_output(const matrix_type& mat, const MatrixExpr& value);
+std::vector<Expr> extract_function_output(const matrix_type& mat, const matrix_expr& value);
 
 // Copy output from a custom struct into a vector.
 template <typename T>
@@ -302,7 +302,7 @@ absl::Span<const Expr> native_field_accessor_member_ptr<StructType, FieldType, U
     const matrix_type& mat = member_type_;
     WF_ASSERT_GREATER_OR_EQ(input.size(), mat.size());
     const auto begin = input.begin();
-    object.*member_ptr_ = MatrixExpr::create(mat.rows(), mat.cols(), begin, begin + mat.size());
+    object.*member_ptr_ = matrix_expr::create(mat.rows(), mat.cols(), begin, begin + mat.size());
     return input.subspan(mat.size());
   } else {
     auto [instance, output_span] = member_type_.initialize_from_expressions(input);
@@ -317,7 +317,7 @@ void native_field_accessor_member_ptr<StructType, FieldType, U>::get(
   if constexpr (std::is_same_v<U, scalar_type>) {
     output.push_back(object.*member_ptr_);
   } else if constexpr (std::is_same_v<U, matrix_type>) {
-    const matrix& mat = static_cast<const MatrixExpr&>(object.*member_ptr_).as_matrix();
+    const matrix& mat = static_cast<const matrix_expr&>(object.*member_ptr_).as_matrix();
     output.insert(output.end(), mat.begin(), mat.end());
   } else {
     // annotated_custom_type

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -19,7 +19,7 @@ template <typename T>
 struct is_function_of_visitor {
   explicit is_function_of_visitor(const T& target) noexcept : target_(target) {}
 
-  bool operator()(const MatrixExpr& mat) const {
+  bool operator()(const matrix_expr& mat) const {
     const matrix& m = mat.as_matrix();
     return std::any_of(m.begin(), m.end(), [this](const Expr& x) { return visit(x, *this); });
   }
@@ -255,8 +255,8 @@ Expr diff(const Expr& function, const Expr& var, const int reps,
   return result;
 }
 
-MatrixExpr jacobian(const absl::Span<const Expr> functions, const absl::Span<const Expr> vars,
-                    const non_differentiable_behavior behavior) {
+matrix_expr jacobian(const absl::Span<const Expr> functions, const absl::Span<const Expr> vars,
+                     const non_differentiable_behavior behavior) {
   if (functions.empty()) {
     throw type_error("Need at least one function to differentiate.");
   }
@@ -280,8 +280,8 @@ MatrixExpr jacobian(const absl::Span<const Expr> functions, const absl::Span<con
     }
   }
 
-  return MatrixExpr::create(static_cast<index_t>(functions.size()),
-                            static_cast<index_t>(vars.size()), std::move(result));
+  return matrix_expr::create(static_cast<index_t>(functions.size()),
+                             static_cast<index_t>(vars.size()), std::move(result));
 }
 
 }  // namespace wf

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -105,7 +105,7 @@ class Expr final : public expression_base<Expr, scalar_meta_type> {
   Expr eval() const { return wf::evaluate(*this); }
 
  protected:
-  friend class MatrixExpr;
+  friend class matrix_expr;
 
   // Construct constant from float.
   static Expr from_float(double x);

--- a/components/core/wf/external_function.cc
+++ b/components/core/wf/external_function.cc
@@ -77,7 +77,7 @@ any_expression external_function::create_invocation(std::vector<any_expression> 
           // TODO: Check numeric type here.
           return scalar_type(code_numeric_type::floating_point);
         },
-        [&](const MatrixExpr& matrix) -> type_variant {
+        [&](const matrix_expr& matrix) -> type_variant {
           return matrix_type(matrix.rows(), matrix.cols());
         },
         [&](const compound_expr& expr) { return get_compound_type(expr); });
@@ -106,8 +106,8 @@ any_expression external_function::create_invocation(std::vector<any_expression> 
         return Expr(std::in_place_type_t<compound_expression_element>{}, std::move(invocation), 0);
       },
       [&](const matrix_type& mat) -> any_expression {
-        return MatrixExpr::create(mat.rows(), mat.cols(),
-                                  create_expression_elements(invocation, mat.size()));
+        return matrix_expr::create(mat.rows(), mat.cols(),
+                                   create_expression_elements(invocation, mat.size()));
       },
       [&](const custom_type&) -> any_expression { return std::move(invocation); });
 }

--- a/components/core/wf/external_function.h
+++ b/components/core/wf/external_function.h
@@ -10,7 +10,7 @@ namespace wf {
 
 // Variant of possible expression types.
 // TODO: This should be declared somewhere more general.
-using any_expression = std::variant<Expr, MatrixExpr, compound_expr>;
+using any_expression = std::variant<Expr, matrix_expr, compound_expr>;
 
 template <>
 struct hash_struct<any_expression> : hash_variant<any_expression> {};

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -374,7 +374,7 @@ Expr where(const Expr& condition, const Expr& if_true, const Expr& if_false) {
   return conditional::create(condition, if_true, if_false);
 }
 
-MatrixExpr where(const Expr& condition, const MatrixExpr& if_true, const MatrixExpr& if_false) {
+matrix_expr where(const Expr& condition, const matrix_expr& if_true, const matrix_expr& if_false) {
   const matrix& mat_true = if_true.as_matrix();
   const matrix& mat_false = if_false.as_matrix();
 
@@ -392,7 +392,7 @@ MatrixExpr where(const Expr& condition, const MatrixExpr& if_true, const MatrixE
   std::transform(mat_true.begin(), mat_true.end(), mat_false.begin(),
                  std::back_inserter(conditionals),
                  [&](const Expr& a, const Expr& b) { return where(condition, a, b); });
-  return MatrixExpr::create(mat_true.rows(), mat_true.cols(), std::move(conditionals));
+  return matrix_expr::create(mat_true.rows(), mat_true.cols(), std::move(conditionals));
 }
 
 struct bool_cast_visitor {

--- a/components/core/wf/functions.h
+++ b/components/core/wf/functions.h
@@ -51,7 +51,7 @@ Expr min(const Expr& a, const Expr& b);
 Expr where(const Expr& condition, const Expr& if_true, const Expr& if_false);
 
 // Conditional over a matrix w/ scalar condition.
-MatrixExpr where(const Expr& condition, const MatrixExpr& if_true, const MatrixExpr& if_false);
+matrix_expr where(const Expr& condition, const matrix_expr& if_true, const matrix_expr& if_false);
 
 // Cast the provided expression from a boolean to an integer.
 Expr cast_int_from_bool(const Expr& bool_expression);

--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -21,7 +21,7 @@ class quaternion {
   quaternion() : quaternion(constants::one, constants::zero, constants::zero, constants::zero) {}
 
   // Construct from a vector ordered `wxyz`.
-  static quaternion from_vector_wxyz(const MatrixExpr& q) {
+  static quaternion from_vector_wxyz(const matrix_expr& q) {
     if (q.rows() != 4 || q.cols() != 1) {
       throw dimension_error("Quaternion storage must be 4x1. Received [{} x {}]", q.rows(),
                             q.cols());
@@ -30,7 +30,7 @@ class quaternion {
   }
 
   // Construct from a vector ordered `xyzw` (scalar last).
-  static quaternion from_vector_xyzw(const MatrixExpr& q) {
+  static quaternion from_vector_xyzw(const matrix_expr& q) {
     if (q.rows() != 4 || q.cols() != 1) {
       throw dimension_error("Quaternion storage must be 4x1. Received [{} x {}]", q.rows(),
                             q.cols());
@@ -57,10 +57,10 @@ class quaternion {
   }
 
   // Convert to a column vector in [w,x,y,z] order.
-  MatrixExpr to_vector_wxyz() const;
+  matrix_expr to_vector_wxyz() const;
 
   // Convert to a column vector in [x,y,z,w] order.
-  MatrixExpr to_vector_xyzw() const;
+  matrix_expr to_vector_xyzw() const;
 
   // Create a new quaternion by substituting.
   quaternion subs(const Expr& target, const Expr& replacement) const;
@@ -90,7 +90,7 @@ class quaternion {
 
   // Convert a unit-norm to a rotation matrix. If the input does not have unit norm, the
   // result will not be a valid member of SO(3).
-  MatrixExpr to_rotation_matrix() const;
+  matrix_expr to_rotation_matrix() const;
 
   // Construct quaternion from axis and angle.
   // It is expected that [vx, vy, vz] form a unit vector. Angle is in radians.
@@ -99,7 +99,7 @@ class quaternion {
 
   // Construct quaternion from axis and angle. It is expected that `v` has unit norm.
   // Angle is in radians.
-  static quaternion from_angle_axis(const Expr& angle, const MatrixExpr& v);
+  static quaternion from_angle_axis(const Expr& angle, const matrix_expr& v);
 
   // Construct quaternion from a rotation vector.
   // When the rotation angle < epsilon, the first order taylor series is used instead.
@@ -108,7 +108,7 @@ class quaternion {
 
   // Construct quaternion from a rotation vector.
   // When the rotation angle < epsilon, the first order taylor series is used instead.
-  static quaternion from_rotation_vector(const MatrixExpr& v, std::optional<Expr> epsilon);
+  static quaternion from_rotation_vector(const matrix_expr& v, std::optional<Expr> epsilon);
 
   // Convenience method for X-axis rotation. Angle is in radians.
   static quaternion from_x_angle(const Expr& angle) {
@@ -128,21 +128,21 @@ class quaternion {
   // Convert to axis-angle representation.
   // Angle is converted into the range [0, pi]. If the norm of the vector component falls below
   // `epsilon`, the rotation cannot be recovered, and we return a zero angle.
-  std::tuple<Expr, MatrixExpr> to_angle_axis(std::optional<Expr> epsilon) const;
+  std::tuple<Expr, matrix_expr> to_angle_axis(std::optional<Expr> epsilon) const;
 
   // Convert quaternion to a Rodrigues rotation vector.
   // When the rotation angle < epsilon, the first order taylor series is used instead.
-  MatrixExpr to_rotation_vector(std::optional<Expr> epsilon) const;
+  matrix_expr to_rotation_vector(std::optional<Expr> epsilon) const;
 
   // Construct a quaternion from a rotation matrix using Caley's method.
   // If `R` is not a member of SO(3), the behavior is undefined. See:
   // Section 3.5 of: "A survey on the Computation of Quaternions from Rotation Matrices"
   // By S. Sarabandi and F. Thomas
-  static quaternion from_rotation_matrix(const MatrixExpr& R_in);
+  static quaternion from_rotation_matrix(const matrix_expr& R_in);
 
   // Compute 4xN jacobian of this quaternion with respect to the `N` input variables `vars`.
   // The rows of the jacobian are ordered in the storage order of the quaternion: [w,x,y,z].
-  MatrixExpr jacobian(
+  matrix_expr jacobian(
       absl::Span<const Expr> vars,
       non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
     return wf::jacobian(wxyz(), vars, behavior);
@@ -150,14 +150,14 @@ class quaternion {
 
   // Compute the 4xN jacobian of this quaternion with respect to the `Nx1` column vector `vars`.
   // The rows of the jacobian are ordered in the storage order of the quaternion: [w,x,y,z].
-  MatrixExpr jacobian(const MatrixExpr& vars, non_differentiable_behavior behavior =
-                                                  non_differentiable_behavior::constant) const;
+  matrix_expr jacobian(const matrix_expr& vars, non_differentiable_behavior behavior =
+                                                    non_differentiable_behavior::constant) const;
 
   // Compute the 4x4 jacobian of this quaternion with respect to the variables in quaternion `vars`.
   // The rows and columns of the output jacobian are ordered in the storage order of the quaternion:
   // [w,x,y,z].
-  MatrixExpr jacobian(const quaternion& vars, non_differentiable_behavior behavior =
-                                                  non_differentiable_behavior::constant) const {
+  matrix_expr jacobian(const quaternion& vars, non_differentiable_behavior behavior =
+                                                   non_differentiable_behavior::constant) const {
     return jacobian(vars.wxyz(), behavior);
   }
 
@@ -168,7 +168,7 @@ class quaternion {
   //
   // Where `Q` is this quaternion, and `w` is an infinitesimal rotation vector, retracted on the
   // right side of Q. It is assumed that `Q` has unit norm, otherwise the result is undefined.
-  MatrixExpr right_retract_derivative() const;
+  matrix_expr right_retract_derivative() const;
 
   // Compute the 3x4 tangent-space derivative of the operation:
   //
@@ -176,7 +176,7 @@ class quaternion {
   //
   // Where `Q` is this (unit norm) quaternion, and Q^T denotes the conjugation operation. dQ is an
   // infinitesimal additive perturbation to the quaternion.
-  MatrixExpr right_local_coordinates_derivative() const;
+  matrix_expr right_local_coordinates_derivative() const;
 
  private:
   // Quaternion elements in order [w, x, y, z].
@@ -197,6 +197,6 @@ quaternion operator*(const quaternion& a, const quaternion& b);
 // You can obtain the right jacobian of SO(3) by transposing this quantity.
 //
 // When the norm of `w` falls below `epsilon`, the small angle approximation is used.
-MatrixExpr left_jacobian_of_so3(const MatrixExpr& w, std::optional<Expr> epsilon);
+matrix_expr left_jacobian_of_so3(const matrix_expr& w, std::optional<Expr> epsilon);
 
 }  // namespace wf

--- a/components/core/wf/limits.cc
+++ b/components/core/wf/limits.cc
@@ -537,7 +537,7 @@ std::optional<Expr> limit(const Expr& f_of_x, const Expr& x) {
   return limit_visitor{x}.visit_no_inf(f_of_x);
 }
 
-std::optional<MatrixExpr> limit(const MatrixExpr& f_of_x, const Expr& x) {
+std::optional<matrix_expr> limit(const matrix_expr& f_of_x, const Expr& x) {
   if (!x.is_type<variable>()) {
     throw type_error(
         "Limit argument `x` must be a variable. Encountered expression of type `{}`: {}",
@@ -556,7 +556,7 @@ std::optional<MatrixExpr> limit(const MatrixExpr& f_of_x, const Expr& x) {
       values.push_back(std::move(*f_lim));
     }
   }
-  return MatrixExpr::create(f_of_x.rows(), f_of_x.cols(), std::move(values));
+  return matrix_expr::create(f_of_x.rows(), f_of_x.cols(), std::move(values));
 }
 
 }  // namespace wf

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -10,27 +10,27 @@ namespace wf {
 // Matrix type that stores a dense block of expressions. For context, this was originally
 // part of the `Expr` type hierarchy. However, this proved to be a mistake because the rules for
 // matrices are sufficiently different from scalars. For now, it is just a wrapper around a shared
-// ptr to `Matrix`. In future a symbolic matrix expression might exist, and then this will be more
+// ptr to `matrix`. In future a symbolic matrix expression might exist, and then this will be more
 // like the `Expr` type.
-class MatrixExpr {
+class matrix_expr {
  public:
   // Construct w/ matrix content.
-  explicit MatrixExpr(class matrix&& content);
+  explicit matrix_expr(class matrix&& content);
 
   // Static constructor: Create a dense matrix of expressions.
-  static MatrixExpr create(index_t rows, index_t cols, std::vector<Expr> args);
+  static matrix_expr create(index_t rows, index_t cols, std::vector<Expr> args);
 
   // Create from a pair of iterators.
   template <typename Iterator>
-  static MatrixExpr create(index_t rows, index_t cols, Iterator begin, Iterator end) {
+  static matrix_expr create(index_t rows, index_t cols, Iterator begin, Iterator end) {
     return create(rows, cols, std::vector<Expr>{begin, end});
   }
 
   // Test if the two expressions are identical.
-  bool is_identical_to(const MatrixExpr& other) const;
+  bool is_identical_to(const matrix_expr& other) const;
 
   // Test if the two expressions have the same underlying address.
-  bool has_same_address(const MatrixExpr& other) const {
+  bool has_same_address(const matrix_expr& other) const {
     return matrix_.get() == other.matrix_.get();
   }
 
@@ -44,35 +44,36 @@ class MatrixExpr {
   std::string to_expression_tree_string() const;
 
   // Negation operator.
-  MatrixExpr operator-() const;
+  matrix_expr operator-() const;
 
   // Differentiate with respect to a single variable. Reps defines how many derivatives to take.
   // The returned matrix is the element-wise derivative.
-  MatrixExpr diff(
+  matrix_expr diff(
       const Expr& var, int reps = 1,
       non_differentiable_behavior behavior = non_differentiable_behavior::constant) const;
 
   // Differentiate a vector with respect to another vector, producing a Jacobian.
   // If the input is an [N,1] vector and `vars` has M expressions, the result will be an NxM matrix.
   // Throws if `this` is not a column vector.
-  MatrixExpr jacobian(absl::Span<const Expr> vars, non_differentiable_behavior behavior =
-                                                       non_differentiable_behavior::constant) const;
+  matrix_expr jacobian(
+      absl::Span<const Expr> vars,
+      non_differentiable_behavior behavior = non_differentiable_behavior::constant) const;
 
-  // Version of `jacobian` that accepts `MatrixExpr` directly.
-  MatrixExpr jacobian(const MatrixExpr& vars, non_differentiable_behavior behavior =
-                                                  non_differentiable_behavior::constant) const;
+  // Version of `jacobian` that accepts `matrix_expr` directly.
+  matrix_expr jacobian(const matrix_expr& vars, non_differentiable_behavior behavior =
+                                                    non_differentiable_behavior::constant) const;
 
   // Distribute terms in this expression.
-  MatrixExpr distribute() const;
+  matrix_expr distribute() const;
 
   // Create a new expression by recursively substituting `replacement` for `target`.
-  MatrixExpr subs(const Expr& target, const Expr& replacement) const;
+  matrix_expr subs(const Expr& target, const Expr& replacement) const;
 
   // Collect terms in every element of this matrix.
-  MatrixExpr collect(absl::Span<const Expr> terms) const;
+  matrix_expr collect(absl::Span<const Expr> terms) const;
 
   // Evaluate to matrix of floats.
-  MatrixExpr eval() const;
+  matrix_expr eval() const;
 
   // Get # of rows.
   index_t rows() const;
@@ -92,16 +93,16 @@ class MatrixExpr {
   void set(index_t i, index_t j, const Expr& value);
 
   // Get a block of rows [start, start + length).
-  MatrixExpr get_block(index_t row, index_t col, index_t nrows, index_t ncols) const;
+  matrix_expr get_block(index_t row, index_t col, index_t nrows, index_t ncols) const;
 
   // Set a block of rows [start, start + length).
-  void set_block(index_t row, index_t col, index_t nrows, index_t ncols, const MatrixExpr& block);
+  void set_block(index_t row, index_t col, index_t nrows, index_t ncols, const matrix_expr& block);
 
   // Transpose the matrix.
-  [[nodiscard]] MatrixExpr transposed() const;
+  [[nodiscard]] matrix_expr transposed() const;
 
   // Reshape the matrix (returns a copy).
-  [[nodiscard]] MatrixExpr reshape(index_t nrows, index_t ncols) const;
+  [[nodiscard]] matrix_expr reshape(index_t nrows, index_t ncols) const;
 
   // Get the squared norm of the matrix.
   Expr squared_norm() const;
@@ -121,40 +122,40 @@ class MatrixExpr {
   std::shared_ptr<matrix> matrix_;
 };
 
-static_assert(std::is_move_assignable_v<MatrixExpr> && std::is_move_constructible_v<MatrixExpr>,
+static_assert(std::is_move_assignable_v<matrix_expr> && std::is_move_constructible_v<matrix_expr>,
               "Should be movable");
 
 // Hash matrix.
 template <>
-struct hash_struct<MatrixExpr> {
-  std::size_t operator()(const MatrixExpr& mat) const;
+struct hash_struct<matrix_expr> {
+  std::size_t operator()(const matrix_expr& mat) const;
 };
 
 // Relative order of matrices (first by dimensions, then by lexicographical order).
 template <>
-struct order_struct<MatrixExpr> {
-  relative_order operator()(const MatrixExpr& a, const MatrixExpr& b) const;
+struct order_struct<matrix_expr> {
+  relative_order operator()(const matrix_expr& a, const matrix_expr& b) const;
 };
 
 // Are two matrices identical.
 template <>
-struct is_identical_struct<MatrixExpr> {
-  bool operator()(const MatrixExpr& a, const MatrixExpr& b) const { return a.is_identical_to(b); }
+struct is_identical_struct<matrix_expr> {
+  bool operator()(const matrix_expr& a, const matrix_expr& b) const { return a.is_identical_to(b); }
 };
 
 // Math operators:
 namespace matrix_operator_overloads {
 
-MatrixExpr operator+(const MatrixExpr& a, const MatrixExpr& b);
-MatrixExpr operator-(const MatrixExpr& a, const MatrixExpr& b);
-MatrixExpr operator*(const MatrixExpr& a, const MatrixExpr& b);
-MatrixExpr operator*(const MatrixExpr& a, const Expr& b);
-inline MatrixExpr operator*(const Expr& a, const MatrixExpr& b) { return b * a; }
+matrix_expr operator+(const matrix_expr& a, const matrix_expr& b);
+matrix_expr operator-(const matrix_expr& a, const matrix_expr& b);
+matrix_expr operator*(const matrix_expr& a, const matrix_expr& b);
+matrix_expr operator*(const matrix_expr& a, const Expr& b);
+inline matrix_expr operator*(const Expr& a, const matrix_expr& b) { return b * a; }
 
 }  // namespace matrix_operator_overloads
 
 // ostream support
-inline std::ostream& operator<<(std::ostream& stream, const MatrixExpr& x) {
+inline std::ostream& operator<<(std::ostream& stream, const matrix_expr& x) {
   stream << x.to_string();
   return stream;
 }
@@ -163,11 +164,11 @@ inline std::ostream& operator<<(std::ostream& stream, const MatrixExpr& x) {
 
 // libfmt support:
 template <>
-struct fmt::formatter<wf::MatrixExpr> {
+struct fmt::formatter<wf::matrix_expr> {
   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const wf::MatrixExpr& x, FormatContext& ctx) const -> decltype(ctx.out()) {
+  auto format(const wf::matrix_expr& x, FormatContext& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", x.to_string());
   }
 };

--- a/components/core/wf/matrix_functions.h
+++ b/components/core/wf/matrix_functions.h
@@ -8,51 +8,51 @@ namespace wf {
 
 // Create a column vector from the arguments.
 template <typename... Ts>
-static MatrixExpr make_vector(Ts&&... args) {
-  return MatrixExpr::create(sizeof...(Ts), 1, {Expr{std::forward<Ts>(args)}...});
+static matrix_expr make_vector(Ts&&... args) {
+  return matrix_expr::create(sizeof...(Ts), 1, {Expr{std::forward<Ts>(args)}...});
 }
 
 // Create a row vector from the arguments.
 template <typename... Ts>
-static MatrixExpr make_row_vector(Ts&&... args) {
-  return MatrixExpr::create(1, sizeof...(Ts), {Expr{std::forward<Ts>(args)}...});
+static matrix_expr make_row_vector(Ts&&... args) {
+  return matrix_expr::create(1, sizeof...(Ts), {Expr{std::forward<Ts>(args)}...});
 }
 
 // Create a matrix from the arguments (args specified in row-major order).
 template <typename... Ts>
-static MatrixExpr make_matrix(index_t rows, index_t cols, Ts&&... args) {
-  return MatrixExpr::create(rows, cols, {Expr{std::forward<Ts>(args)}...});
+static matrix_expr make_matrix(index_t rows, index_t cols, Ts&&... args) {
+  return matrix_expr::create(rows, cols, {Expr{std::forward<Ts>(args)}...});
 }
 
 // Create a matrix of symbols.
-MatrixExpr make_matrix_of_symbols(std::string_view prefix, index_t rows, index_t cols);
+matrix_expr make_matrix_of_symbols(std::string_view prefix, index_t rows, index_t cols);
 
 // Create a matrix of zeros.
-MatrixExpr make_zeros(index_t rows, index_t cols);
+matrix_expr make_zeros(index_t rows, index_t cols);
 
 // Create an identity matrix.
-MatrixExpr make_identity(index_t rows);
+matrix_expr make_identity(index_t rows);
 
 // Create a vector by flattening a matrix in column-major order.
-MatrixExpr vectorize_matrix(const MatrixExpr& m);
+matrix_expr vectorize_matrix(const matrix_expr& m);
 
 // Horizontally stack matrices.
-MatrixExpr hstack(absl::Span<const MatrixExpr> values);
+matrix_expr hstack(absl::Span<const matrix_expr> values);
 
 // Vertically stack matrices.
-MatrixExpr vstack(absl::Span<const MatrixExpr> values);
+matrix_expr vstack(absl::Span<const matrix_expr> values);
 
 // Diagonally stack matrices (filling in off-diagonal elements with zero).
-MatrixExpr diagonal_stack(absl::Span<const MatrixExpr> values);
+matrix_expr diagonal_stack(absl::Span<const matrix_expr> values);
 
 // Perform full-pivoting gaussian elimination on a symbolic matrix.
 // Returns matrices [P, L, U, Q] such that: A = P*L*U*Q
 // Where `L` is lower triangular, `U` is upper triangular, and both `P` and `Q` are permutation
 // matrices.
-std::tuple<MatrixExpr, MatrixExpr, MatrixExpr, MatrixExpr> factorize_full_piv_lu(
-    const MatrixExpr& A);
+std::tuple<matrix_expr, matrix_expr, matrix_expr, matrix_expr> factorize_full_piv_lu(
+    const matrix_expr& A);
 
 // Compute determinant of a matrix. Only valid for square matrices.
-Expr determinant(const MatrixExpr& m);
+Expr determinant(const matrix_expr& m);
 
 }  // namespace wf

--- a/components/core/wf/operations.h
+++ b/components/core/wf/operations.h
@@ -7,7 +7,7 @@
 
 namespace wf {
 class Expr;
-class MatrixExpr;
+class matrix_expr;
 
 // Replace instances of `target` w/ `replacement` in the input expression tree `input`.
 // Implemented in substitute.cc
@@ -19,8 +19,8 @@ Expr substitute_variables(const Expr& input, absl::Span<const std::tuple<Expr, E
 
 // Replace all the [target, replacement] pairs in the input matrix expression tree `input`.
 // Every `target` must be a variable.
-MatrixExpr substitute_variables(const MatrixExpr& input,
-                                absl::Span<const std::tuple<Expr, Expr>> pairs);
+matrix_expr substitute_variables(const matrix_expr& input,
+                                 absl::Span<const std::tuple<Expr, Expr>> pairs);
 
 // Govern behavior of the derivative visitor when we encounter non-differentiable functions.
 // An example would be the round(x) function, which has derivatives:
@@ -41,8 +41,8 @@ Expr diff(const Expr& function, const Expr& var, int reps, non_differentiable_be
 
 // Compute the jacobian of the vector `functions` wrt the variables in `vars`.
 // If `functions` has length `N` and `vars` length `M`, the result will be NxM.
-MatrixExpr jacobian(absl::Span<const Expr> functions, absl::Span<const Expr> vars,
-                    non_differentiable_behavior behavior);
+matrix_expr jacobian(absl::Span<const Expr> functions, absl::Span<const Expr> vars,
+                     non_differentiable_behavior behavior);
 
 // Distribute over multiplications in the input expression.
 // Expands terms like: (a + b) * (c * d) --> a*c + a*d + b*c + b*d
@@ -70,7 +70,7 @@ std::optional<Expr> limit(const Expr& f_of_x, const Expr& x);
 // Take the limit of matrix-valued function `f_of_x` as `x` goes to 0 from the right.
 // The expression `x` must be a variable.
 // This feature is considered unstable.
-std::optional<MatrixExpr> limit(const MatrixExpr& f_of_x, const Expr& x);
+std::optional<matrix_expr> limit(const matrix_expr& f_of_x, const Expr& x);
 
 // Determine what set of numbers an expression belongs to.
 // Returns `NumberSet::unknown` if the set cannot be determined.

--- a/components/core/wf/output_annotations.h
+++ b/components/core/wf/output_annotations.h
@@ -22,7 +22,7 @@ class output_arg {
   constexpr output_arg(std::string_view name, U&& u, bool is_optional)
       : value_(std::forward<U>(u)), name_(name), is_optional_(is_optional) {}
 
-  // Access the output value. Typically, an `Expr` or `MatrixExpr`, etc.
+  // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.
   constexpr const T& value() const { return value_; }
 
   // Name of the argument.
@@ -60,7 +60,7 @@ class return_value {
   template <typename U, typename = enable_if_decayed_type_matches_t<U>>
   explicit return_value(U&& value) : value_(std::forward<U>(value)) {}
 
-  // Access the output value. Typically, an `Expr` or `MatrixExpr`, etc.
+  // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.
   constexpr const T& value() const { return value_; }
 
   // Convert to `output_arg`.

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -10,7 +10,7 @@
 namespace wf {
 
 void plain_formatter::operator()(const Expr& x) { return visit(x, *this); }
-void plain_formatter::operator()(const MatrixExpr& x) { operator()(x.as_matrix()); }
+void plain_formatter::operator()(const matrix_expr& x) { operator()(x.as_matrix()); }
 
 void plain_formatter::operator()(const addition& expr) {
   WF_ASSERT_GREATER_OR_EQ(expr.size(), 2);

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -9,7 +9,7 @@ namespace wf {
 class plain_formatter {
  public:
   void operator()(const Expr& x);
-  void operator()(const MatrixExpr& x);
+  void operator()(const matrix_expr& x);
 
   void operator()(const addition& add);
   void operator()(const cast_bool& cast);

--- a/components/core/wf/substitute.cc
+++ b/components/core/wf/substitute.cc
@@ -25,8 +25,8 @@ struct substitute_visitor_base {
 
   Expr operator()(const Expr& expr) { return visit(expr, *this); }
 
-  MatrixExpr operator()(const MatrixExpr& expr) {
-    return MatrixExpr{expr.as_matrix().map_children(*this)};
+  matrix_expr operator()(const matrix_expr& expr) {
+    return matrix_expr{expr.as_matrix().map_children(*this)};
   }
 
   compound_expr operator()(const compound_expr& expr) {
@@ -343,15 +343,15 @@ Expr substitute_variables(const Expr& input, absl::Span<const std::tuple<Expr, E
   return create_subs_visitor(pairs)(input);
 }
 
-MatrixExpr substitute_variables(const MatrixExpr& input,
-                                const absl::Span<const std::tuple<Expr, Expr>> pairs) {
+matrix_expr substitute_variables(const matrix_expr& input,
+                                 const absl::Span<const std::tuple<Expr, Expr>> pairs) {
   substitute_variables_visitor visitor = create_subs_visitor(pairs);
   const matrix& m = input.as_matrix();
 
   std::vector<Expr> replaced{};
   replaced.reserve(m.size());
   std::transform(m.begin(), m.end(), std::back_inserter(replaced), std::move(visitor));
-  return MatrixExpr::create(m.rows(), m.cols(), std::move(replaced));
+  return matrix_expr::create(m.rows(), m.cols(), std::move(replaced));
 }
 
 void substitute_variables_visitor::add_substitution(const Expr& target, Expr replacement) {
@@ -391,8 +391,8 @@ Expr substitute_variables_visitor::operator()(const Expr& expression) {
   return it_inserted->second;
 }
 
-MatrixExpr substitute_variables_visitor::operator()(const MatrixExpr& expression) {
-  return MatrixExpr{expression.as_matrix().map_children(*this)};
+matrix_expr substitute_variables_visitor::operator()(const matrix_expr& expression) {
+  return matrix_expr{expression.as_matrix().map_children(*this)};
 }
 
 compound_expr substitute_variables_visitor::operator()(const compound_expr& expression) {

--- a/components/core/wf/substitute.h
+++ b/components/core/wf/substitute.h
@@ -27,7 +27,7 @@ class substitute_variables_visitor {
 
   // Apply the substitute variable visitor. The cache is checked first.
   Expr operator()(const Expr& expression);
-  MatrixExpr operator()(const MatrixExpr& expression);
+  matrix_expr operator()(const matrix_expr& expression);
   compound_expr operator()(const compound_expr& expression);
 
   template <typename T>

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -71,7 +71,7 @@ struct tree_formatter {
 
   void operator()(const Expr& x) { visit(x, *this); }
 
-  void operator()(const MatrixExpr& m) { operator()(m.as_matrix()); }
+  void operator()(const matrix_expr& m) { operator()(m.as_matrix()); }
 
   void operator()(const addition& op) {
     absl::InlinedVector<Expr, 16> terms;
@@ -219,7 +219,7 @@ std::string Expr::to_expression_tree_string() const {
   return formatter.take_output();
 }
 
-std::string MatrixExpr::to_expression_tree_string() const {
+std::string matrix_expr::to_expression_tree_string() const {
   tree_formatter formatter{};
   formatter(as_matrix());
   return formatter.take_output();

--- a/components/core/wf/type_annotations.h
+++ b/components/core/wf/type_annotations.h
@@ -19,13 +19,13 @@ struct arg {
 
 namespace type_annotations {
 
-// A wrapper around `MatrixExpr` with statically declared dimensions.
+// A wrapper around `matrix_expr` with statically declared dimensions.
 // This is so that we can write functions in C++, and have the argument dimensions accessible at
 // compile time.
 template <index_t Rows, index_t Cols>
 struct static_matrix {
-  // Allow implicit construction from MatrixExpr.
-  static_matrix(MatrixExpr expr) : expr_(std::move(expr)) {  // NOLINT(google-explicit-constructor)
+  // Allow implicit construction from matrix_expr.
+  static_matrix(matrix_expr expr) : expr_(std::move(expr)) {  // NOLINT(google-explicit-constructor)
     WF_ASSERT_EQUAL(Rows, expr_.rows());
     WF_ASSERT_EQUAL(Cols, expr_.cols());
   }
@@ -50,19 +50,19 @@ struct static_matrix {
   // Access vector element.
   const Expr& operator[](index_t element) const { return expr_[element]; }
 
-  // Assign from MatrixExpr
-  static_matrix& operator=(const MatrixExpr& other) {
+  // Assign from matrix_expr
+  static_matrix& operator=(const matrix_expr& other) {
     WF_ASSERT_EQUAL(Rows, other.rows());
     WF_ASSERT_EQUAL(Cols, other.cols());
     expr_ = other;
     return *this;
   }
 
-  // Explicit cast to MatrixExpr.
-  constexpr const MatrixExpr& inner() const noexcept { return expr_; }
+  // Explicit cast to matrix_expr.
+  constexpr const matrix_expr& inner() const noexcept { return expr_; }
 
-  // Implicit cast to MatrixExpr.
-  constexpr operator const MatrixExpr&() const noexcept { return expr_; }  // NOLINT
+  // Implicit cast to matrix_expr.
+  constexpr operator const matrix_expr&() const noexcept { return expr_; }  // NOLINT
 
   // Transpose:
   [[nodiscard]] static_matrix<Cols, Rows> transposed() const {
@@ -70,7 +70,7 @@ struct static_matrix {
   }
 
  private:
-  MatrixExpr expr_;
+  matrix_expr expr_;
 };
 
 // Evaluates to true if `T` is a static_matrix type annotation.

--- a/components/core/wf/visit.h
+++ b/components/core/wf/visit.h
@@ -39,7 +39,7 @@ auto visit(const Var& variant, F&& visitor) {
         if constexpr (inherits_expression_base_v<T>) {
           return visit(x, std::forward<F>(visitor));
         } else {
-          // TODO: Fallback path for MatrixExpr - maybe temporary?
+          // TODO: Fallback path for matrix_expr - maybe temporary?
           return visitor(x);
         }
       },
@@ -68,13 +68,13 @@ compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
   return visit(expr, make_overloaded(
                          [&](const external_function_invocation& invocation) {
                            return invocation.map_children([&](const any_expression& arg) {
-                             // TODO: Make `MatrixExpr` derived from `expression_base`, and call
+                             // TODO: Make `matrix_expr` derived from `expression_base`, and call
                              //  visit(...) here.
                              return overloaded_visit(
                                  arg, [&](const Expr& x) -> any_expression { return f(x); },
-                                 [&](const MatrixExpr& x) -> any_expression {
+                                 [&](const matrix_expr& x) -> any_expression {
                                    matrix m = x.as_matrix().map_children(std::forward<F>(f));
-                                   return MatrixExpr(std::move(m));
+                                   return matrix_expr(std::move(m));
                                  },
                                  [&](const compound_expr& x) -> any_expression { return f(x); });
                            });

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -282,7 +282,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def(
           "add_output_argument",
           [](function_description& self, const std::string_view name, const bool is_optional,
-             const MatrixExpr& value) {
+             const matrix_expr& value) {
             self.add_output_argument(name, matrix_type(value.rows(), value.cols()), is_optional,
                                      value.to_vector());
           },
@@ -304,7 +304,7 @@ void wrap_codegen_operations(py::module_& m) {
           py::arg("value"))
       .def(
           "set_return_value",
-          [](function_description& self, const MatrixExpr& value) {
+          [](function_description& self, const matrix_expr& value) {
             self.set_return_value(matrix_type(value.rows(), value.cols()), value.to_vector());
           },
           py::arg("value"))

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -126,7 +126,8 @@ void wrap_geometry_operations(py::module_& m) {
               "radians."))
       .def_static(
           "from_angle_axis",
-          static_cast<quaternion (*)(const Expr&, const MatrixExpr&)>(&quaternion::from_angle_axis),
+          static_cast<quaternion (*)(const Expr&, const matrix_expr&)>(
+              &quaternion::from_angle_axis),
           "angle"_a, "v"_a,
           py::doc("Create a quaternion from angle-axis parameters. Vector v must be a "
                   "unit vector, or the result does not represent a rotation. Angle is specified in "
@@ -139,7 +140,7 @@ void wrap_geometry_operations(py::module_& m) {
           py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
                   "of radians."))
       .def_static("from_rotation_vector",
-                  static_cast<quaternion (*)(const MatrixExpr&, std::optional<Expr>)>(
+                  static_cast<quaternion (*)(const matrix_expr&, std::optional<Expr>)>(
                       &quaternion::from_rotation_vector),
                   "v"_a, py::arg("epsilon"),
                   py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
@@ -160,7 +161,7 @@ void wrap_geometry_operations(py::module_& m) {
                   py::doc("Convert from a rotation matrix via Calley's method."))
       .def(
           "jacobian",
-          [](const quaternion& self, const MatrixExpr& vars, bool use_abstract) {
+          [](const quaternion& self, const matrix_expr& vars, bool use_abstract) {
             return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
                                                     : non_differentiable_behavior::constant);
           },

--- a/examples/quaternion_interpolation/quat_interpolation_expressions.h
+++ b/examples/quaternion_interpolation/quat_interpolation_expressions.h
@@ -16,7 +16,7 @@ auto quaternion_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<
 
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
-  const MatrixExpr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
   const quaternion q_interp =
       q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);
 


### PR DESCRIPTION
The only two types left that I didn't switch from Camel -> snake are `Expr` and `MatrixExpr`. This change renames `MatrixExpr` to `matrix_expr`.