### PR TITLE
Add additional method variations to `quat_interpolation_gen`

### DIFF
--- a/components/core/wf/code_generation/ir_builder.cc
+++ b/components/core/wf/code_generation/ir_builder.cc
@@ -433,7 +433,7 @@ class ir_form_visitor {
   ir::value_ptr operator()(const addition& add, const Expr& add_abstract) {
     // For additions, first check if the negated version has already been cached:
     const Expr negative_add = -add_abstract;
-    if (auto it = computed_values_.find(negative_add); it != computed_values_.end()) {
+    if (const auto it = computed_values_.find(negative_add); it != computed_values_.end()) {
       const auto promoted_type = std::max(it->second->numeric_type(), code_numeric_type::integral);
       const ir::value_ptr negative_one =
           maybe_cast(operator()(constants::negative_one), promoted_type);

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -270,7 +270,7 @@ matrix_expr jacobian(const absl::Span<const Expr> functions, const absl::Span<co
   // Crate row-major span over `result`:
   const auto output_dims = make_value_pack(functions.size(), vars.size());
   const auto output_strides = make_value_pack(vars.size(), constant<1>{});
-  auto result_span = make_span(result.data(), output_dims, output_strides);
+  const auto result_span = make_span(result.data(), output_dims, output_strides);
 
   for (std::size_t col = 0; col < vars.size(); ++col) {
     // We cache derivative expressions, so that every row reuses the same cache:

--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -104,11 +104,11 @@ class quaternion {
   // Construct quaternion from a rotation vector.
   // When the rotation angle < epsilon, the first order taylor series is used instead.
   static quaternion from_rotation_vector(const Expr& vx, const Expr& vy, const Expr& vz,
-                                         std::optional<Expr> epsilon);
+                                         const std::optional<Expr>& epsilon);
 
   // Construct quaternion from a rotation vector.
   // When the rotation angle < epsilon, the first order taylor series is used instead.
-  static quaternion from_rotation_vector(const matrix_expr& v, std::optional<Expr> epsilon);
+  static quaternion from_rotation_vector(const matrix_expr& v, const std::optional<Expr>& epsilon);
 
   // Convenience method for X-axis rotation. Angle is in radians.
   static quaternion from_x_angle(const Expr& angle) {
@@ -143,8 +143,8 @@ class quaternion {
   // Compute 4xN jacobian of this quaternion with respect to the `N` input variables `vars`.
   // The rows of the jacobian are ordered in the storage order of the quaternion: [w,x,y,z].
   matrix_expr jacobian(
-      absl::Span<const Expr> vars,
-      non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
+      const absl::Span<const Expr> vars,
+      const non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
     return wf::jacobian(wxyz(), vars, behavior);
   }
 

--- a/components/core/wf/output_annotations.h
+++ b/components/core/wf/output_annotations.h
@@ -12,14 +12,14 @@ class output_arg {
   using value_type = T;
 
   template <typename U>
-  using enable_if_decayed_type_matches_t = std::enable_if_t<std::is_same_v<T, std::decay_t<U>>>;
+  using enable_if_constructible_t = std::enable_if_t<std::is_constructible_v<T, U>>;
 
-  template <typename U, typename = enable_if_decayed_type_matches_t<U>>
-  constexpr output_arg(std::string_view name, U&& u)
+  template <typename U, typename = enable_if_constructible_t<U>>
+  constexpr output_arg(const std::string_view name, U&& u)
       : value_(std::forward<U>(u)), name_(name), is_optional_(false) {}
 
-  template <typename U, typename = enable_if_decayed_type_matches_t<U>>
-  constexpr output_arg(std::string_view name, U&& u, bool is_optional)
+  template <typename U, typename = enable_if_constructible_t<U>>
+  constexpr output_arg(const std::string_view name, U&& u, const bool is_optional)
       : value_(std::forward<U>(u)), name_(name), is_optional_(is_optional) {}
 
   // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.
@@ -55,9 +55,9 @@ class return_value {
   using value_type = T;
 
   template <typename U>
-  using enable_if_decayed_type_matches_t = std::enable_if_t<std::is_same_v<T, std::decay_t<U>>>;
+  using enable_if_constructible_t = std::enable_if_t<std::is_constructible_v<T, U>>;
 
-  template <typename U, typename = enable_if_decayed_type_matches_t<U>>
+  template <typename U, typename = enable_if_constructible_t<U>>
   explicit return_value(U&& value) : value_(std::forward<U>(value)) {}
 
   // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -132,15 +132,15 @@ void wrap_geometry_operations(py::module_& m) {
           py::doc("Create a quaternion from angle-axis parameters. Vector v must be a "
                   "unit vector, or the result does not represent a rotation. Angle is specified in "
                   "radians."))
-      .def_static(
-          "from_rotation_vector",
-          static_cast<quaternion (*)(const Expr&, const Expr&, const Expr&, std::optional<Expr>)>(
-              &quaternion::from_rotation_vector),
-          "x"_a, "y"_a, "z"_a, py::arg("epsilon"),
-          py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
-                  "of radians."))
       .def_static("from_rotation_vector",
-                  static_cast<quaternion (*)(const matrix_expr&, std::optional<Expr>)>(
+                  static_cast<quaternion (*)(const Expr&, const Expr&, const Expr&,
+                                             const std::optional<Expr>&)>(
+                      &quaternion::from_rotation_vector),
+                  "x"_a, "y"_a, "z"_a, py::arg("epsilon"),
+                  py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
+                          "of radians."))
+      .def_static("from_rotation_vector",
+                  static_cast<quaternion (*)(const matrix_expr&, const std::optional<Expr>&)>(
                       &quaternion::from_rotation_vector),
                   "v"_a, py::arg("epsilon"),
                   py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "

--- a/examples/quaternion_interpolation/quat_interpolation_expressions.h
+++ b/examples/quaternion_interpolation/quat_interpolation_expressions.h
@@ -10,13 +10,14 @@ namespace wf {
 
 // Interpolate between two quaternions, `q0` and `q1` (passed as scalar-last vectors).
 // Outputs the interpolated quaternion, as well as the tangent space derivatives.
-auto quaternion_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec,
-                              Expr alpha) {
+inline auto quaternion_interpolation(const ta::static_matrix<4, 1>& q0_vec,
+                                     const ta::static_matrix<4, 1>& q1_vec, const Expr& alpha,
+                                     const std::optional<Expr>& epsilon) {
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
-  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon);
   const quaternion q_interp =
-      q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);
+      q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, epsilon);
 
   ta::static_matrix<3, 3> D_q0 = q_interp.right_local_coordinates_derivative() *
                                  q_interp.jacobian(q0) * q0.right_retract_derivative();
@@ -24,6 +25,24 @@ auto quaternion_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<
                                  q_interp.jacobian(q1) * q1.right_retract_derivative();
 
   return std::make_tuple(output_arg("q_out", ta::static_matrix<4, 1>(q_interp.to_vector_xyzw())),
+                         optional_output_arg("D_q0", std::move(D_q0)),
+                         optional_output_arg("D_q1", std::move(D_q1)));
+}
+
+// log(q0^-1 * q1), w/ no handling for the small angle case
+inline auto quaternion_local_coordinates(const ta::static_matrix<4, 1>& q0_vec,
+                                         const ta::static_matrix<4, 1>& q1_vec,
+                                         const std::optional<Expr>& epsilon) {
+  const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
+  const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon);
+
+  ta::static_matrix<3, 3> D_q0 =
+      q_delta_tangent.jacobian(q0.wxyz()) * q0.right_retract_derivative();
+  ta::static_matrix<3, 3> D_q1 =
+      q_delta_tangent.jacobian(q1.wxyz()) * q1.right_retract_derivative();
+
+  return std::make_tuple(output_arg("result", ta::static_matrix<3, 1>(q_delta_tangent)),
                          optional_output_arg("D_q0", std::move(D_q0)),
                          optional_output_arg("D_q1", std::move(D_q1)));
 }

--- a/examples/quaternion_interpolation/quat_interpolation_gen.cc
+++ b/examples/quaternion_interpolation/quat_interpolation_gen.cc
@@ -15,8 +15,45 @@ int main() {
   code += "namespace gen {\n\n";
 
   cpp_code_generator gen{};
-  generate_func(gen, code, &quaternion_interpolation, "quaternion_interpolation", "q0", "q1",
-                "alpha");
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+        return quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16);
+      },
+      "quaternion_interpolation", "q0", "q1", "alpha");
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+        return quaternion_interpolation(q0_vec, q1_vec, alpha, std::nullopt);
+      },
+      "quaternion_interpolation_no_conditional", "q0", "q1", "alpha");
+
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+        return std::get<0>(quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16));
+      },
+      "quaternion_interpolation_no_diff", "q0", "q1", "alpha");
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+        return std::get<0>(quaternion_interpolation(q0_vec, q1_vec, alpha, std::nullopt));
+      },
+      "quaternion_interpolation_no_conditional_no_diff", "q0", "q1", "alpha");
+
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec) {
+        return quaternion_local_coordinates(q0_vec, q1_vec, 1.0e-16);
+      },
+      "quaternion_local_coordinates", "q0", "q1");
+
+  generate_func(
+      gen, code,
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec) {
+        return quaternion_local_coordinates(q0_vec, q1_vec, std::nullopt);
+      },
+      "quaternion_local_coordinates_no_conditional", "q0", "q1");
 
   code += "} // namespace gen";
 

--- a/examples/quaternion_interpolation/quat_interpolation_test.cc
+++ b/examples/quaternion_interpolation/quat_interpolation_test.cc
@@ -25,9 +25,14 @@ Eigen::Quaternion<Scalar> quat_interp(const Eigen::Quaternion<Scalar>& a,
       a, (manifold<Quaterniond>::local_coordinates(a, b) * alpha).eval());
 }
 
+auto quat_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec,
+                        Expr alpha) {
+  return quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16);
+};
+
 // Test the quaternion interpolation result numerically.
 TEST(QuaternionInterpolationTest, TestQuatInterpolation) {
-  auto evaluator = create_evaluator(&wf::quaternion_interpolation);
+  auto evaluator = create_evaluator(&quat_interpolation);
 
   const Quaterniond q0 = Quaterniond{AngleAxisd(M_PI / 3, Vector3d::UnitX())} *
                          Quaterniond{AngleAxisd(M_PI / 6, Vector3d::UnitZ())};


### PR DESCRIPTION
Added some additional method variations to the `quat_interpolation_gen` target. I have been using these for profiling, which for now resides in a separate repo (but I will move it into this one shortly).