### PR TITLE
Rename Expr --> scalar_expr

### DIFF
--- a/components/core/benchmarks/bench_add_mul.cc
+++ b/components/core/benchmarks/bench_add_mul.cc
@@ -11,13 +11,13 @@ static void BM_ScalarAddition(benchmark::State& state) {
   constexpr int num_terms = 100;
   constexpr int num_symbols = 10;
 
-  std::vector<Expr> symbols;
+  std::vector<scalar_expr> symbols;
   for (int i = 0; i < num_symbols; ++i) {
     symbols.emplace_back(fmt::format("x{:02}", i));
   }
 
   for (auto _ : state) {
-    Expr output = 0;
+    scalar_expr output = 0;
     for (int i = 0; i < num_terms; ++i) {
       output = output + symbols[i % num_symbols];
     }
@@ -31,13 +31,13 @@ static void BM_ScalarMultiplication(benchmark::State& state) {
   constexpr int num_terms = 100;
   constexpr int num_symbols = 10;
 
-  std::vector<Expr> symbols;
+  std::vector<scalar_expr> symbols;
   for (int i = 0; i < num_symbols; ++i) {
     symbols.emplace_back(fmt::format("x{:02}", i));
   }
 
   for (auto _ : state) {
-    Expr output = 1;
+    scalar_expr output = 1;
     for (int i = 0; i < num_terms; ++i) {
       output = output * symbols[i % num_symbols];
     }

--- a/components/core/benchmarks/bench_code_generation.cc
+++ b/components/core/benchmarks/bench_code_generation.cc
@@ -15,7 +15,7 @@ namespace ta = type_annotations;
 
 // TODO: De-dup with quat_interpolation_expressions example.
 auto quaternion_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec,
-                              Expr alpha) {
+                              scalar_expr alpha) {
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
   const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);

--- a/components/core/benchmarks/bench_jacobian.cc
+++ b/components/core/benchmarks/bench_jacobian.cc
@@ -10,7 +10,7 @@ namespace wf {
 static void BM_QuaternionInterpolateJacobian(benchmark::State& state) {
   const quaternion q0 = quaternion::from_name_prefix("q0");
   const quaternion q1 = quaternion::from_name_prefix("q1");
-  const Expr alpha{"alpha"};
+  const scalar_expr alpha{"alpha"};
   const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(1.0e-16);
   const quaternion q_interp =
       q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, 1.0e-16);

--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -39,9 +39,9 @@ testing::AssertionResult format_failed_result(const std::string_view description
 template <typename T, typename = void>
 struct convert_assertion_argument;
 template <typename T>
-struct convert_assertion_argument<T, std::enable_if_t<std::is_convertible_v<T, Expr>>> {
+struct convert_assertion_argument<T, std::enable_if_t<std::is_convertible_v<T, scalar_expr>>> {
   // This overload will get selected for numeric literals.
-  Expr operator()(const T& arg) const { return static_cast<Expr>(arg); }
+  scalar_expr operator()(const T& arg) const { return static_cast<scalar_expr>(arg); }
 };
 template <>
 struct convert_assertion_argument<matrix_expr> {

--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -12,7 +12,7 @@ namespace wf {
 using namespace wf::custom_literals;
 
 TEST(DerivativesTest, TestConstants) {
-  const Expr x{"x"};
+  const scalar_expr x{"x"};
   ASSERT_IDENTICAL(constants::zero, (5_s).diff(x));
   ASSERT_IDENTICAL(constants::zero, (22.5_s).diff(x, 4));
   ASSERT_IDENTICAL(constants::zero, constants::pi.diff(x));
@@ -23,9 +23,9 @@ TEST(DerivativesTest, TestConstants) {
 }
 
 TEST(DerivativesTest, TestAdditionAndSubtraction) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(constants::zero, (x + y).diff(w));
   ASSERT_IDENTICAL(constants::zero, (x - y).diff(w, 2));
   ASSERT_IDENTICAL(constants::one, (x + y).diff(y));
@@ -36,9 +36,9 @@ TEST(DerivativesTest, TestAdditionAndSubtraction) {
 }
 
 TEST(DerivativesTest, TestMultiplication) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(0, (x * y).diff(w));
   ASSERT_IDENTICAL(y, (x * y).diff(x));
   ASSERT_IDENTICAL(x, (x * y).diff(y));
@@ -59,9 +59,9 @@ TEST(DerivativesTest, TestMultiplication) {
 }
 
 TEST(DerivativesTest, TestPower) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(constants::zero, pow(x, y).diff(w));
 
   ASSERT_IDENTICAL(y * pow(x, y - 1), pow(x, y).diff(x));
@@ -73,14 +73,14 @@ TEST(DerivativesTest, TestPower) {
   ASSERT_IDENTICAL(pow(y, w) * pow(log(y), 3), pow(y, w).diff(w, 3));
   ASSERT_IDENTICAL(pow(x, x) * log(x) + pow(x, x), pow(x, x).diff(x));
 
-  const Expr coeff = (5 / 7_s) * pow(2, (5 / 7_s) * x) * pow(x, (5 / 7_s) * x);
+  const scalar_expr coeff = (5 / 7_s) * pow(2, (5 / 7_s) * x) * pow(x, (5 / 7_s) * x);
   ASSERT_IDENTICAL((coeff * (1 + log(2) + log(x))).distribute(),
                    pow(x * 2, x * 5 / 7_s).diff(x).distribute());
 }
 
 TEST(DerivativesTest, TestLog) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(1 / x, log(x).diff(x));
   ASSERT_IDENTICAL(0, log(x).diff(y));
   ASSERT_IDENTICAL(1 / y, log(x * y).diff(y));
@@ -88,8 +88,8 @@ TEST(DerivativesTest, TestLog) {
 }
 
 TEST(DerivativesTest, TestTrig) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(cos(x), sin(x).diff(x));
   ASSERT_IDENTICAL(-sin(x), cos(x).diff(x));
   ASSERT_IDENTICAL(-cos(y) * cos(cos(sin(y))) * sin(sin(y)), sin(cos(sin(y))).diff(y));
@@ -100,8 +100,8 @@ TEST(DerivativesTest, TestTrig) {
 }
 
 TEST(DerivativesTest, TestInverseTrig) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
 
   ASSERT_IDENTICAL(constants::zero, acos(5).diff(x));
   ASSERT_IDENTICAL(-1 / sqrt(1 - x * x), acos(x).diff(x));
@@ -117,9 +117,9 @@ TEST(DerivativesTest, TestInverseTrig) {
 }
 
 TEST(DerivativesTest, TestAtan2) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_IDENTICAL(0, atan2(y, x).diff(z));
   ASSERT_IDENTICAL(x / (x * x + y * y), atan2(y, x).diff(y));
   ASSERT_IDENTICAL(-y / (x * x + y * y), atan2(y, x).diff(x));
@@ -130,8 +130,8 @@ TEST(DerivativesTest, TestAtan2) {
 }
 
 TEST(DerivativesTest, TestAbs) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(0, abs(x).diff(y));
   ASSERT_IDENTICAL(y / abs(y), abs(y).diff(y));
   ASSERT_IDENTICAL(cos(x) * sin(x) / abs(sin(x)), abs(sin(x)).diff(x));
@@ -164,9 +164,9 @@ TEST(DerivativesTest, TestMaxMin) {
 
 TEST(DerivativesTest, TestMatrix) {
   // Matrix derivative should do element-wise differentiation.
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_IDENTICAL(make_vector(0, 0, 0), make_vector(x, y, 1).diff(z));
   ASSERT_IDENTICAL(make_vector(0, 1, 0), make_vector(x, y, z).diff(y));
   ASSERT_IDENTICAL(make_vector(cos(y), 2 * x, -z / pow(x, 2)),

--- a/components/core/tests/functions_test.cc
+++ b/components/core/tests/functions_test.cc
@@ -26,23 +26,23 @@ TEST(FunctionsTest, TestCosine) {
   ASSERT_IDENTICAL(constants::one, cos(0_s));
   for (int i = -15; i < 15; ++i) {
     // Even and odd multiples of pi.
-    ASSERT_IDENTICAL(constants::one, cos(Expr(i * 2) * constants::pi));
-    ASSERT_IDENTICAL(constants::negative_one, cos(Expr(i * 2 + 1) * constants::pi));
+    ASSERT_IDENTICAL(constants::one, cos(scalar_expr(i * 2) * constants::pi));
+    ASSERT_IDENTICAL(constants::negative_one, cos(scalar_expr(i * 2 + 1) * constants::pi));
   }
 
   ASSERT_IDENTICAL(constants::zero, cos(constants::pi / 2_s));
   ASSERT_IDENTICAL(constants::zero, cos(-constants::pi / 2_s));
   for (int i = -15; i < 15; ++i) {
     // Multiples of pi/2
-    ASSERT_IDENTICAL(constants::zero, cos(constants::pi / 2_s + Expr(i) * constants::pi));
+    ASSERT_IDENTICAL(constants::zero, cos(constants::pi / 2_s + scalar_expr(i) * constants::pi));
   }
 
   // Modulo:
   for (int i = -15; i < 15; ++i) {
     ASSERT_IDENTICAL(cos(constants::pi * 3_s / 5_s),
-                     cos(constants::pi * 3_s / 5_s + Expr(2 * i) * constants::pi));
+                     cos(constants::pi * 3_s / 5_s + scalar_expr(2 * i) * constants::pi));
     ASSERT_IDENTICAL(cos(constants::pi * -2_s / 7_s),
-                     cos(constants::pi * -2_s / 7_s + Expr(2 * i) * constants::pi));
+                     cos(constants::pi * -2_s / 7_s + scalar_expr(2 * i) * constants::pi));
   }
 
   // Sign adjustment
@@ -52,7 +52,7 @@ TEST(FunctionsTest, TestCosine) {
 
   // Evaluation on floats:
   for (double v : {-0.51, 0.78, 1.8, -2.1}) {
-    ASSERT_IDENTICAL(Expr(std::cos(v)), cos(v));
+    ASSERT_IDENTICAL(scalar_expr(std::cos(v)), cos(v));
   }
 
   ASSERT_IDENTICAL(constants::undefined, cos(constants::complex_infinity));
@@ -67,24 +67,24 @@ TEST(FunctionsTest, TestSine) {
 
   ASSERT_IDENTICAL(constants::zero, sin(0_s));
   for (int i = -15; i < 15; ++i) {
-    ASSERT_IDENTICAL(constants::zero, sin(Expr(i * 2) * constants::pi));
-    ASSERT_IDENTICAL(constants::zero, sin(Expr(i * 2 + 1) * constants::pi));
+    ASSERT_IDENTICAL(constants::zero, sin(scalar_expr(i * 2) * constants::pi));
+    ASSERT_IDENTICAL(constants::zero, sin(scalar_expr(i * 2 + 1) * constants::pi));
   }
 
   ASSERT_IDENTICAL(constants::one, sin(constants::pi / 2_s));
   ASSERT_IDENTICAL(constants::negative_one, sin(-constants::pi / 2_s));
   for (int i = -15; i < 15; ++i) {
-    ASSERT_IDENTICAL(constants::one, sin(constants::pi / 2_s + Expr(i * 2) * constants::pi));
+    ASSERT_IDENTICAL(constants::one, sin(constants::pi / 2_s + scalar_expr(i * 2) * constants::pi));
     ASSERT_IDENTICAL(constants::negative_one,
-                     sin(-constants::pi / 2_s + Expr(i * 2) * constants::pi));
+                     sin(-constants::pi / 2_s + scalar_expr(i * 2) * constants::pi));
   }
 
   // Modulo:
   for (int i = -15; i < 15; ++i) {
     ASSERT_IDENTICAL(sin(constants::pi * 2_s / 11_s),
-                     sin(constants::pi * 2_s / 11_s + Expr(2 * i) * constants::pi));
+                     sin(constants::pi * 2_s / 11_s + scalar_expr(2 * i) * constants::pi));
     ASSERT_IDENTICAL(sin(constants::pi * -6_s / 13_s),
-                     sin(constants::pi * -6_s / 13_s + Expr(2 * i) * constants::pi));
+                     sin(constants::pi * -6_s / 13_s + scalar_expr(2 * i) * constants::pi));
   }
 
   ASSERT_IDENTICAL(-sin(x), sin(-x));
@@ -92,7 +92,7 @@ TEST(FunctionsTest, TestSine) {
   ASSERT_IDENTICAL(-sin(3_s / 5_s), sin(-3_s / 5_s));
 
   for (double v : {6.0, 0.112, -0.65, 0.22}) {
-    ASSERT_IDENTICAL(Expr(std::sin(v)), sin(v));
+    ASSERT_IDENTICAL(scalar_expr(std::sin(v)), sin(v));
   }
 
   ASSERT_IDENTICAL(constants::undefined, sin(constants::complex_infinity));
@@ -107,27 +107,28 @@ TEST(FunctionsTest, TestTan) {
 
   // Zero at multiples of pi.
   for (int i = -15; i < 15; ++i) {
-    ASSERT_IDENTICAL(constants::zero, tan(Expr(i) * constants::pi));
+    ASSERT_IDENTICAL(constants::zero, tan(scalar_expr(i) * constants::pi));
   }
 
   // complex_infinity at odd multiples of pi/2:
   for (int i = -15; i < 15; ++i) {
-    ASSERT_IDENTICAL(constants::complex_infinity, tan(Expr(i * 2 + 1) * constants::pi / 2_s));
+    ASSERT_IDENTICAL(constants::complex_infinity,
+                     tan(scalar_expr(i * 2 + 1) * constants::pi / 2_s));
   }
 
   // Modulo pi:
   for (int i = -15; i < 15; ++i) {
     ASSERT_IDENTICAL(tan(constants::pi * 4_s / 11_s),
-                     tan(constants::pi * 4_s / 11_s + Expr(i) * constants::pi));
+                     tan(constants::pi * 4_s / 11_s + scalar_expr(i) * constants::pi));
     ASSERT_IDENTICAL(tan(constants::pi * -3_s / 13_s),
-                     tan(constants::pi * -3_s / 13_s + Expr(i) * constants::pi));
+                     tan(constants::pi * -3_s / 13_s + scalar_expr(i) * constants::pi));
   }
 
   ASSERT_IDENTICAL(-tan(x), tan(-x));
   ASSERT_IDENTICAL(-tan(x * y), tan(-x * y));
 
   for (double v : {-4.0, -0.132, 1.6, 6.8}) {
-    ASSERT_IDENTICAL(Expr(std::tan(v)), tan(v));
+    ASSERT_IDENTICAL(scalar_expr(std::tan(v)), tan(v));
   }
 
   ASSERT_IDENTICAL(constants::undefined, tan(constants::complex_infinity));

--- a/components/core/tests/limits_test.cc
+++ b/components/core/tests/limits_test.cc
@@ -15,8 +15,8 @@ using namespace custom_literals;
 
 // Test some trivial limits.
 TEST(LimitsTest, TestSimpleLimits1) {
-  const Expr x{"x", number_set::real_non_negative};
-  const Expr y{"y"};
+  const scalar_expr x{"x", number_set::real_non_negative};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(22, limit(22, x).value());
   ASSERT_IDENTICAL(0, limit(x, x).value());
   ASSERT_IDENTICAL(-y, limit(x - y, x).value());
@@ -29,7 +29,7 @@ TEST(LimitsTest, TestSimpleLimits1) {
 }
 
 TEST(LimitsTest, TestIndeterminateMultiplicativeForms1) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   const auto [y, z] = make_symbols("y", "z");
 
   // (x^3 - x*y^2) / (x - x*y)
@@ -86,7 +86,7 @@ TEST(LimitsTest, TestIndeterminateMultiplicativeForms1) {
 }
 
 TEST(LimitsTest, TestIndeterminateMultiplicativeForms2) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   const auto [y, z] = make_symbols("y", "z");
 
   auto f1 = tan(7 * x) / log(1 + 2 * x) + 3 * cos(x);
@@ -125,7 +125,7 @@ TEST(LimitsTest, TestIndeterminateMultiplicativeForms2) {
 
 // Test limits of the form 0^0
 TEST(LimitsTest, TestIndeterminatePowerForms1) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   const auto [y, z] = make_symbols("y", "z");
 
   auto f1 = pow(x, x);
@@ -159,7 +159,7 @@ TEST(LimitsTest, TestIndeterminatePowerForms1) {
 
 // Test limits of the form ∞^0
 TEST(LimitsTest, TestIndeterminatePowerForms2) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   const auto [y, z] = make_symbols("y", "z");
 
   // Contains both 0^0 (sin(x)/x) and ∞^0 (1/x)^x
@@ -190,7 +190,7 @@ TEST(LimitsTest, TestIndeterminatePowerForms2) {
 
 // Test limits of the form 1^∞
 TEST(LimitsTest, TestIndeterminatePowerForms3) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   const auto [y, z] = make_symbols("y", "z");
 
   auto f1 = pow(cos(x * y), 1 / x);
@@ -212,7 +212,7 @@ TEST(LimitsTest, TestIndeterminatePowerForms3) {
 
 // Test limits of the form ∞ - ∞
 TEST(LimitsTest, TestIndeterminateSubtractiveForms1) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
 
   auto f1 = 1 / x - 1 / log(x + 1);
   ASSERT_IDENTICAL(constants::undefined, f1.subs(x, 0));
@@ -224,7 +224,7 @@ TEST(LimitsTest, TestIndeterminateSubtractiveForms1) {
 }
 
 TEST(LimitsTest, TestInvalidForms) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
 
   // This would recurse indefinitely:
   const auto e = constants::euler;
@@ -249,7 +249,7 @@ TEST(LimitsTest, TestInvalidForms) {
 
 // Test the limit function called on matrices.
 TEST(LimitsTest, TestMatrixLimits) {
-  const Expr x{"x", number_set::real_non_negative};
+  const scalar_expr x{"x", number_set::real_non_negative};
   auto [y, z] = make_symbols("y", "z");
   auto f1 = make_matrix(2, 2, sin(y * x) / (x * 3), x * log(x * y), x + 2,
                         3 * (x - 1) * sin(y * x) / (x * z));
@@ -260,7 +260,7 @@ TEST(LimitsTest, TestMatrixLimits) {
 TEST(LimitsTest, TestMatrixLimitsQuaternion) {
   const auto [x0, y0, z0] = make_symbols("x0", "y0", "z0");
   const auto [x, y, z] = make_symbols("x", "y", "z");
-  const Expr t{"t", number_set::real_non_negative};
+  const scalar_expr t{"t", number_set::real_non_negative};
 
   const quaternion Q = quaternion::from_rotation_vector(x0, y0, z0, std::nullopt);
   const quaternion Q_subbed = Q.subs(x0, x * t).subs(y0, y * t).subs(z0, z * t);
@@ -279,7 +279,7 @@ TEST(LimitsTest, TestMatrixLimitsQuaternion) {
 TEST(LimitsTest, TestMatrixLimitsRotation) {
   const auto [x0, y0, z0] = make_symbols("x0", "y0", "z0");
   const auto [x, y, z] = make_symbols("x", "y", "z");
-  const Expr t{"t", number_set::real_non_negative};
+  const scalar_expr t{"t", number_set::real_non_negative};
 
   const quaternion Q = quaternion::from_rotation_vector(x0, y0, z0, std::nullopt);
   const matrix_expr R = Q.to_rotation_matrix();
@@ -310,7 +310,7 @@ TEST(LimitsTest, TestMatrixLimitsRotation) {
 
 TEST(LimitsTest, TestMatrixLimitsQuaternionToVector) {
   const auto [w, x, y, z] = make_symbols("w", "x", "y", "z");
-  const Expr t{"t", number_set::real_non_negative};
+  const scalar_expr t{"t", number_set::real_non_negative};
 
   // Take the limit as the quaternion approaches identity:
   const matrix_expr J = quaternion{w, x, y, z}
@@ -329,7 +329,7 @@ TEST(LimitsTest, TestMatrixLimitsQuaternionToVector) {
 
 TEST(LimitsTest, TestJacobianSo3) {
   const auto [x, y, z] = make_symbols("x", "y", "z");
-  const Expr t{"t", number_set::real_non_negative};
+  const scalar_expr t{"t", number_set::real_non_negative};
   // Should converge to identify as norm of `w` goes to zero:
   const matrix_expr J = left_jacobian_of_so3(make_vector(x * t, y * t, z * t), std::nullopt);
   const std::optional<matrix_expr> J_lim = limit(J, t);

--- a/components/core/tests/matrix_operations_test.cc
+++ b/components/core/tests/matrix_operations_test.cc
@@ -13,9 +13,9 @@ namespace wf {
 using namespace custom_literals;
 
 TEST(MatrixOperationsTest, TestConstruct) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
 
   // Construct vector:
   const matrix_expr v = make_vector(x, 4, y + z);
@@ -58,12 +58,12 @@ TEST(MatrixOperationsTest, TestConstruct) {
 }
 
 TEST(MatrixOperationsTest, TestGetBlock) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
   // clang-format off
   const matrix_expr m1 = make_matrix(3, 2,
                                      x, a,
@@ -95,9 +95,9 @@ TEST(MatrixOperationsTest, TestGetBlock) {
 }
 
 TEST(MatrixOperationsTest, TestTranspose) {
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
   // clang-format off
   const matrix_expr m = make_matrix(2, 5,
                                     cos(a), sin(b), -1, constants::pi * 3, 0.0,
@@ -125,16 +125,16 @@ TEST(MatrixOperationsTest, TestReshape) {
   const auto old_contents = m.to_vector();
   const auto new_contents = m_reshape.to_vector();
   ASSERT_TRUE(std::equal(old_contents.begin(), old_contents.end(), new_contents.begin(),
-                         new_contents.end(), is_identical_struct<Expr>{}));
+                         new_contents.end(), is_identical_struct<scalar_expr>{}));
 }
 
 TEST(MatrixOperationsTest, TestVec) {
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
-  const Expr d{"d"};
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
+  const scalar_expr d{"d"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_IDENTICAL(make_vector(a, b, c), vectorize_matrix(make_row_vector(a, b, c)));
   ASSERT_IDENTICAL(make_vector(a, c, b, d, x, y),
                    vectorize_matrix(make_matrix(2, 3, a, b, x, c, d, y)));
@@ -178,10 +178,10 @@ TEST(MatrixOperationsTest, TestStack) {
 }
 
 TEST(MatrixOperationsTest, TestAddition) {
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
-  const Expr d{"d"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
+  const scalar_expr d{"d"};
   ASSERT_IDENTICAL(make_vector(a + c, b - d, b * 2 + 5),
                    make_vector(a, -d, b) + make_vector(c, b, b + 5));
   ASSERT_IDENTICAL(make_vector(0, 0, 0), make_vector(a, b, c) + make_vector(-a, -b, -c));
@@ -200,14 +200,14 @@ TEST(MatrixOperationsTest, TestAddition) {
 }
 
 TEST(MatrixOperationsTest, TestMultiplication) {
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
-  const Expr d{"d"};
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
-  const Expr w{"w"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
+  const scalar_expr d{"d"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
+  const scalar_expr w{"w"};
 
   ASSERT_IDENTICAL(make_identity(4), make_identity(4) * make_identity(4));
   ASSERT_IDENTICAL(make_vector(a, b, c, d), make_identity(4) * make_vector(a, b, c, d));
@@ -310,7 +310,7 @@ void check_full_piv_lu_solution(
 }
 
 matrix_expr check_permutation_matrix(absl::Span<const int> permutation) {
-  std::vector<Expr> elements(permutation.size() * permutation.size(), constants::zero);
+  std::vector<scalar_expr> elements(permutation.size() * permutation.size(), constants::zero);
 
   for (std::size_t row = 0; row < permutation.size(); ++row) {
     const int col_index = permutation[row];
@@ -422,7 +422,7 @@ TEST(MatrixOperationsTest, TestFactorizeRandomLU) {
   for (const auto& [rows, cols] : dims) {
     constexpr int num_trials = 25;
     for (int i = 0; i < num_trials; ++i) {
-      std::vector<Expr> data{};
+      std::vector<scalar_expr> data{};
       data.reserve(rows * cols);
       for (int j = 0; j < rows * cols; ++j) {
         data.emplace_back(distribution(engine));

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -9,9 +9,9 @@ namespace wf {
 using namespace wf::custom_literals;
 
 TEST(PlainFormatterTest, TestAdditionAndSubtraction) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_STR_EQ("w + x + y", x + y + w);
   ASSERT_STR_EQ("2 + x", x + 2);
   ASSERT_STR_EQ("-10 + y", y - 10);
@@ -27,10 +27,10 @@ TEST(PlainFormatterTest, TestAdditionAndSubtraction) {
 }
 
 TEST(PlainFormatterTest, TestMultiplication) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_STR_EQ("x * y", x * y);
   ASSERT_STR_EQ("x * y * z", x * z * y);
   ASSERT_STR_EQ("z * (x + y)", (x + y) * z);
@@ -73,9 +73,9 @@ TEST(PlainFormatterTest, TestMultiplication) {
 }
 
 TEST(PlainFormatterTest, TestPower) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_STR_EQ("x ** y", pow(x, y));
   ASSERT_STR_EQ("8", pow(2, 3));
   ASSERT_STR_EQ("(x + y) ** z", pow(x + y, z));
@@ -114,8 +114,8 @@ TEST(PlainFormatterTest, TestConditionals) {
 }
 
 TEST(PlainFormatterTest, TestBuiltInFunctions) {
-  const Expr x{"x"};
-  const Expr y{"y"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
   ASSERT_STR_EQ("ln(x)", log(x));
   ASSERT_STR_EQ("ln(x * y)", log(x * y));
   ASSERT_STR_EQ("-x * ln(x / y)", -x * log(x / y));
@@ -132,10 +132,10 @@ TEST(PlainFormatterTest, TestBuiltInFunctions) {
 }
 
 TEST(PlainFormatterTest, TestMatrix) {
-  const Expr a{"a"};
-  const Expr b{"b"};
-  const Expr c{"c"};
-  const Expr d{"d"};
+  const scalar_expr a{"a"};
+  const scalar_expr b{"b"};
+  const scalar_expr c{"c"};
+  const scalar_expr d{"d"};
   ASSERT_STR_EQ("[[a, b],\n [c, d]]", make_matrix(2, 2, a, b, c, d));
   ASSERT_STR_EQ("[[2 * a, b - c],\n [    c, 3 * d]]", make_matrix(2, 2, a * 2, b - c, c, d * 3));
   ASSERT_STR_EQ("[[a],\n [b],\n [c]]", make_vector(a, b, c));
@@ -144,7 +144,7 @@ TEST(PlainFormatterTest, TestMatrix) {
 }
 
 TEST(PlainFormatterTest, TestDerivativeExpression) {
-  const Expr a{"a"};
+  const scalar_expr a{"a"};
   ASSERT_STR_EQ("Derivative(signum(a), a)",
                 signum(a).diff(a, 1, non_differentiable_behavior::abstract));
   ASSERT_STR_EQ("Derivative(signum(a), a, 2)",

--- a/components/core/tests/quaternion_test.cc
+++ b/components/core/tests/quaternion_test.cc
@@ -197,8 +197,8 @@ TEST(QuaternionTest, TestFromAxisAngle) {
 
   // Show that the norm is one.
   // TODO: Have the trig simplification cos^2(x) + sin^2(x) = 1 be automatic.
-  const Expr half_angle = angle / 2;
-  const Expr q_norm_2 = collect(q.squared_norm(), sin(half_angle));
+  const scalar_expr half_angle = angle / 2;
+  const scalar_expr q_norm_2 = collect(q.squared_norm(), sin(half_angle));
   ASSERT_IDENTICAL(1, q_norm_2.subs(vx * vx + vy * vy + vz * vz, 1)
                           .subs(pow(cos(half_angle), 2) + pow(sin(half_angle), 2), 1));
 
@@ -287,8 +287,8 @@ auto get_angle_axis_test_pairs() {
 
 TEST(QuaternionTest, FromRotationVector) {
   auto [vx, vy, vz] = make_symbols("vx", "vy", "vz");
-  const Expr angle = sqrt(vx * vx + vy * vy + vz * vz);
-  const Expr half_angle = angle / 2;
+  const scalar_expr angle = sqrt(vx * vx + vy * vy + vz * vz);
+  const scalar_expr half_angle = angle / 2;
   const quaternion q_no_conditional = quaternion::from_rotation_vector(vx, vy, vz, std::nullopt);
   ASSERT_IDENTICAL(q_no_conditional.w(), cos(angle / 2));
   ASSERT_IDENTICAL(q_no_conditional.x(), vx * sin(angle / 2) / angle);
@@ -339,7 +339,7 @@ TEST(QuaternionTest, FromRotationVector) {
 
 TEST(QuaternionTest, TestAngleConversions) {
   auto [angle] = make_symbols("theta");
-  const Expr half_angle = angle / 2;
+  const scalar_expr half_angle = angle / 2;
   // clang-format off
   const matrix_expr R_x =
       make_matrix(3, 3,
@@ -425,14 +425,14 @@ TEST(QuaternionTest, TestToRotationVector) {
   const matrix_expr w = Q.to_rotation_vector(std::nullopt);
 
   // We sub this in for the angle (the norm of [x, y, z]).
-  const Expr a{"a", number_set::real_non_negative};
+  const scalar_expr a{"a", number_set::real_non_negative};
 
   // Sin and cosine of the half-angle:
-  const Expr s{"s", number_set::real};
-  const Expr c{"c", number_set::real};
+  const scalar_expr s{"s", number_set::real};
+  const scalar_expr c{"c", number_set::real};
 
   // Simplify the round-trip conversion.
-  const Expr vector_norm = sqrt(x * x + y * y + z * z);
+  const scalar_expr vector_norm = sqrt(x * x + y * y + z * z);
   const matrix_expr w_simplified = w.subs(vector_norm, a)
                                        .subs(sin(a / 2), s)
                                        .subs(cos(a / 2), c)
@@ -527,7 +527,7 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
   //  S(4) -> SO(3) -> S(4)
   //  For now I'll just test this numerically.
 
-  auto cast_to_float = [](const Expr& expr) -> double {
+  auto cast_to_float = [](const scalar_expr& expr) -> double {
     if (expr.is_type<float_constant>()) {
       return cast_checked<const float_constant>(expr).get_value();
     }

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -13,10 +13,10 @@ namespace wf {
 using namespace wf::custom_literals;
 
 TEST(ScalarOperationsTest, TestAddition) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_TRUE((x + y).is_type<addition>());
   ASSERT_IDENTICAL(x + y, x + y);
   ASSERT_IDENTICAL(x + y, y + x);
@@ -72,9 +72,9 @@ TEST(ScalarOperationsTest, TestAdditionUndefined) {
 }
 
 TEST(ScalarOperationsTest, TestMultiplication) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_TRUE((x * y).is_type<multiplication>());
   ASSERT_IDENTICAL(x * y, x * y);
   ASSERT_EQ("Multiplication", (x * y).type_name());
@@ -167,7 +167,7 @@ TEST(ScalarOperationsTest, TestMultiplicationUndefined) {
 }
 
 TEST(ScalarOperationsTest, TestNegation) {
-  const Expr x{"x"};
+  const scalar_expr x{"x"};
   ASSERT_IDENTICAL(-x, -x);
   ASSERT_TRUE((-x).is_type<multiplication>());
   ASSERT_IDENTICAL(-(-x), x);
@@ -175,9 +175,9 @@ TEST(ScalarOperationsTest, TestNegation) {
 }
 
 TEST(ScalarOperationsTest, TestDivision) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
   ASSERT_IDENTICAL(x / y, x / y);
   ASSERT_TRUE((x / y).is_type<multiplication>());
   ASSERT_NOT_IDENTICAL(y / x, x / y);
@@ -202,9 +202,9 @@ TEST(ScalarOperationsTest, TestDivision) {
 }
 
 TEST(ScalarOperationsTest, TestAsCoeffAndMultiplicand) {
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
 
   ASSERT_IDENTICAL(constants::zero, as_coeff_and_mul(0).first);
   ASSERT_IDENTICAL(constants::one, as_coeff_and_mul(0).second);
@@ -232,9 +232,9 @@ TEST(ScalarOperationsTest, TestAsCoeffAndMultiplicand) {
 
 TEST(ScalarOperationsTest, TestPower) {
   const auto [x, y, z] = make_symbols("x", "y", "z");
-  const Expr w{"w", number_set::real_non_negative};
-  const Expr u{"u", number_set::real_positive};
-  const Expr v{"v", number_set::real};
+  const scalar_expr w{"w", number_set::real_non_negative};
+  const scalar_expr u{"u", number_set::real_positive};
+  const scalar_expr v{"v", number_set::real};
 
   ASSERT_IDENTICAL(pow(x, y), pow(x, y));
   ASSERT_NOT_IDENTICAL(pow(x, y), pow(y, x));
@@ -264,9 +264,9 @@ TEST(ScalarOperationsTest, TestPower) {
   ASSERT_IDENTICAL(1 / 5_s, pow(5, -1));
 
   // Floats...
-  ASSERT_IDENTICAL(Expr{std::pow(2.0, 4.5)}, pow(2, 4.5));
-  ASSERT_IDENTICAL(Expr{std::pow(1.122, 6.0)}, pow(1.122, 6));
-  ASSERT_IDENTICAL(Expr{std::pow(6.7, -0.5)}, pow(6.7, -0.5));
+  ASSERT_IDENTICAL(scalar_expr{std::pow(2.0, 4.5)}, pow(2, 4.5));
+  ASSERT_IDENTICAL(scalar_expr{std::pow(1.122, 6.0)}, pow(1.122, 6));
+  ASSERT_IDENTICAL(scalar_expr{std::pow(6.7, -0.5)}, pow(6.7, -0.5));
 
   // Rational powers of integers:
   ASSERT_IDENTICAL(0, pow(0, 6_s / 11));
@@ -324,7 +324,7 @@ TEST(ScalarOperationsTest, TestPower) {
   ASSERT_NOT_IDENTICAL(pow(x, y / 4), pow(pow(x, y), 1 / 4_s));
 
   // Simplifications when the inner value is non-negative:
-  for (const Expr& s : {w, u}) {
+  for (const scalar_expr& s : {w, u}) {
     ASSERT_IDENTICAL(s, pow(pow(s, 2), 1 / 2_s));
     ASSERT_IDENTICAL(s, pow(pow(s, 3), 1 / 3_s));
     ASSERT_IDENTICAL(pow(s, 12 / 7_s), pow(pow(s, 2), 6 / 7_s));
@@ -482,20 +482,20 @@ TEST(ScalarOperationsTest, TestConditional) {
   ASSERT_IDENTICAL(abs(x) + z * 5, where(x - y < z, abs(x) + z * 5, abs(x) + z * 5));
 
   // Nested conditionals don't simplify:
-  const Expr nested = where(x < 0, where(x < 0, cos(x), sin(x)), log(z));
+  const scalar_expr nested = where(x < 0, where(x < 0, cos(x), sin(x)), log(z));
   ASSERT_IDENTICAL(cast_checked<const conditional>(nested).if_branch(),
                    where(x < 0, cos(x), sin(x)));
   ASSERT_IDENTICAL(cast_checked<const conditional>(nested).else_branch(), log(z));
 }
 
 TEST(ScalarOperationsTest, TestDistribute) {
-  const Expr w{"w"};
-  const Expr x{"x"};
-  const Expr y{"y"};
-  const Expr z{"z"};
-  const Expr p{"p"};
-  const Expr q{"q"};
-  const Expr v{"v"};
+  const scalar_expr w{"w"};
+  const scalar_expr x{"x"};
+  const scalar_expr y{"y"};
+  const scalar_expr z{"z"};
+  const scalar_expr p{"p"};
+  const scalar_expr q{"q"};
+  const scalar_expr v{"v"};
   ASSERT_IDENTICAL(x, x.distribute());
   ASSERT_IDENTICAL(x + y, (x + y).distribute());
   ASSERT_IDENTICAL(6 + 3 * x, (3 * (x + 2)).distribute());
@@ -644,8 +644,8 @@ TEST(ScalarOperationsTest, TestCollectMany) {
 
   // Generate a polynomial in four variables:
   // Use std::function, so that we can recurse this lambda.
-  std::function<Expr(absl::Span<const Expr>)> make_poly;
-  make_poly = [&make_poly](absl::Span<const Expr> vars) -> Expr {
+  std::function<scalar_expr(absl::Span<const scalar_expr>)> make_poly;
+  make_poly = [&make_poly](absl::Span<const scalar_expr> vars) -> scalar_expr {
     if (vars.size() == 1) {
       return pow(vars[0], 2) + vars[0] + 1;
     } else {
@@ -659,15 +659,16 @@ TEST(ScalarOperationsTest, TestCollectMany) {
 }
 
 TEST(ScalarOperationsTest, TestNumericSetsVariables) {
-  ASSERT_EQ(number_set::unknown, determine_numeric_set(Expr{"x"}));
-  ASSERT_EQ(number_set::real, determine_numeric_set(Expr{"x", number_set::real}));
-  ASSERT_EQ(number_set::complex, determine_numeric_set(Expr{"x", number_set::complex}));
+  ASSERT_EQ(number_set::unknown, determine_numeric_set(scalar_expr{"x"}));
+  ASSERT_EQ(number_set::real, determine_numeric_set(scalar_expr{"x", number_set::real}));
+  ASSERT_EQ(number_set::complex, determine_numeric_set(scalar_expr{"x", number_set::complex}));
 
   // Identical must consider the numeric set of the variable.
-  ASSERT_IDENTICAL(Expr("x"), Expr("x", number_set::unknown));
-  ASSERT_IDENTICAL(Expr("x", number_set::real), Expr("x", number_set::real));
-  ASSERT_NOT_IDENTICAL(Expr("x", number_set::real), Expr("x", number_set::complex));
-  ASSERT_NOT_IDENTICAL(Expr("x", number_set::real), Expr("x", number_set::real_non_negative));
+  ASSERT_IDENTICAL(scalar_expr("x"), scalar_expr("x", number_set::unknown));
+  ASSERT_IDENTICAL(scalar_expr("x", number_set::real), scalar_expr("x", number_set::real));
+  ASSERT_NOT_IDENTICAL(scalar_expr("x", number_set::real), scalar_expr("x", number_set::complex));
+  ASSERT_NOT_IDENTICAL(scalar_expr("x", number_set::real),
+                       scalar_expr("x", number_set::real_non_negative));
 }
 
 TEST(ScalarOperationsTest, TestNumericSetsNumericalValues) {
@@ -743,11 +744,11 @@ TEST(ScalarOperationsTest, TestNumericSetsAddMul) {
 }
 
 TEST(ScalarOperationsTest, TestNumericSetsPow) {
-  const Expr real = make_unique_variable_symbol(number_set::real);
-  const Expr real_non_negative = make_unique_variable_symbol(number_set::real_non_negative);
-  const Expr real_positive = make_unique_variable_symbol(number_set::real_positive);
-  const Expr complex{"z", number_set::complex};
-  const Expr unknown{"v", number_set::unknown};
+  const scalar_expr real = make_unique_variable_symbol(number_set::real);
+  const scalar_expr real_non_negative = make_unique_variable_symbol(number_set::real_non_negative);
+  const scalar_expr real_positive = make_unique_variable_symbol(number_set::real_positive);
+  const scalar_expr complex{"z", number_set::complex};
+  const scalar_expr unknown{"v", number_set::unknown};
 
   ASSERT_EQ(number_set::real_non_negative, determine_numeric_set(real * real));
   ASSERT_EQ(number_set::real_non_negative, determine_numeric_set(pow(real, 4)));
@@ -781,10 +782,10 @@ TEST(ScalarOperationsTest, TestNumericSetsPow) {
 }
 
 TEST(ScalarOperationsTest, TestNumericSetsFunctions) {
-  const Expr real{"x", number_set::real};
-  const Expr real_non_negative{"y", number_set::real_non_negative};
-  const Expr real_positive{"w", number_set::real_positive};
-  const Expr complex{"z", number_set::complex};
+  const scalar_expr real{"x", number_set::real};
+  const scalar_expr real_non_negative{"y", number_set::real_non_negative};
+  const scalar_expr real_positive{"w", number_set::real_positive};
+  const scalar_expr complex{"z", number_set::complex};
 
   ASSERT_EQ(number_set::real, determine_numeric_set(cos(real)));
   ASSERT_EQ(number_set::real, determine_numeric_set(sin(real)));
@@ -827,10 +828,10 @@ TEST(ScalarOperationsTest, TestNumericSetsSpecialValues) {
 }
 
 TEST(ScalarOperationsTest, TestNumericSetsConditional) {
-  const Expr real{"x", number_set::real};
-  const Expr real_non_negative{"y", number_set::real_non_negative};
-  const Expr real_positive{"w", number_set::real_positive};
-  const Expr complex{"z", number_set::complex};
+  const scalar_expr real{"x", number_set::real};
+  const scalar_expr real_non_negative{"y", number_set::real_non_negative};
+  const scalar_expr real_positive{"w", number_set::real_positive};
+  const scalar_expr complex{"z", number_set::complex};
 
   ASSERT_EQ(number_set::real_non_negative,
             determine_numeric_set(real > 0));  //  TODO: Should be boolean.

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -16,11 +16,13 @@ namespace wf {
 namespace ta = type_annotations;
 
 // A very simple function that combines three input arguments.
-inline Expr simple_multiply_add(Expr x, Expr y, Expr z) { return x * y + z; }
+inline scalar_expr simple_multiply_add(scalar_expr x, scalar_expr y, scalar_expr z) {
+  return x * y + z;
+}
 
 // Rotate a 2D vector by an angle. Output the vector, and its derivative with respect
 // to the angle.
-inline auto vector_rotation_2d(Expr theta, ta::static_matrix<2, 1> v) {
+inline auto vector_rotation_2d(scalar_expr theta, ta::static_matrix<2, 1> v) {
   matrix_expr R = make_matrix(2, 2, cos(theta), -sin(theta), sin(theta), cos(theta));
   ta::static_matrix<2, 1> v_rot{R * v};
   ta::static_matrix<2, 1> v_dot_D_theta{v_rot.inner().diff(theta)};
@@ -29,46 +31,46 @@ inline auto vector_rotation_2d(Expr theta, ta::static_matrix<2, 1> v) {
 
 // Norm of a 3D vector + the 1x3 derivative.
 inline auto vector_norm_3d(ta::static_matrix<3, 1> v) {
-  Expr len = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+  scalar_expr len = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
   auto D_v = ta::static_matrix<1, 3>{len.diff(v[0]), len.diff(v[1]), len.diff(v[2])};
   return std::make_tuple(return_value(len), output_arg("D_v", D_v));
 }
 
 // Heaviside step function - a very simple test of conditionals.
-inline Expr heaviside(Expr x) { return where(x >= 0, 1, 0); }
+inline scalar_expr heaviside(scalar_expr x) { return where(x >= 0, 1, 0); }
 
 // Exclusive or on the conditions x > 0 and y > 0 (a simple nested conditional).
-inline Expr exclusive_or(Expr x, Expr y) {
-  Expr cond_x = x > 0;
-  Expr cond_y = y > 0;
+inline scalar_expr exclusive_or(scalar_expr x, scalar_expr y) {
+  scalar_expr cond_x = x > 0;
+  scalar_expr cond_y = y > 0;
   return where(cond_x, where(cond_y, 0, 1), where(cond_y, 1, 0));
 }
 
 // Test generation of signum and abs.
-inline auto signum_and_abs(Expr x) {
+inline auto signum_and_abs(scalar_expr x) {
   return std::make_tuple(return_value(signum(x)), output_arg("abs", abs(x)));
 }
 
 // Arc-tangent w/ derivatives.
-inline auto atan2_with_derivatives(Expr y, Expr x) {
-  Expr f = atan2(y, x);
+inline auto atan2_with_derivatives(scalar_expr y, scalar_expr x) {
+  scalar_expr f = atan2(y, x);
   return std::make_tuple(return_value(f), output_arg("D_y", f.diff(y)),
                          output_arg("D_x", f.diff(x)));
 }
 
 // Three layers of nested conditionals.
-inline auto nested_conditionals_1(Expr x, Expr y) {
-  Expr c0 = where(y > 0, cos(x * y), cos(x) + 2);
-  Expr c1 = where(x > 0, log(abs(y)), atan2(y, x) * 3);
-  Expr c2 = where(abs(x) > abs(y), c0 * 3 - sqrt(abs(c0)), pow(abs(c1), 1.0 / 3.0) / 5);
+inline auto nested_conditionals_1(scalar_expr x, scalar_expr y) {
+  scalar_expr c0 = where(y > 0, cos(x * y), cos(x) + 2);
+  scalar_expr c1 = where(x > 0, log(abs(y)), atan2(y, x) * 3);
+  scalar_expr c2 = where(abs(x) > abs(y), c0 * 3 - sqrt(abs(c0)), pow(abs(c1), 1.0 / 3.0) / 5);
   return c2;
 }
 
 // Nested conditionals, but only on the if-branch side.
-inline auto nested_conditionals_2(Expr x, Expr y) {
-  Expr c0 = where(y > 0, cos(x * y * constants::pi), sin(22 / y) - 3 * x);
-  Expr c1 = where(x > 0, c0, atan2(y * 0.4, x * 0.1) * 19 - y);
-  Expr c2 = where(abs(x) > abs(y), c1, sqrt(abs(x * y + 2 * x)));
+inline auto nested_conditionals_2(scalar_expr x, scalar_expr y) {
+  scalar_expr c0 = where(y > 0, cos(x * y * constants::pi), sin(22 / y) - 3 * x);
+  scalar_expr c1 = where(x > 0, c0, atan2(y * 0.4, x * 0.1) * 19 - y);
+  scalar_expr c2 = where(abs(x) > abs(y), c1, sqrt(abs(x * y + 2 * x)));
   return c2;
 }
 
@@ -89,7 +91,7 @@ inline auto rotation_vector_from_matrix(ta::static_matrix<3, 3> R) {
 }
 
 // A function with no required outputs (all outputs optional).
-inline auto no_required_outputs(Expr x) {
+inline auto no_required_outputs(scalar_expr x) {
   return std::make_tuple(optional_output_arg("out1", cos(x) + 2),
                          optional_output_arg("out2", abs(x) * 2));
 }
@@ -97,14 +99,14 @@ inline auto no_required_outputs(Expr x) {
 namespace symbolic {
 // A simple custom type.
 struct Point2d {
-  Expr x{0};
-  Expr y{0};
+  scalar_expr x{0};
+  scalar_expr y{0};
 };
 
 // Custom type with nested type.
 struct Circle {
   Point2d center{};
-  Expr radius{0};
+  scalar_expr radius{0};
 };
 
 }  // namespace symbolic
@@ -129,12 +131,12 @@ struct custom_type_registrant<symbolic::Circle> {
 
 // A method that accepts a custom point.
 inline symbolic::Point2d custom_type_1(const symbolic::Point2d& p) {
-  const Expr norm = sqrt(p.x * p.x + p.y * p.y);
+  const scalar_expr norm = sqrt(p.x * p.x + p.y * p.y);
   return {where(norm > 0, p.x / norm, 0), where(norm > 0, p.y / norm, 0)};
 }
 
 // A method that outputs a custom type via optional output argument.
-inline auto custom_type_2(Expr theta, Expr radius) {
+inline auto custom_type_2(scalar_expr theta, scalar_expr radius) {
   symbolic::Point2d p{cos(theta) * radius, sin(theta) * radius};
   ta::static_matrix<2, 2> D_inputs = make_vector(p.x, p.y).jacobian({theta, radius});
   return std::make_tuple(optional_output_arg("out", p), optional_output_arg("D_inputs", D_inputs));
@@ -143,8 +145,8 @@ inline auto custom_type_2(Expr theta, Expr radius) {
 // Construct a nested custom type.
 inline auto nested_custom_type_1(symbolic::Circle a, symbolic::Point2d b) {
   // Expand circle `a` if required to fit point `b`.
-  Expr d2 = make_vector(a.center.x - b.x, a.center.y - b.y).squared_norm();
-  Expr d = sqrt(d2);
+  scalar_expr d2 = make_vector(a.center.x - b.x, a.center.y - b.y).squared_norm();
+  scalar_expr d = sqrt(d2);
   symbolic::Circle result{};
   result.radius = where(d <= a.radius, a.radius, d);
   result.center = a.center;
@@ -152,20 +154,20 @@ inline auto nested_custom_type_1(symbolic::Circle a, symbolic::Point2d b) {
 }
 
 // Declare an external function.
-struct external_function_1
-    : declare_external_function<external_function_1, Expr, type_list<Expr, Expr>> {
+struct external_function_1 : declare_external_function<external_function_1, scalar_expr,
+                                                       type_list<scalar_expr, scalar_expr>> {
   static constexpr std::string_view name() noexcept { return "external_function_1"; }
   static constexpr auto arg_names() noexcept { return std::make_tuple("arg0", "arg1"); }
 };
 
-inline auto external_function_call_1(Expr x, Expr y) {
-  const Expr f = external_function_1::call(x * 2, y - 5);
+inline auto external_function_call_1(scalar_expr x, scalar_expr y) {
+  const scalar_expr f = external_function_1::call(x * 2, y - 5);
   return f * x;
 }
 
 // An external function that accepts a matrix argument.
-struct external_function_2
-    : declare_external_function<external_function_2, Expr, type_list<ta::static_matrix<2, 3>>> {
+struct external_function_2 : declare_external_function<external_function_2, scalar_expr,
+                                                       type_list<ta::static_matrix<2, 3>>> {
   static constexpr std::string_view name() noexcept { return "external_function_2"; }
   static constexpr auto arg_names() noexcept { return std::make_tuple("arg0"); }
 };
@@ -187,7 +189,7 @@ struct external_function_3
   static constexpr auto arg_names() noexcept { return std::make_tuple("arg0", "arg1"); }
 };
 
-inline auto external_function_call_3(Expr x, ta::static_matrix<2, 1> v) {
+inline auto external_function_call_3(scalar_expr x, ta::static_matrix<2, 1> v) {
   return external_function_3::call(make_vector(x, pow(x, 2)), v);
 }
 
@@ -198,27 +200,27 @@ struct external_function_4 : declare_external_function<external_function_4, symb
   static constexpr auto arg_names() noexcept { return std::make_tuple("p"); }
 };
 
-inline auto external_function_call_4(Expr a, Expr b) {
+inline auto external_function_call_4(scalar_expr a, scalar_expr b) {
   const symbolic::Point2d p = external_function_4::call(symbolic::Point2d{a - b, b * 2});
   return where(abs(p.x) > abs(p.y), p.x, p.y);
 }
 
 // A external function that accepts a nested custom type.
 struct external_function_5
-    : declare_external_function<external_function_5, Expr,
+    : declare_external_function<external_function_5, scalar_expr,
                                 type_list<symbolic::Circle, symbolic::Circle>> {
   static constexpr std::string_view name() noexcept { return "external_function_5"; }
   static constexpr auto arg_names() noexcept { return std::make_tuple("c", "p"); }
 };
 
-inline auto external_function_call_5(symbolic::Circle c, Expr x, Expr y) {
+inline auto external_function_call_5(symbolic::Circle c, scalar_expr x, scalar_expr y) {
   return 2 * external_function_5::call(c, symbolic::Circle{symbolic::Point2d{x, y}, 1.0}) - 1;
 }
 
 // Pass the result of one external function to another. Fill the first one in a conditional.
-inline auto external_function_call_6(Expr x, Expr y) {
-  Expr a = where(abs(x) > abs(y), x, y);
-  Expr b = where(abs(x) > abs(y), y * 2, x * 3);
+inline auto external_function_call_6(scalar_expr x, scalar_expr y) {
+  scalar_expr a = where(abs(x) > abs(y), x, y);
+  scalar_expr b = where(abs(x) > abs(y), y * 2, x * 3);
   symbolic::Point2d p1{a, b};
   symbolic::Point2d p2 = external_function_4::call(p1);
   return external_function_4::call(p2);

--- a/components/core/wf/code_generation/expression_group.h
+++ b/components/core/wf/code_generation/expression_group.h
@@ -42,12 +42,12 @@ struct output_key {
 // we want to code-generate.
 struct expression_group {
   // All the expressions in this group.
-  std::vector<Expr> expressions;
+  std::vector<scalar_expr> expressions;
 
   // Key describing how these expressions are used in a function we intend to code generate.
   output_key key;
 
-  expression_group(std::vector<Expr> expressions, output_key key) noexcept
+  expression_group(std::vector<scalar_expr> expressions, output_key key) noexcept
       : expressions(std::move(expressions)), key(std::move(key)) {}
 };
 

--- a/components/core/wf/code_generation/function_description.cc
+++ b/components/core/wf/code_generation/function_description.cc
@@ -23,11 +23,11 @@ bool is_identical_struct<argument>::operator()(const argument& a, const argument
 function_description::function_description(std::string name) noexcept
     : impl_(std::make_shared<impl>(std::move(name))) {}
 
-std::variant<Expr, matrix_expr, compound_expr> function_description::add_input_argument(
+std::variant<scalar_expr, matrix_expr, compound_expr> function_description::add_input_argument(
     const std::string_view name, type_variant type) {
   const argument& arg = add_argument(name, std::move(type), argument_direction::input);
 
-  using return_type = std::variant<Expr, matrix_expr, compound_expr>;
+  using return_type = std::variant<scalar_expr, matrix_expr, compound_expr>;
   return std::visit(
       [&](const auto& type_concrete) -> return_type {
         return detail::create_function_input(type_concrete, arg.index());
@@ -37,7 +37,7 @@ std::variant<Expr, matrix_expr, compound_expr> function_description::add_input_a
 
 void function_description::add_output_argument(const std::string_view name, type_variant type,
                                                const bool is_optional,
-                                               std::vector<Expr> expressions) {
+                                               std::vector<scalar_expr> expressions) {
   add_argument(name, std::move(type),
                is_optional ? argument_direction::optional_output : argument_direction::output);
 
@@ -48,7 +48,8 @@ void function_description::add_output_argument(const std::string_view name, type
 }
 
 // ReSharper disable once CppMemberFunctionMayBeConst
-void function_description::set_return_value(type_variant type, std::vector<Expr> expressions) {
+void function_description::set_return_value(type_variant type,
+                                            std::vector<scalar_expr> expressions) {
   WF_ASSERT(!impl_->return_value_type.has_value(), "Return value on function `{}` already set.",
             name());
   impl_->return_value_type = std::move(type);

--- a/components/core/wf/code_generation/function_description.h
+++ b/components/core/wf/code_generation/function_description.h
@@ -100,28 +100,28 @@ class function_description {
   // Returns the argument that the python side should pass to the user method.
   // For custom types, we return a vector of expressions and the python side must map these to
   // fields on the user's custom type.
-  std::variant<Expr, matrix_expr, compound_expr> add_input_argument(std::string_view name,
-                                                                    type_variant type);
+  std::variant<scalar_expr, matrix_expr, compound_expr> add_input_argument(std::string_view name,
+                                                                           type_variant type);
 
   // Record an output.
   void add_output_argument(std::string_view name, type_variant type, bool is_optional,
-                           std::vector<Expr> expressions);
+                           std::vector<scalar_expr> expressions);
 
   // Set the return value. Only one return value is presently supported, so this may only be invoked
   // once.
-  void set_return_value(type_variant type, std::vector<Expr> expressions);
+  void set_return_value(type_variant type, std::vector<scalar_expr> expressions);
 
   // Add a `return_value` to this signature.
   template <typename Value, typename Type>
   void add_output_value(const return_value<Value>& value, Type type) {
-    std::vector<Expr> expressions = detail::extract_function_output(type, value.value());
+    std::vector<scalar_expr> expressions = detail::extract_function_output(type, value.value());
     set_return_value(std::move(type), std::move(expressions));
   }
 
   // Add an `output_arg` output to this function.
   template <typename Value, typename Type>
   void add_output_value(const output_arg<Value>& value, Type type) {
-    std::vector<Expr> expressions = detail::extract_function_output(type, value.value());
+    std::vector<scalar_expr> expressions = detail::extract_function_output(type, value.value());
     add_output_argument(value.name(), std::move(type), value.is_optional(), std::move(expressions));
   }
 

--- a/components/core/wf/code_generation/ir_builder.h
+++ b/components/core/wf/code_generation/ir_builder.h
@@ -138,8 +138,8 @@ enum class search_direction { downwards, upwards };
 // Find the block where control flow merges after branching into left/right.
 ir::block_ptr find_merge_point(ir::block_ptr left, ir::block_ptr right, search_direction direction);
 
-// Re-create `Expr` tree from the IR representation. For use in round-trip unit tests.
-std::unordered_map<output_key, std::vector<Expr>, hash_struct<output_key>>
+// Re-create `scalar_expr` tree from the IR representation. For use in round-trip unit tests.
+std::unordered_map<output_key, std::vector<scalar_expr>, hash_struct<output_key>>
 create_output_expression_map(ir::block_ptr starting_block,
                              std::unordered_map<std::string, bool>&& output_arg_exists);
 

--- a/components/core/wf/code_generation/type_registry.cc
+++ b/components/core/wf/code_generation/type_registry.cc
@@ -5,12 +5,13 @@
 namespace wf::detail {
 
 // TODO: Pass the numeric type information here.
-Expr create_function_input(const scalar_type&, const std::size_t arg_index) {
+scalar_expr create_function_input(const scalar_type&, const std::size_t arg_index) {
   return variable::create_function_argument(arg_index, 0);
 }
 
-static std::vector<Expr> create_function_args(const std::size_t arg_index, const std::size_t size) {
-  std::vector<Expr> expressions{};
+static std::vector<scalar_expr> create_function_args(const std::size_t arg_index,
+                                                     const std::size_t size) {
+  std::vector<scalar_expr> expressions{};
   expressions.reserve(size);
   for (const std::size_t index : make_range(size)) {
     expressions.push_back(variable::create_function_argument(arg_index, index));
@@ -23,11 +24,11 @@ matrix_expr create_function_input(const matrix_type& mat, const std::size_t arg_
 }
 
 // TODO: The numeric type information needs to be propagate to the IR here.
-std::vector<Expr> extract_function_output(const scalar_type&, const Expr& value) {
+std::vector<scalar_expr> extract_function_output(const scalar_type&, const scalar_expr& value) {
   return std::vector(1, value);
 }
 
-std::vector<Expr> extract_function_output(const matrix_type&, const matrix_expr& value) {
+std::vector<scalar_expr> extract_function_output(const matrix_type&, const matrix_expr& value) {
   return value.to_vector();
 }
 

--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -9,9 +9,9 @@ namespace wf {
 // Visitor for collecting terms.
 // Can transform x^2*y + x^2*pi + -x * 5 - cos(z) * x --> x^2 * (y + pi) + x * (-5 - cos(z))
 struct collect_visitor {
-  explicit collect_visitor(const absl::Span<const Expr> terms) : collected_terms_(terms) {}
+  explicit collect_visitor(const absl::Span<const scalar_expr> terms) : collected_terms_(terms) {}
 
-  Expr operator()(const Expr& x) { return visit(x, *this); }
+  scalar_expr operator()(const scalar_expr& x) { return visit(x, *this); }
   compound_expr operator()(const compound_expr& x) { return map_compound_expressions(x, *this); }
 
   template <typename T>
@@ -19,66 +19,70 @@ struct collect_visitor {
     return op.map_children(*this);
   }
 
-  Expr collect_addition_terms(addition::container_type&& container) const {
+  scalar_expr collect_addition_terms(addition::container_type&& container) const {
     // iterate over the terms we want to search for:
-    const Expr& collected_term = collected_terms_.front();
+    const scalar_expr& collected_term = collected_terms_.front();
 
     // Mapping from exponents of `collected_term` to the values multiplied by them.
     // For example, if given: x**2 * 3 + x*5 - x**2 * pi
     // This map would look like:
     //  2 --> [3]
     //  1 --> [5, pi]
-    std::unordered_map<Expr, addition::container_type, hash_struct<Expr>, is_identical_struct<Expr>>
+    std::unordered_map<scalar_expr, addition::container_type, hash_struct<scalar_expr>,
+                       is_identical_struct<scalar_expr>>
         exponents_to_mul{};
 
-    const auto new_end = std::remove_if(container.begin(), container.end(), [&](const Expr& child) {
-      if (const multiplication* mul = cast_ptr<const multiplication>(child); mul != nullptr) {
-        // Look for relevant terms:
-        std::optional<Expr> exponent;
-        const auto it = std::find_if(mul->begin(), mul->end(), [&](const Expr& mul_term) {
-          auto [base, exp] = as_base_and_exp(mul_term);
-          if (base.is_identical_to(collected_term)) {
-            // found the base we want
-            exponent = std::move(exp);
+    const auto new_end =
+        std::remove_if(container.begin(), container.end(), [&](const scalar_expr& child) {
+          if (const multiplication* mul = cast_ptr<const multiplication>(child); mul != nullptr) {
+            // Look for relevant terms:
+            std::optional<scalar_expr> exponent;
+            const auto it =
+                std::find_if(mul->begin(), mul->end(), [&](const scalar_expr& mul_term) {
+                  auto [base, exp] = as_base_and_exp(mul_term);
+                  if (base.is_identical_to(collected_term)) {
+                    // found the base we want
+                    exponent = std::move(exp);
+                    return true;
+                  }
+                  return false;
+                });
+
+            if (it == mul->end()) {
+              // The variable we are searching for doesn't appear in this term of the addition.
+              return false;
+            }
+
+            // The remaining terms (after factoring out the collected term) all get put into
+            // our table from exponents to coefficients of the collected term.
+            // So for example, if we had found `x**5 * pi * y`, we'd insert `pi` and `y` into the
+            // table.
+            if (it != mul->end()) {
+              multiplication::container_type mul_parts{};
+              std::copy(mul->begin(), it, std::back_inserter(mul_parts));
+              std::copy(std::next(it), mul->end(), std::back_inserter(mul_parts));
+              auto reduced_mul = multiplication::from_operands(mul_parts);
+              // TODO: Move into multiplication:
+              exponents_to_mul[*exponent].push_back(std::move(reduced_mul));
+            }
             return true;
+          } else {
+            auto [base, exp] = as_base_and_exp(child);
+            if (base.is_identical_to(collected_term)) {
+              // This term is standalone in the sum, so just push one
+              exponents_to_mul[exp].push_back(constants::one);
+              return true;
+            }
           }
           return false;
         });
-
-        if (it == mul->end()) {
-          // The variable we are searching for doesn't appear in this term of the addition.
-          return false;
-        }
-
-        // The remaining terms (after factoring out the collected term) all get put into
-        // our table from exponents to coefficients of the collected term.
-        // So for example, if we had found `x**5 * pi * y`, we'd insert `pi` and `y` into the table.
-        if (it != mul->end()) {
-          multiplication::container_type mul_parts{};
-          std::copy(mul->begin(), it, std::back_inserter(mul_parts));
-          std::copy(std::next(it), mul->end(), std::back_inserter(mul_parts));
-          auto reduced_mul = multiplication::from_operands(mul_parts);
-          // TODO: Move into multiplication:
-          exponents_to_mul[*exponent].push_back(std::move(reduced_mul));
-        }
-        return true;
-      } else {
-        auto [base, exp] = as_base_and_exp(child);
-        if (base.is_identical_to(collected_term)) {
-          // This term is standalone in the sum, so just push one
-          exponents_to_mul[exp].push_back(constants::one);
-          return true;
-        }
-      }
-      return false;
-    });
 
     container.erase(new_end, container.end());
 
     // We need to recurse on the remaining terms in the container.
     // Some terms ignored above could still be relevant to the other terms we are collecting over.
     if (collected_terms_.size() > 1 && !container.empty()) {
-      Expr remaining_addition_terms =
+      scalar_expr remaining_addition_terms =
           collect_visitor{collected_terms_.subspan(1)}.collect_addition_terms(std::move(container));
       container.clear();
       container.push_back(std::move(remaining_addition_terms));
@@ -87,59 +91,59 @@ struct collect_visitor {
     // Now we're done with the first term, we recurse for the remaining terms.
     for (auto it = exponents_to_mul.begin(); it != exponents_to_mul.end(); ++it) {
       // The term we are collecting, e.g. x, x**2, x**3, etc...
-      Expr collected_pow = power::create(collected_term, it->first);
+      scalar_expr collected_pow = power::create(collected_term, it->first);
 
       // Check if we need to collect remaining terms of our coefficient, otherwise just turn it into
       // an addition. In some cases, the addition might just reduce to a single expression.
-      Expr term_coefficient =
+      scalar_expr term_coefficient =
           collected_terms_.size() > 1
               ? collect_visitor{collected_terms_.subspan(1)}.collect_addition_terms(
                     std::move(it->second))
               : addition::from_operands(it->second);
 
       // Multiply the power by the collected terms: x**2 * (y + pi - 3)
-      Expr mul =
+      scalar_expr mul =
           multiplication::from_operands({std::move(collected_pow), std::move(term_coefficient)});
       container.push_back(std::move(mul));
     }
     return addition::from_operands(container);  //  TODO: should be a move
   }
 
-  Expr operator()(const addition& add) {
+  scalar_expr operator()(const addition& add) {
     // transform all children of the addition:
     addition::container_type children{};
     children.reserve(add.size());
     std::transform(add.begin(), add.end(), std::back_inserter(children),
-                   [this](const Expr& x) { return visit(x, *this); });
+                   [this](const scalar_expr& x) { return visit(x, *this); });
     return collect_addition_terms(std::move(children));
   }
 
-  Expr operator()(const compound_expression_element& el) { return el.map_children(*this); }
+  scalar_expr operator()(const compound_expression_element& el) { return el.map_children(*this); }
 
-  Expr operator()(const multiplication& mul, const Expr&) { return recurse(mul); }
-  Expr operator()(const function& f) { return recurse(f); }
-  Expr operator()(const power& pow) { return recurse(pow); }
-  Expr operator()(const cast_bool& cast) { return recurse(cast); }
-  Expr operator()(const conditional& conditional) { return recurse(conditional); }
-  Expr operator()(const symbolic_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const derivative& diff, const Expr&) { return recurse(diff); }
-  Expr operator()(const complex_infinity&, const Expr& arg) const { return arg; }
-  Expr operator()(const integer_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const float_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const rational_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const relational& relation) { return recurse(relation); }
-  Expr operator()(const undefined&) const { return constants::undefined; }
-  Expr operator()(const variable&, const Expr& arg) const { return arg; }
+  scalar_expr operator()(const multiplication& mul, const scalar_expr&) { return recurse(mul); }
+  scalar_expr operator()(const function& f) { return recurse(f); }
+  scalar_expr operator()(const power& pow) { return recurse(pow); }
+  scalar_expr operator()(const cast_bool& cast) { return recurse(cast); }
+  scalar_expr operator()(const conditional& conditional) { return recurse(conditional); }
+  scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const derivative& diff, const scalar_expr&) { return recurse(diff); }
+  scalar_expr operator()(const complex_infinity&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const integer_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const float_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const relational& relation) { return recurse(relation); }
+  scalar_expr operator()(const undefined&) const { return constants::undefined; }
+  scalar_expr operator()(const variable&, const scalar_expr& arg) const { return arg; }
 
  private:
-  absl::Span<const Expr> collected_terms_;
+  absl::Span<const scalar_expr> collected_terms_;
 };
 
-Expr collect_many(const Expr& arg, const absl::Span<const Expr> terms) {
+scalar_expr collect_many(const scalar_expr& arg, const absl::Span<const scalar_expr> terms) {
   if (terms.empty()) {
     return arg;
   }
-  for (const Expr& term : terms) {
+  for (const scalar_expr& term : terms) {
     if (term.is_type<integer_constant, float_constant, rational_constant>()) {
       throw type_error("Arguments to collect cannot be numeric values. Term = {}", term);
     }
@@ -147,6 +151,8 @@ Expr collect_many(const Expr& arg, const absl::Span<const Expr> terms) {
   return visit(arg, collect_visitor{terms});
 }
 
-Expr collect(const Expr& arg, const Expr& term) { return collect_many(arg, {term}); }
+scalar_expr collect(const scalar_expr& arg, const scalar_expr& term) {
+  return collect_many(arg, {term});
+}
 
 }  // namespace wf

--- a/components/core/wf/common_visitors.h
+++ b/components/core/wf/common_visitors.h
@@ -24,7 +24,7 @@ struct is_numeric_visitor {
   }
 };
 
-inline bool is_numeric(const Expr& expr) { return visit(expr, is_numeric_visitor{}); }
+inline bool is_numeric(const scalar_expr& expr) { return visit(expr, is_numeric_visitor{}); }
 
 // Visitor that identifies negative numeric constants, or products of numeric constants that will be
 // negative.
@@ -40,7 +40,7 @@ struct is_negative_number_visitor {
 
   // Multiplications can be negative-like, if the product of all the constant terms is negative.
   bool operator()(const multiplication& m) const {
-    const std::size_t count = std::count_if(m.begin(), m.end(), [](const Expr& expr) {
+    const std::size_t count = std::count_if(m.begin(), m.end(), [](const scalar_expr& expr) {
       return visit(expr, is_negative_number_visitor{});
     });
     // odd = negative, even = positive
@@ -49,7 +49,7 @@ struct is_negative_number_visitor {
 };
 
 // TODO: This probably deserves a better name, since it doesn't just check for numbers.
-inline bool is_negative_number(const Expr& expr) {
+inline bool is_negative_number(const scalar_expr& expr) {
   return visit(expr, is_negative_number_visitor{});
 }
 

--- a/components/core/wf/compound_expression.cc
+++ b/components/core/wf/compound_expression.cc
@@ -13,9 +13,9 @@ std::string compound_expr::to_string() const {
   return formatter.take_output();
 }
 
-std::vector<Expr> create_expression_elements(const compound_expr& provenance,
-                                             const std::size_t num) {
-  std::vector<Expr> elements{};
+std::vector<scalar_expr> create_expression_elements(const compound_expr& provenance,
+                                                    const std::size_t num) {
+  std::vector<scalar_expr> elements{};
   elements.reserve(num);
   for (const std::size_t index : make_range(num)) {
     elements.emplace_back(compound_expression_element::create(provenance, index));
@@ -28,7 +28,7 @@ compound_expr create_custom_type_argument(const custom_type& type, const std::si
 }
 
 compound_expr create_custom_type_construction(const custom_type& type,
-                                              std::vector<Expr> expressions) {
+                                              std::vector<scalar_expr> expressions) {
   return custom_type_construction::create(type, std::move(expressions));
 }
 

--- a/components/core/wf/compound_expression.h
+++ b/components/core/wf/compound_expression.h
@@ -39,13 +39,14 @@ struct order_struct<compound_expr> {
 
 // Create `num` instances of `compound_expression_element` whose provenance is the provided compound
 // expression.
-std::vector<Expr> create_expression_elements(const compound_expr& provenance, std::size_t num);
+std::vector<scalar_expr> create_expression_elements(const compound_expr& provenance,
+                                                    std::size_t num);
 
 // Create compound expression with type `custom_type_argument` using the provided type and argument.
 compound_expr create_custom_type_argument(const class custom_type& type, std::size_t arg_index);
 
 // Create compound expression with type `custom_type_construction`.
 compound_expr create_custom_type_construction(const custom_type& type,
-                                              std::vector<Expr> expressions);
+                                              std::vector<scalar_expr> expressions);
 
 }  // namespace wf

--- a/components/core/wf/constants.cc
+++ b/components/core/wf/constants.cc
@@ -6,16 +6,16 @@
 
 namespace wf {
 
-const Expr constants::zero = make_expr<integer_constant>(0);
-const Expr constants::one = make_expr<integer_constant>(1);
-const Expr constants::pi = make_expr<symbolic_constant>(symbolic_constant_enum::pi);
-const Expr constants::euler = make_expr<symbolic_constant>(symbolic_constant_enum::euler);
-const Expr constants::negative_one = make_expr<integer_constant>(-1);
-const Expr constants::complex_infinity = make_expr<wf::complex_infinity>();
-const Expr constants::boolean_true =
+const scalar_expr constants::zero = make_expr<integer_constant>(0);
+const scalar_expr constants::one = make_expr<integer_constant>(1);
+const scalar_expr constants::pi = make_expr<symbolic_constant>(symbolic_constant_enum::pi);
+const scalar_expr constants::euler = make_expr<symbolic_constant>(symbolic_constant_enum::euler);
+const scalar_expr constants::negative_one = make_expr<integer_constant>(-1);
+const scalar_expr constants::complex_infinity = make_expr<wf::complex_infinity>();
+const scalar_expr constants::boolean_true =
     make_expr<symbolic_constant>(symbolic_constant_enum::boolean_true);
-const Expr constants::boolean_false =
+const scalar_expr constants::boolean_false =
     make_expr<symbolic_constant>(symbolic_constant_enum::boolean_false);
-const Expr constants::undefined = make_expr<wf::undefined>();
+const scalar_expr constants::undefined = make_expr<wf::undefined>();
 
 }  // namespace wf

--- a/components/core/wf/constants.h
+++ b/components/core/wf/constants.h
@@ -4,34 +4,36 @@
 namespace wf {
 class constants {
  public:
-  static const Expr zero;
-  static const Expr one;
-  static const Expr pi;
-  static const Expr euler;
-  static const Expr negative_one;
-  static const Expr complex_infinity;
-  static const Expr boolean_true;
-  static const Expr boolean_false;
-  static const Expr undefined;
+  static const scalar_expr zero;
+  static const scalar_expr one;
+  static const scalar_expr pi;
+  static const scalar_expr euler;
+  static const scalar_expr negative_one;
+  static const scalar_expr complex_infinity;
+  static const scalar_expr boolean_true;
+  static const scalar_expr boolean_false;
+  static const scalar_expr undefined;
 };
 
-inline bool is_zero(const Expr& expr) { return expr.is_identical_to(constants::zero); }
+inline bool is_zero(const scalar_expr& expr) { return expr.is_identical_to(constants::zero); }
 
-inline bool is_one(const Expr& expr) { return expr.is_identical_to(constants::one); }
+inline bool is_one(const scalar_expr& expr) { return expr.is_identical_to(constants::one); }
 
-inline bool is_negative_one(const Expr& expr) {
+inline bool is_negative_one(const scalar_expr& expr) {
   return expr.is_identical_to(constants::negative_one);
 }
 
-inline bool is_pi(const Expr& expr) { return expr.is_identical_to(constants::pi); }
+inline bool is_pi(const scalar_expr& expr) { return expr.is_identical_to(constants::pi); }
 
-inline bool is_complex_infinity(const Expr& expr) {
+inline bool is_complex_infinity(const scalar_expr& expr) {
   return expr.is_identical_to(constants::complex_infinity);
 }
 
-inline bool is_undefined(const Expr& expr) { return expr.is_identical_to(constants::undefined); }
+inline bool is_undefined(const scalar_expr& expr) {
+  return expr.is_identical_to(constants::undefined);
+}
 
-inline bool is_numeric_or_constant(const Expr& expr) {
+inline bool is_numeric_or_constant(const scalar_expr& expr) {
   return expr.is_type<symbolic_constant, integer_constant, float_constant, rational_constant>();
 }
 

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -12,37 +12,40 @@ class derivative_visitor {
  public:
   // Construct w/ const reference to the variable to differentiate wrt to.
   // Must remain in scope for the duration of evaluation.
-  derivative_visitor(const Expr& argument, non_differentiable_behavior behavior);
+  derivative_visitor(const scalar_expr& argument, non_differentiable_behavior behavior);
 
   // Apply this visitor to the specified expression.
-  Expr apply(const Expr& expression);
+  scalar_expr apply(const scalar_expr& expression);
 
-  Expr operator()(const addition& add);
-  Expr operator()(const cast_bool&, const Expr& expr) const;
-  Expr operator()(const compound_expression_element&, const Expr& expr) const;
-  Expr operator()(const conditional& cond);
-  Expr operator()(const symbolic_constant&) const;
-  Expr operator()(const derivative& derivative, const Expr& derivative_abstract) const;
-  Expr operator()(const multiplication& mul);
-  Expr operator()(const function& func);
-  Expr operator()(const complex_infinity&) const;
-  Expr operator()(const integer_constant&) const;
-  Expr operator()(const float_constant&) const;
-  Expr operator()(const power& pow);
-  Expr operator()(const rational_constant&) const;
-  Expr operator()(const relational&, const Expr& rel_expr) const;
-  Expr operator()(const undefined&) const;
-  Expr operator()(const variable& var) const;
+  scalar_expr operator()(const addition& add);
+  scalar_expr operator()(const cast_bool&, const scalar_expr& expr) const;
+  scalar_expr operator()(const compound_expression_element&, const scalar_expr& expr) const;
+  scalar_expr operator()(const conditional& cond);
+  scalar_expr operator()(const symbolic_constant&) const;
+  scalar_expr operator()(const derivative& derivative,
+                         const scalar_expr& derivative_abstract) const;
+  scalar_expr operator()(const multiplication& mul);
+  scalar_expr operator()(const function& func);
+  scalar_expr operator()(const complex_infinity&) const;
+  scalar_expr operator()(const integer_constant&) const;
+  scalar_expr operator()(const float_constant&) const;
+  scalar_expr operator()(const power& pow);
+  scalar_expr operator()(const rational_constant&) const;
+  scalar_expr operator()(const relational&, const scalar_expr& rel_expr) const;
+  scalar_expr operator()(const undefined&) const;
+  scalar_expr operator()(const variable& var) const;
 
  private:
   // Argument we differentiate with respect to.
-  const Expr& argument_;
+  const scalar_expr& argument_;
 
   // See `non_differentiable_behavior` - how we handle non-differentiable functions.
   non_differentiable_behavior non_diff_behavior_;
 
   // Cache of f(x) --> df(x)/dx.
-  std::unordered_map<Expr, Expr, hash_struct<Expr>, is_identical_struct<Expr>> cache_;
+  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
+                     is_identical_struct<scalar_expr>>
+      cache_;
 };
 
 }  // namespace wf

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -10,27 +10,29 @@ namespace wf {
 // Visitor for distributing terms in multiplications:
 // (a + b) * (x + y) = a*x + a*y + b*x + b*y
 struct distribute_visitor {
-  Expr operator()(const Expr& x) const { return visit(x, *this); }
+  scalar_expr operator()(const scalar_expr& x) const { return visit(x, *this); }
 
   compound_expr operator()(const compound_expr& x) const {
     return map_compound_expressions(x, *this);
   }
 
-  Expr operator()(const addition& add) const { return add.map_children(&distribute); }
+  scalar_expr operator()(const addition& add) const { return add.map_children(&distribute); }
 
-  Expr operator()(const compound_expression_element& el) const { return el.map_children(*this); }
+  scalar_expr operator()(const compound_expression_element& el) const {
+    return el.map_children(*this);
+  }
 
-  Expr operator()(const multiplication& mul, const Expr&) const {
+  scalar_expr operator()(const multiplication& mul, const scalar_expr&) const {
     // First distribute all the children of the multiplication:
-    std::vector<Expr> children{};
+    std::vector<scalar_expr> children{};
     children.reserve(mul.size());
     std::transform(mul.begin(), mul.end(), std::back_inserter(children),
-                   [](const Expr& expr) { return distribute(expr); });
+                   [](const scalar_expr& expr) { return distribute(expr); });
 
     // Are any of the child expressions additions?
     const std::size_t total_terms = std::accumulate(
         children.begin(), children.end(), static_cast<std::size_t>(1lu),
-        [](std::size_t total, const Expr& expr) {
+        [](std::size_t total, const scalar_expr& expr) {
           if (const addition* const add = cast_ptr<const addition>(expr); add != nullptr) {
             total *= add->size();
           }
@@ -47,11 +49,12 @@ struct distribute_visitor {
 
     // Otherwise, we need to expand all the terms. This multiplication will become an addition of
     // multiplications. For each addition, we need to distribute its terms over the remaining
-    // values. TODO: Make each of these a small vector of Expr, then convert them to multiplication.
-    std::vector<Expr> output_terms(total_terms, constants::one);
+    // values. TODO: Make each of these a small vector of scalar_expr, then convert them to
+    // multiplication.
+    std::vector<scalar_expr> output_terms(total_terms, constants::one);
 
     std::size_t step = total_terms;
-    for (const Expr& expr : children) {
+    for (const scalar_expr& expr : children) {
       if (const addition* add = cast_ptr<const addition>(expr); add != nullptr) {
         // For additions, first update the step by dividing by the size of this addition:
         WF_ASSERT_EQUAL(0, step % add->size());
@@ -59,7 +62,7 @@ struct distribute_visitor {
         step /= add->size();
         // Now multiply terms in the addition:
         for (std::size_t out = 0; out < total_terms;) {
-          for (const Expr& term : *add) {
+          for (const scalar_expr& term : *add) {
             for (std::size_t rep = 0; rep < step; ++rep, ++out) {
               output_terms[out] = output_terms[out] * term;
             }
@@ -67,7 +70,7 @@ struct distribute_visitor {
         }
       } else {
         // Not an addition, multiply by everything:
-        for (Expr& output : output_terms) {
+        for (scalar_expr& output : output_terms) {
           output = output * expr;
         }
       }
@@ -76,35 +79,37 @@ struct distribute_visitor {
     return addition::from_operands(output_terms);
   }
 
-  Expr operator()(const function& f, const Expr&) const { return f.map_children(&distribute); }
+  scalar_expr operator()(const function& f, const scalar_expr&) const {
+    return f.map_children(&distribute);
+  }
 
-  Expr operator()(const power& pow, const Expr&) const {
+  scalar_expr operator()(const power& pow, const scalar_expr&) const {
     // TODO: If base is an addition, and exponent an integer, we should distribute.
-    const Expr& a = pow.base();
-    const Expr& b = pow.exponent();
+    const scalar_expr& a = pow.base();
+    const scalar_expr& b = pow.exponent();
     return power::create(distribute(a), distribute(b));
   }
 
-  Expr operator()(const cast_bool& cast) const { return cast.map_children(&distribute); }
-  Expr operator()(const conditional& conditional, const Expr&) const {
+  scalar_expr operator()(const cast_bool& cast) const { return cast.map_children(&distribute); }
+  scalar_expr operator()(const conditional& conditional, const scalar_expr&) const {
     return conditional.map_children(&distribute);
   }
 
-  Expr operator()(const symbolic_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const derivative& diff, const Expr&) const {
+  scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const derivative& diff, const scalar_expr&) const {
     return diff.map_children(&distribute);
   }
-  Expr operator()(const complex_infinity&, const Expr& arg) const { return arg; }
-  Expr operator()(const integer_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const float_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const rational_constant&, const Expr& arg) const { return arg; }
-  Expr operator()(const relational& relation, const Expr&) const {
+  scalar_expr operator()(const complex_infinity&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const integer_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const float_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const { return arg; }
+  scalar_expr operator()(const relational& relation, const scalar_expr&) const {
     return relation.map_children(&distribute);
   }
-  Expr operator()(const undefined&) const { return constants::undefined; }
-  Expr operator()(const variable&, const Expr& arg) const { return arg; }
+  scalar_expr operator()(const undefined&) const { return constants::undefined; }
+  scalar_expr operator()(const variable&, const scalar_expr& arg) const { return arg; }
 };
 
-Expr distribute(const Expr& arg) { return visit(arg, distribute_visitor{}); }
+scalar_expr distribute(const scalar_expr& arg) { return visit(arg, distribute_visitor{}); }
 
 }  // namespace wf

--- a/components/core/wf/evaluate.cc
+++ b/components/core/wf/evaluate.cc
@@ -6,7 +6,7 @@
 namespace wf {
 
 template <typename T, typename>
-Expr evaluate_visitor::operator()(const T& input_typed, const Expr& input) {
+scalar_expr evaluate_visitor::operator()(const T& input_typed, const scalar_expr& input) {
   if constexpr (type_list_contains_v<T, derivative, complex_infinity>) {
     throw type_error("Cannot call eval on expression of type: {}", T::name_str);
   } else if constexpr (T::is_leaf_node) {
@@ -16,27 +16,27 @@ Expr evaluate_visitor::operator()(const T& input_typed, const Expr& input) {
   }
 }
 
-Expr evaluate_visitor::operator()(const integer_constant& x) const {
-  return Expr(static_cast<float_constant>(x));
+scalar_expr evaluate_visitor::operator()(const integer_constant& x) const {
+  return scalar_expr(static_cast<float_constant>(x));
 }
 
-Expr evaluate_visitor::operator()(const rational_constant& x) const {
-  return Expr(static_cast<float_constant>(x));
+scalar_expr evaluate_visitor::operator()(const rational_constant& x) const {
+  return scalar_expr(static_cast<float_constant>(x));
 }
 
-Expr evaluate_visitor::operator()(const symbolic_constant& c) const {
+scalar_expr evaluate_visitor::operator()(const symbolic_constant& c) const {
   const auto c_enum = c.name();
   const double value = double_from_symbolic_constant(c_enum);
   WF_ASSERT(!std::isnan(value), "Invalid symbolic constant: {}",
             string_from_symbolic_constant(c_enum));
-  return Expr(value);
+  return scalar_expr(value);
 }
 
-Expr evaluate_visitor::operator()(const Expr& input) {
+scalar_expr evaluate_visitor::operator()(const scalar_expr& input) {
   if (auto it = cache_.find(input); it != cache_.end()) {
     return it->second;
   }
-  Expr result = visit(input, *this);
+  scalar_expr result = visit(input, *this);
   cache_.emplace(input, result);
   return result;
 }
@@ -50,6 +50,6 @@ compound_expr evaluate_visitor::operator()(const compound_expr& input) {
   return result;
 }
 
-Expr evaluate(const Expr& arg) { return evaluate_visitor{}(arg); }
+scalar_expr evaluate(const scalar_expr& arg) { return evaluate_visitor{}(arg); }
 
 }  // namespace wf

--- a/components/core/wf/evaluate.h
+++ b/components/core/wf/evaluate.h
@@ -14,20 +14,22 @@ class evaluate_visitor {
  public:
   template <typename T, typename = enable_if_does_not_contain_type_t<
                             T, integer_constant, rational_constant, symbolic_constant>>
-  Expr operator()(const T& input_typed, const Expr& input);
+  scalar_expr operator()(const T& input_typed, const scalar_expr& input);
 
-  Expr operator()(const integer_constant& x) const;
-  Expr operator()(const rational_constant& x) const;
-  Expr operator()(const symbolic_constant& x) const;
+  scalar_expr operator()(const integer_constant& x) const;
+  scalar_expr operator()(const rational_constant& x) const;
+  scalar_expr operator()(const symbolic_constant& x) const;
 
   // Visit and cache the result.
-  Expr operator()(const Expr& input);
+  scalar_expr operator()(const scalar_expr& input);
   compound_expr operator()(const compound_expr& expr);
 
  private:
   // Cached evaluated values:
   // TODO: Introduce a cache type that can accept any expression type.
-  std::unordered_map<Expr, Expr, hash_struct<Expr>, is_identical_struct<Expr>> cache_;
+  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
+                     is_identical_struct<scalar_expr>>
+      cache_;
   std::unordered_map<compound_expr, compound_expr, hash_struct<compound_expr>,
                      is_identical_struct<compound_expr>>
       compound_cache_;

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -41,14 +41,15 @@ struct type_list_trait<scalar_meta_type> {
 };
 
 // An abstract scalar-valued expression.
-class Expr final : public expression_base<Expr, scalar_meta_type> {
+class scalar_expr final : public expression_base<scalar_expr, scalar_meta_type> {
  public:
   using expression_base::expression_base;
 
   // Construct variable with name and specific numeric set:
-  explicit Expr(std::string_view name, number_set set = number_set::unknown);
+  explicit scalar_expr(std::string_view name, number_set set = number_set::unknown);
 
-  // Enable if the type `T` is a numeric type that we allow to be implicitly converted to `Expr`.
+  // Enable if the type `T` is a numeric type that we allow to be implicitly converted to
+  // `scalar_expr`.
   template <typename T>
   using enable_if_supports_implicit_conversion =
       std::enable_if_t<(std::is_integral_v<T> && !std::is_same_v<T, bool>) ||
@@ -57,10 +58,10 @@ class Expr final : public expression_base<Expr, scalar_meta_type> {
   // Implicit construction from integers and floats.
   // enable_if argument is a trick we use until c++20 and constraints.
   template <typename T, typename = enable_if_supports_implicit_conversion<T>>
-  Expr(T v) : Expr(construct_implicit(v)) {}
+  scalar_expr(T v) : scalar_expr(construct_implicit(v)) {}
 
   // Construct from rational.
-  explicit Expr(rational_constant r);
+  explicit scalar_expr(rational_constant r);
 
   // Convert to string.
   std::string to_string() const;
@@ -70,30 +71,32 @@ class Expr final : public expression_base<Expr, scalar_meta_type> {
   std::string to_expression_tree_string() const;
 
   // Negation operator.
-  Expr operator-() const;
+  scalar_expr operator-() const;
 
   // Differentiate wrt a single variable. Reps defines how many derivatives to take.
-  Expr diff(const Expr& var, int reps = 1,
-            non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
+  scalar_expr diff(
+      const scalar_expr& var, int reps = 1,
+      non_differentiable_behavior behavior = non_differentiable_behavior::constant) const {
     return wf::diff(*this, var, reps, behavior);
   }
 
   // Distribute terms in this expression.
-  Expr distribute() const { return wf::distribute(*this); }
+  scalar_expr distribute() const { return wf::distribute(*this); }
 
   // Create a new expression by recursively substituting `replacement` for `target`.
-  Expr subs(const Expr& target, const Expr& replacement) const {
+  scalar_expr subs(const scalar_expr& target, const scalar_expr& replacement) const {
     return wf::substitute(*this, target, replacement);
   }
 
   // Create a new expression by recursively replacing [variable, replacement] pairs.
-  Expr substitute_variables(absl::Span<const std::tuple<Expr, Expr>> pairs) const {
+  scalar_expr substitute_variables(
+      absl::Span<const std::tuple<scalar_expr, scalar_expr>> pairs) const {
     return wf::substitute_variables(*this, pairs);
   }
 
   // Collect terms in this expression.
   template <typename... Args>
-  Expr collect(Args&&... args) const {
+  scalar_expr collect(Args&&... args) const {
     if constexpr (sizeof...(Args) == 1) {
       return wf::collect(*this, std::forward<Args>(args)...);
     } else {
@@ -102,20 +105,20 @@ class Expr final : public expression_base<Expr, scalar_meta_type> {
   }
 
   // Evaluate into float.
-  Expr eval() const { return wf::evaluate(*this); }
+  scalar_expr eval() const { return wf::evaluate(*this); }
 
  protected:
   friend class matrix_expr;
 
   // Construct constant from float.
-  static Expr from_float(double x);
+  static scalar_expr from_float(double x);
 
   // Construct from integer.
-  static Expr from_int(std::int64_t x);
+  static scalar_expr from_int(std::int64_t x);
 
   // TODO: Use checked casts here + safe numeric type.
   template <typename T>
-  static Expr construct_implicit(T v) {
+  static scalar_expr construct_implicit(T v) {
     static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>);
     if constexpr (std::is_integral_v<T>) {
       return from_int(static_cast<std::int64_t>(v));
@@ -125,80 +128,81 @@ class Expr final : public expression_base<Expr, scalar_meta_type> {
   }
 };
 
-static_assert(std::is_nothrow_move_constructible_v<Expr> && std::is_nothrow_move_assignable_v<Expr>,
+static_assert(std::is_nothrow_move_constructible_v<scalar_expr> &&
+                  std::is_nothrow_move_assignable_v<scalar_expr>,
               "Should be movable");
 
 // ostream support
-inline std::ostream& operator<<(std::ostream& stream, const Expr& x) {
+inline std::ostream& operator<<(std::ostream& stream, const scalar_expr& x) {
   stream << x.to_string();
   return stream;
 }
 
 // Math operators.
-Expr operator+(const Expr& a, const Expr& b);
-Expr operator-(const Expr& a, const Expr& b);
-Expr operator*(const Expr& a, const Expr& b);
-Expr operator/(const Expr& a, const Expr& b);
+scalar_expr operator+(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator-(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator*(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator/(const scalar_expr& a, const scalar_expr& b);
 
 // Comparison operators. These create relational expressions, rather than directly returning bool.
-Expr operator<(const Expr& a, const Expr& b);
-Expr operator>(const Expr& a, const Expr& b);
-Expr operator<=(const Expr& a, const Expr& b);
-Expr operator>=(const Expr& a, const Expr& b);
-Expr operator==(const Expr& a, const Expr& b);
+scalar_expr operator<(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator>(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator<=(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator>=(const scalar_expr& a, const scalar_expr& b);
+scalar_expr operator==(const scalar_expr& a, const scalar_expr& b);
 
 // Determine relative order of two expressions.
 // This is not a mathematical ordering - rather it is a canonical ordering we impose on expressions.
 template <>
-struct order_struct<Expr> {
+struct order_struct<scalar_expr> {
   // Implemented in ordering.cc
-  relative_order operator()(const Expr& a, const Expr& b) const;
+  relative_order operator()(const scalar_expr& a, const scalar_expr& b) const;
 };
 
 // Predicate for sorting expressions.
 struct expression_order_struct {
-  bool operator()(const Expr& a, const Expr& b) const {
+  bool operator()(const scalar_expr& a, const scalar_expr& b) const {
     return determine_order(a, b) == relative_order::less_than;
   }
 };
 
 // Get operation precedence (order of operations).
 // Implemented in expression.cc
-precedence get_precedence(const Expr& expr);
+precedence get_precedence(const scalar_expr& expr);
 
 // Custom literal suffix support.
 namespace custom_literals {
-inline Expr operator"" _s(unsigned long long int arg) { return Expr{arg}; }
-inline Expr operator"" _s(long double arg) { return Expr{arg}; }
+inline scalar_expr operator"" _s(unsigned long long int arg) { return scalar_expr{arg}; }
+inline scalar_expr operator"" _s(long double arg) { return scalar_expr{arg}; }
 }  // namespace custom_literals
 
-// Create a tuple of `Expr` from string arguments.
+// Create a tuple of `scalar_expr` from string arguments.
 template <typename... Args>
 auto make_symbols(Args&&... args) {
   static_assert(std::disjunction_v<std::is_constructible<std::string_view, std::decay_t<Args>>...>,
                 "Argument types must be coercible to string_view");
-  return std::make_tuple(Expr{std::forward<Args>(args)}...);
+  return std::make_tuple(scalar_expr{std::forward<Args>(args)}...);
 }
 
 // Make a unique variable symbol.
-Expr make_unique_variable_symbol(number_set set);
+scalar_expr make_unique_variable_symbol(number_set set);
 
-// Create an `Expr` with underlying type `T` and constructor args `Args`.
+// Create an `scalar_expr` with underlying type `T` and constructor args `Args`.
 template <typename T, typename... Args>
-Expr make_expr(Args&&... args) noexcept(noexcept(Expr{std::in_place_type_t<T>{},
-                                                      std::forward<Args>(args)...})) {
-  return Expr{std::in_place_type_t<T>{}, std::forward<Args>(args)...};
+scalar_expr make_expr(Args&&... args) noexcept(noexcept(scalar_expr{std::in_place_type_t<T>{},
+                                                                    std::forward<Args>(args)...})) {
+  return scalar_expr{std::in_place_type_t<T>{}, std::forward<Args>(args)...};
 }
 
 }  // namespace wf
 
 // libfmt support:
 template <>
-struct fmt::formatter<wf::Expr> {
+struct fmt::formatter<wf::scalar_expr> {
   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const wf::Expr& x, FormatContext& ctx) const -> decltype(ctx.out()) {
+  auto format(const wf::scalar_expr& x, FormatContext& ctx) const -> decltype(ctx.out()) {
     // TODO: This could be implemented so as to avoid the string copy.
     //  It would require all types being visible at the formatter location though.
     return fmt::format_to(ctx.out(), "{}", x.to_string());

--- a/components/core/wf/expressions/casts.h
+++ b/components/core/wf/expressions/casts.h
@@ -12,10 +12,10 @@ class cast_bool {
   static constexpr std::string_view name_str = "CastBool";
   static constexpr bool is_leaf_node = false;
 
-  explicit cast_bool(Expr arg) noexcept(std::is_nothrow_move_constructible_v<Expr>)
+  explicit cast_bool(scalar_expr arg) noexcept(std::is_nothrow_move_constructible_v<scalar_expr>)
       : arg_{std::move(arg)} {}
 
-  constexpr const Expr& arg() const noexcept { return arg_[0]; }
+  constexpr const scalar_expr& arg() const noexcept { return arg_[0]; }
 
   // Iterators
   constexpr auto begin() const noexcept { return arg_.begin(); }
@@ -34,12 +34,12 @@ class cast_bool {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
+  scalar_expr map_children(Operation&& operation) const {
     return cast_int_from_bool(operation(arg_.front()));
   }
 
  private:
-  std::array<Expr, 1> arg_;
+  std::array<scalar_expr, 1> arg_;
 };
 
 template <>

--- a/components/core/wf/expressions/compound_expression_element.cc
+++ b/components/core/wf/expressions/compound_expression_element.cc
@@ -6,13 +6,14 @@
 
 namespace wf {
 
-Expr compound_expression_element::create(compound_expr provenance, const std::size_t index) {
+scalar_expr compound_expression_element::create(compound_expr provenance, const std::size_t index) {
   if (const custom_type_construction* construct =
           cast_ptr<const custom_type_construction>(provenance);
       construct != nullptr) {
     return construct->at(index);
   }
-  return Expr(std::in_place_type_t<compound_expression_element>{}, std::move(provenance), index);
+  return scalar_expr(std::in_place_type_t<compound_expression_element>{}, std::move(provenance),
+                     index);
 }
 
 }  // namespace wf

--- a/components/core/wf/expressions/compound_expression_element.h
+++ b/components/core/wf/expressions/compound_expression_element.h
@@ -29,13 +29,13 @@ class compound_expression_element {
   constexpr auto end() const noexcept { return begin() + 1; }
 
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
+  scalar_expr map_children(Operation&& operation) const {
     return create(operation(provenance_), index_);
   }
 
   // Create a reference to an element of a compound expression. This will simplify if the compound
   // expression is a constructor.
-  static Expr create(compound_expr provenance, std::size_t index);
+  static scalar_expr create(compound_expr provenance, std::size_t index);
 
  private:
   compound_expr provenance_;

--- a/components/core/wf/expressions/conditional.cc
+++ b/components/core/wf/expressions/conditional.cc
@@ -5,7 +5,8 @@
 
 namespace wf {
 
-Expr conditional::create(wf::Expr condition, wf::Expr if_branch, wf::Expr else_branch) {
+scalar_expr conditional::create(wf::scalar_expr condition, wf::scalar_expr if_branch,
+                                wf::scalar_expr else_branch) {
   if (condition.is_identical_to(constants::boolean_true)) {
     return if_branch;
   } else if (condition.is_identical_to(constants::boolean_false)) {

--- a/components/core/wf/expressions/conditional.h
+++ b/components/core/wf/expressions/conditional.h
@@ -10,12 +10,12 @@ class conditional {
   static constexpr std::string_view name_str = "Conditional";
   static constexpr bool is_leaf_node = false;
 
-  conditional(Expr condition, Expr if_branch, Expr else_branch)
+  conditional(scalar_expr condition, scalar_expr if_branch, scalar_expr else_branch)
       : children_{std::move(condition), std::move(if_branch), std::move(else_branch)} {}
 
   bool is_identical_to(const conditional& other) const {
     return std::equal(children_.begin(), children_.end(), other.children_.begin(),
-                      is_identical_struct<Expr>{});
+                      is_identical_struct<scalar_expr>{});
   }
 
   // Implement ExpressionImpl::Iterate
@@ -26,8 +26,8 @@ class conditional {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
-    Expr cond = operation(condition());
+  scalar_expr map_children(Operation&& operation) const {
+    scalar_expr cond = operation(condition());
     if (cond.is_identical_to(constants::boolean_true)) {
       return operation(if_branch());
     } else if (cond.is_identical_to(constants::boolean_false)) {
@@ -37,17 +37,17 @@ class conditional {
   }
 
   // Create a new conditional.
-  static Expr create(Expr condition, Expr if_branch, Expr else_branch);
+  static scalar_expr create(scalar_expr condition, scalar_expr if_branch, scalar_expr else_branch);
 
-  constexpr const Expr& condition() const noexcept { return children_[0]; }
-  constexpr const Expr& if_branch() const noexcept { return children_[1]; }
-  constexpr const Expr& else_branch() const noexcept { return children_[2]; }
+  constexpr const scalar_expr& condition() const noexcept { return children_[0]; }
+  constexpr const scalar_expr& if_branch() const noexcept { return children_[1]; }
+  constexpr const scalar_expr& else_branch() const noexcept { return children_[2]; }
 
   constexpr auto begin() const noexcept { return children_.begin(); }
   constexpr auto end() const noexcept { return children_.end(); }
 
  protected:
-  std::array<Expr, 3> children_;
+  std::array<scalar_expr, 3> children_;
 };
 
 template <>

--- a/components/core/wf/expressions/custom_type_expressions.cc
+++ b/components/core/wf/expressions/custom_type_expressions.cc
@@ -5,7 +5,7 @@
 
 namespace wf {
 
-custom_type_construction::custom_type_construction(custom_type type, std::vector<Expr> args)
+custom_type_construction::custom_type_construction(custom_type type, std::vector<scalar_expr> args)
     : type_(std::move(type)), args_(std::move(args)) {
   WF_ASSERT_EQUAL(
       type_.total_size(), args_.size(),

--- a/components/core/wf/expressions/custom_type_expressions.h
+++ b/components/core/wf/expressions/custom_type_expressions.h
@@ -56,9 +56,9 @@ class custom_type_construction {
  public:
   static constexpr std::string_view name_str = "CustomTypeConstruction";
   static constexpr bool is_leaf_node = false;
-  using container_type = std::vector<Expr>;
+  using container_type = std::vector<scalar_expr>;
 
-  custom_type_construction(custom_type type, std::vector<Expr> args);
+  custom_type_construction(custom_type type, std::vector<scalar_expr> args);
 
   // The type being constructed.
   constexpr const custom_type& type() const noexcept { return type_; }
@@ -70,7 +70,7 @@ class custom_type_construction {
   std::size_t size() const noexcept { return args_.size(); }
 
   // Get the specified argument.
-  const Expr& at(const std::size_t index) const {
+  const scalar_expr& at(const std::size_t index) const {
     WF_ASSERT_LESS(index, size());
     return args_[index];
   }

--- a/components/core/wf/expressions/derivative_expression.cc
+++ b/components/core/wf/expressions/derivative_expression.cc
@@ -5,7 +5,7 @@
 
 namespace wf {
 
-Expr derivative::create(Expr function, Expr arg, int order) {
+scalar_expr derivative::create(scalar_expr function, scalar_expr arg, int order) {
   WF_ASSERT_GREATER_OR_EQ(order, 1, "Order of the derivative must >= 1");
 
   if (!arg.is_type<variable>()) {

--- a/components/core/wf/expressions/derivative_expression.h
+++ b/components/core/wf/expressions/derivative_expression.h
@@ -13,16 +13,16 @@ class derivative {
   static constexpr std::string_view name_str = "Derivative";
   static constexpr bool is_leaf_node = false;
 
-  derivative(Expr differentiand, Expr arg, int order = 1)
+  derivative(scalar_expr differentiand, scalar_expr arg, int order = 1)
       : children_{std::move(differentiand), std::move(arg)}, order_(order) {
     WF_ASSERT_GREATER_OR_EQ(order_, 1);
   }
 
   // The function we are taking the derivative of:
-  constexpr const Expr& differentiand() const noexcept { return children_[0]; }
+  constexpr const scalar_expr& differentiand() const noexcept { return children_[0]; }
 
   // The variable with respect to which the derivative is being taken.
-  constexpr const Expr& argument() const noexcept { return children_[1]; }
+  constexpr const scalar_expr& argument() const noexcept { return children_[1]; }
 
   // Order of the derivative (first, second, third, etc).
   constexpr int order() const noexcept { return order_; }
@@ -34,7 +34,7 @@ class derivative {
   // All arguments must match.
   bool is_identical_to(const derivative& other) const {
     return order_ == other.order_ &&
-           std::equal(begin(), end(), other.begin(), is_identical_struct<Expr>{});
+           std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
   // Implement ExpressionImpl::Iterate
@@ -45,15 +45,15 @@ class derivative {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
+  scalar_expr map_children(Operation&& operation) const {
     return derivative::create(operation(differentiand()), operation(argument()), order_);
   }
 
   // Create a new derivative expression.
-  static Expr create(Expr function, Expr arg, int order);
+  static scalar_expr create(scalar_expr function, scalar_expr arg, int order);
 
  private:
-  std::array<Expr, 2> children_;
+  std::array<scalar_expr, 2> children_;
   int order_;
 };
 

--- a/components/core/wf/expressions/function_expressions.h
+++ b/components/core/wf/expressions/function_expressions.h
@@ -15,14 +15,14 @@ class function {
  public:
   static constexpr std::string_view name_str = "Function";
   static constexpr bool is_leaf_node = false;
-  using container_type = absl::InlinedVector<Expr, 2>;
+  using container_type = absl::InlinedVector<scalar_expr, 2>;
 
   template <typename... Args>
   function(built_in_function func, Args&&... args)
       : func_(func), args_{std::forward<Args>(args)...} {}
 
   // Create a function. Examines `name`, and then invokes the correct function method.
-  static Expr create(built_in_function name, container_type&& container);
+  static scalar_expr create(built_in_function name, container_type&& container);
 
   // Get the function name.
   constexpr built_in_function enum_value() const noexcept { return func_; }
@@ -45,7 +45,7 @@ class function {
   // Function type and argument must match.
   bool is_identical_to(const function& other) const {
     return func_ == other.func_ && args_.size() == other.args_.size() &&
-           std::equal(begin(), end(), other.begin(), is_identical_struct<Expr>{});
+           std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
   // Implement ExpressionImpl::Iterate
@@ -56,7 +56,7 @@ class function {
 
   // Implement ExpressionImpl::Map
   template <typename F>
-  Expr map_children(F&& f) const {
+  scalar_expr map_children(F&& f) const {
     return function::create(func_, transform_map<container_type>(args_, std::forward<F>(f)));
   }
 
@@ -74,7 +74,7 @@ struct hash_struct<function> {
 
 // Call the appropriate creation method for the specified enum value.
 // We need this logic because each type of function has simplifications it applies.
-inline Expr function::create(built_in_function name, function::container_type&& container) {
+inline scalar_expr function::create(built_in_function name, function::container_type&& container) {
   switch (name) {
     case built_in_function::cos:
       return cos(container.front());

--- a/components/core/wf/expressions/matrix.cc
+++ b/components/core/wf/expressions/matrix.cc
@@ -14,7 +14,7 @@ matrix matrix::get_block(const index_t row, const index_t col, const index_t nro
         "Block [position: ({}, {}), size: ({}, {})] is out of bounds for matrix of shape ({}, {})",
         row, col, nrows, ncols, rows_, cols_);
   }
-  std::vector<Expr> data;
+  std::vector<scalar_expr> data;
   data.reserve(nrows * ncols);
   iter_matrix(nrows, ncols,
               [&](index_t i, index_t j) { data.push_back(get_unchecked(i + row, j + col)); });
@@ -38,7 +38,7 @@ void matrix::set_block(const index_t row, const index_t col, const index_t nrows
 }
 
 matrix matrix::transposed() const {
-  std::vector<Expr> output{};
+  std::vector<scalar_expr> output{};
   output.reserve(size());
   const index_t output_rows = cols();
   const index_t output_cols = rows();
@@ -57,15 +57,15 @@ matrix operator*(const matrix& a, const matrix& b) {
   const index_t output_rows = a.rows();
   const index_t output_cols = b.cols();
 
-  std::vector<Expr> output;
+  std::vector<scalar_expr> output;
   output.reserve(output_rows * output_cols);
 
-  std::vector<Expr> addition_args;
+  std::vector<scalar_expr> addition_args;
   iter_matrix(output_rows, output_cols, [&](index_t i, index_t j) {
     // Multiply row times column:
     addition_args.clear();
     for (index_t k = 0; k < a.cols(); ++k) {
-      Expr prod = a(i, k) * b(k, j);
+      scalar_expr prod = a(i, k) * b(k, j);
       if (!is_zero(prod)) {
         addition_args.push_back(std::move(prod));
       }
@@ -84,7 +84,7 @@ matrix operator+(const matrix& a, const matrix& b) {
     throw dimension_error("dimension mismatch in matrix addition: ({}, {}) + ({}, {}).", a.rows(),
                           a.cols(), b.rows(), b.cols());
   }
-  std::vector<Expr> output;
+  std::vector<scalar_expr> output;
   output.reserve(a.size());
   iter_matrix(a.rows(), a.cols(),
               [&](index_t i, index_t j) { output.push_back(a(i, j) + b(i, j)); });
@@ -97,7 +97,7 @@ matrix operator-(const matrix& a, const matrix& b) {
     throw dimension_error("dimension mismatch in matrix subtraction: ({}, {}) - ({}, {}).",
                           a.rows(), a.cols(), b.rows(), b.cols());
   }
-  std::vector<Expr> output;
+  std::vector<scalar_expr> output;
   output.reserve(a.size());
   iter_matrix(a.rows(), a.cols(),
               [&](index_t i, index_t j) { output.push_back(a(i, j) - b(i, j)); });

--- a/components/core/wf/expressions/matrix.h
+++ b/components/core/wf/expressions/matrix.h
@@ -15,7 +15,7 @@ class matrix {
  public:
   static constexpr std::string_view name_str = "Matrix";
   static constexpr bool is_leaf_node = false;
-  using container_type = std::vector<Expr>;
+  using container_type = std::vector<scalar_expr>;
 
   // Construct from data vector.
   matrix(index_t rows, index_t cols, container_type data)
@@ -31,7 +31,8 @@ class matrix {
   // All elements must match.
   bool is_identical_to(const matrix& other) const {
     return rows_ == other.rows_ && cols_ == other.cols_ &&
-           std::equal(data_.begin(), data_.end(), other.data_.begin(), is_identical_struct<Expr>{});
+           std::equal(data_.begin(), data_.end(), other.data_.begin(),
+                      is_identical_struct<scalar_expr>{});
   }
 
   // Implement ExpressionImpl::Iterate
@@ -48,21 +49,21 @@ class matrix {
   }
 
   // Access element in a vector. Only valid if `cols` or `rows` is 1.
-  const Expr& operator[](index_t i) const;
+  const scalar_expr& operator[](index_t i) const;
 
   // Access element in a matrix.
-  const Expr& operator()(index_t i, index_t j) const;
+  const scalar_expr& operator()(index_t i, index_t j) const;
 
   // Get with no bounds checking.
-  const Expr& get_unchecked(index_t i, index_t j) const noexcept {
+  const scalar_expr& get_unchecked(index_t i, index_t j) const noexcept {
     return data_[compute_index(i, j)];
   }
 
   // Non-const accessor with no bounds checking.
-  Expr& get_unchecked(index_t i, index_t j) noexcept { return data_[compute_index(i, j)]; }
+  scalar_expr& get_unchecked(index_t i, index_t j) noexcept { return data_[compute_index(i, j)]; }
 
   // Set with no bounds checking.
-  void set_unchecked(index_t i, index_t j, const Expr& value) noexcept {
+  void set_unchecked(index_t i, index_t j, const scalar_expr& value) noexcept {
     data_[compute_index(i, j)] = value;
   }
 
@@ -88,7 +89,7 @@ class matrix {
   std::size_t size() const noexcept { return data_.size(); }
 
   // Access elements.
-  constexpr const std::vector<Expr>& data() const noexcept { return data_; }
+  constexpr const std::vector<scalar_expr>& data() const noexcept { return data_; }
 
   // Iterators:
   auto begin() const noexcept { return data_.begin(); }
@@ -107,7 +108,7 @@ class matrix {
 
 static_assert(std::is_move_constructible_v<matrix> && std::is_move_assignable_v<matrix>);
 
-inline const Expr& matrix::operator[](index_t i) const {
+inline const scalar_expr& matrix::operator[](index_t i) const {
   if (rows_ != 1 && cols_ != 1) {
     throw dimension_error(
         "Array-style accessor is only valid on vectors. Matrix has dimensions ({}, {}).", rows_,
@@ -119,7 +120,7 @@ inline const Expr& matrix::operator[](index_t i) const {
   return data_[static_cast<std::size_t>(i)];
 }
 
-inline const Expr& matrix::operator()(index_t i, index_t j) const {
+inline const scalar_expr& matrix::operator()(index_t i, index_t j) const {
   if (i >= rows_ || i < 0 || j >= cols_ || j < 0) {
     throw dimension_error("Index ({}, {}) is out of bounds for matrix of size ({}, {})", i, j,
                           rows_, cols_);

--- a/components/core/wf/expressions/power.h
+++ b/components/core/wf/expressions/power.h
@@ -11,7 +11,7 @@ class power {
   static constexpr std::string_view name_str = "Power";
   static constexpr bool is_leaf_node = false;
 
-  power(Expr base, Expr exponent) : children_{std::move(base), std::move(exponent)} {}
+  power(scalar_expr base, scalar_expr exponent) : children_{std::move(base), std::move(exponent)} {}
 
   // Base and exponent must match.
   bool is_identical_to(const power& other) const {
@@ -26,26 +26,26 @@ class power {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
+  scalar_expr map_children(Operation&& operation) const {
     return power::create(operation(base()), operation(exponent()));
   }
 
   // Create a new power.
   // Will apply rules to simplify automatically.
-  static Expr create(Expr a, Expr b);
+  static scalar_expr create(scalar_expr a, scalar_expr b);
 
-  constexpr const Expr& base() const noexcept { return children_[0]; }
-  constexpr const Expr& exponent() const noexcept { return children_[1]; }
+  constexpr const scalar_expr& base() const noexcept { return children_[0]; }
+  constexpr const scalar_expr& exponent() const noexcept { return children_[1]; }
 
   constexpr auto begin() const noexcept { return children_.begin(); }
   constexpr auto end() const noexcept { return children_.end(); }
 
  protected:
-  std::array<Expr, 2> children_;
+  std::array<scalar_expr, 2> children_;
 };
 
 // Convert an expression to a base/exponent pair.
-std::pair<Expr, Expr> as_base_and_exp(const Expr& expr);
+std::pair<scalar_expr, scalar_expr> as_base_and_exp(const scalar_expr& expr);
 
 // Convert a rational exponent to the whole integer part and the remainder.
 // If the exponent is negative, we add to the whole integer part so that the rational part

--- a/components/core/wf/expressions/relational.cc
+++ b/components/core/wf/expressions/relational.cc
@@ -95,7 +95,8 @@ struct RelationalSimplification {
   relational_operation operation_;
 };
 
-Expr relational::create(relational_operation operation, Expr left, Expr right) {
+scalar_expr relational::create(relational_operation operation, scalar_expr left,
+                               scalar_expr right) {
   if (is_complex_infinity(left) || is_complex_infinity(right) || is_undefined(left) ||
       is_undefined(right)) {
     throw type_error("Cannot construct relational with types: {} {} {}", left.type_name(),

--- a/components/core/wf/expressions/relational.h
+++ b/components/core/wf/expressions/relational.h
@@ -10,7 +10,7 @@ class relational {
   static constexpr std::string_view name_str = "Relational";
   static constexpr bool is_leaf_node = false;
 
-  relational(relational_operation operation, Expr left, Expr right)
+  relational(relational_operation operation, scalar_expr left, scalar_expr right)
       : operation_(operation), children_{std::move(left), std::move(right)} {}
 
   // Base and exponent must match.
@@ -27,16 +27,16 @@ class relational {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  Expr map_children(Operation&& operation) const {
+  scalar_expr map_children(Operation&& operation) const {
     return relational::create(operation_, operation(left()), operation(right()));
   }
 
   // Create a relational operation.
-  static Expr create(relational_operation operation, Expr left, Expr right);
+  static scalar_expr create(relational_operation operation, scalar_expr left, scalar_expr right);
 
   constexpr relational_operation operation() const noexcept { return operation_; }
-  constexpr const Expr& left() const noexcept { return children_[0]; }
-  constexpr const Expr& right() const noexcept { return children_[1]; }
+  constexpr const scalar_expr& left() const noexcept { return children_[0]; }
+  constexpr const scalar_expr& right() const noexcept { return children_[1]; }
 
   constexpr std::string_view operation_string() const noexcept {
     return string_from_relational_operation(operation_);
@@ -47,7 +47,7 @@ class relational {
 
  protected:
   relational_operation operation_;
-  std::array<Expr, 2> children_;
+  std::array<scalar_expr, 2> children_;
 };
 
 template <>

--- a/components/core/wf/expressions/variable.h
+++ b/components/core/wf/expressions/variable.h
@@ -100,7 +100,7 @@ class variable {
   std::string to_string() const;
 
   // Create a function argument expression.
-  static Expr create_function_argument(std::size_t arg_index, std::size_t element_index) {
+  static scalar_expr create_function_argument(std::size_t arg_index, std::size_t element_index) {
     // TODO: Support creating function arguments that are not real.
     return make_expr<variable>(function_argument_variable(arg_index, element_index),
                                number_set::real);

--- a/components/core/wf/external_function.cc
+++ b/components/core/wf/external_function.cc
@@ -73,7 +73,7 @@ any_expression external_function::create_invocation(std::vector<any_expression> 
     // Determine what type we were passed:
     const type_variant passed_type = overloaded_visit(
         args[i],
-        [&](const Expr&) -> type_variant {
+        [&](const scalar_expr&) -> type_variant {
           // TODO: Check numeric type here.
           return scalar_type(code_numeric_type::floating_point);
         },
@@ -103,7 +103,8 @@ any_expression external_function::create_invocation(std::vector<any_expression> 
   return overloaded_visit(
       return_type(),
       [&](const scalar_type) -> any_expression {
-        return Expr(std::in_place_type_t<compound_expression_element>{}, std::move(invocation), 0);
+        return scalar_expr(std::in_place_type_t<compound_expression_element>{},
+                           std::move(invocation), 0);
       },
       [&](const matrix_type& mat) -> any_expression {
         return matrix_expr::create(mat.rows(), mat.cols(),

--- a/components/core/wf/external_function.h
+++ b/components/core/wf/external_function.h
@@ -10,7 +10,7 @@ namespace wf {
 
 // Variant of possible expression types.
 // TODO: This should be declared somewhere more general.
-using any_expression = std::variant<Expr, matrix_expr, compound_expr>;
+using any_expression = std::variant<scalar_expr, matrix_expr, compound_expr>;
 
 template <>
 struct hash_struct<any_expression> : hash_variant<any_expression> {};

--- a/components/core/wf/functions.h
+++ b/components/core/wf/functions.h
@@ -2,58 +2,60 @@
 #pragma once
 #include "wf/expression.h"
 
-// User facing math functions that operate on `Expr` go in this file.
+// User facing math functions that operate on `scalar_expr` go in this file.
 namespace wf {
 
 // Natural log.
-Expr log(const Expr& arg);
+scalar_expr log(const scalar_expr& arg);
 
 // Power.
-Expr pow(const Expr& b, const Expr& e);
+scalar_expr pow(const scalar_expr& b, const scalar_expr& e);
 
 // Cosine.
-Expr cos(const Expr& arg);
+scalar_expr cos(const scalar_expr& arg);
 
 // Sine.
-Expr sin(const Expr& arg);
+scalar_expr sin(const scalar_expr& arg);
 
 // Tangent.
-Expr tan(const Expr& arg);
+scalar_expr tan(const scalar_expr& arg);
 
 // Inverse cosine.
-Expr acos(const Expr& arg);
+scalar_expr acos(const scalar_expr& arg);
 
 // Inverse sine.
-Expr asin(const Expr& arg);
+scalar_expr asin(const scalar_expr& arg);
 
 // Inverse tangent.
-Expr atan(const Expr& arg);
+scalar_expr atan(const scalar_expr& arg);
 
 // 2-argument inverse tangent.
-Expr atan2(const Expr& y, const Expr& x);
+scalar_expr atan2(const scalar_expr& y, const scalar_expr& x);
 
 // Square root.
-Expr sqrt(const Expr& arg);
+scalar_expr sqrt(const scalar_expr& arg);
 
 // Absolute value function.
-Expr abs(const Expr& arg);
+scalar_expr abs(const scalar_expr& arg);
 
 // Signum function.
-Expr signum(const Expr& arg);
+scalar_expr signum(const scalar_expr& arg);
 
 // Maximum of two values. Equivalent to: (a < b) ? b : a
-Expr max(const Expr& a, const Expr& b);
+scalar_expr max(const scalar_expr& a, const scalar_expr& b);
 
 // Minimum of two values. Equivalent to: (b < a) ? b : a
-Expr min(const Expr& a, const Expr& b);
+scalar_expr min(const scalar_expr& a, const scalar_expr& b);
 
 // Conditional/ternary expression.
-Expr where(const Expr& condition, const Expr& if_true, const Expr& if_false);
+scalar_expr where(const scalar_expr& condition, const scalar_expr& if_true,
+                  const scalar_expr& if_false);
 
 // Conditional over a matrix w/ scalar condition.
-matrix_expr where(const Expr& condition, const matrix_expr& if_true, const matrix_expr& if_false);
+matrix_expr where(const scalar_expr& condition, const matrix_expr& if_true,
+                  const matrix_expr& if_false);
 
 // Cast the provided expression from a boolean to an integer.
-Expr cast_int_from_bool(const Expr& bool_expression);
+scalar_expr cast_int_from_bool(const scalar_expr& bool_expression);
 
 }  // namespace wf

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -28,12 +28,12 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   using expression_base::expression_base;
 
   // Static constructor: Create a dense matrix of expressions.
-  static matrix_expr create(index_t rows, index_t cols, std::vector<Expr> args);
+  static matrix_expr create(index_t rows, index_t cols, std::vector<scalar_expr> args);
 
   // Create from a pair of iterators.
   template <typename Iterator>
   static matrix_expr create(const index_t rows, const index_t cols, Iterator begin, Iterator end) {
-    return create(rows, cols, std::vector<Expr>{begin, end});
+    return create(rows, cols, std::vector<scalar_expr>{begin, end});
   }
 
   // Convert to string.
@@ -48,14 +48,14 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   // Differentiate with respect to a single variable. Reps defines how many derivatives to take.
   // The returned matrix is the element-wise derivative.
   matrix_expr diff(
-      const Expr& var, int reps = 1,
+      const scalar_expr& var, int reps = 1,
       non_differentiable_behavior behavior = non_differentiable_behavior::constant) const;
 
   // Differentiate a vector with respect to another vector, producing a Jacobian.
   // If the input is an [N,1] vector and `vars` has M expressions, the result will be an NxM matrix.
   // Throws if `this` is not a column vector.
   matrix_expr jacobian(
-      absl::Span<const Expr> vars,
+      absl::Span<const scalar_expr> vars,
       non_differentiable_behavior behavior = non_differentiable_behavior::constant) const;
 
   // Version of `jacobian` that accepts `matrix_expr` directly.
@@ -66,10 +66,10 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   matrix_expr distribute() const;
 
   // Create a new expression by recursively substituting `replacement` for `target`.
-  matrix_expr subs(const Expr& target, const Expr& replacement) const;
+  matrix_expr subs(const scalar_expr& target, const scalar_expr& replacement) const;
 
   // Collect terms in every element of this matrix.
-  matrix_expr collect(absl::Span<const Expr> terms) const;
+  matrix_expr collect(absl::Span<const scalar_expr> terms) const;
 
   // Evaluate to matrix of floats.
   matrix_expr eval() const;
@@ -84,13 +84,13 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   std::size_t size() const { return static_cast<std::size_t>(rows() * cols()); }
 
   // For vectors or row-vectors only. Access element `i`.
-  const Expr& operator[](index_t i) const;
+  const scalar_expr& operator[](index_t i) const;
 
   // Access row `i` and column `j`.
-  const Expr& operator()(index_t i, index_t j) const;
+  const scalar_expr& operator()(index_t i, index_t j) const;
 
   // Set row `i` and column `j` (only valid on dense matrix expression).
-  void set(index_t i, index_t j, const Expr& value);
+  void set(index_t i, index_t j, const scalar_expr& value);
 
   // Get a block of rows [start, start + length).
   matrix_expr get_block(index_t row, index_t col, index_t nrows, index_t ncols) const;
@@ -105,10 +105,10 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   [[nodiscard]] matrix_expr reshape(index_t nrows, index_t ncols) const;
 
   // Get the squared norm of the matrix.
-  Expr squared_norm() const;
+  scalar_expr squared_norm() const;
 
   // Get the norm of the matrix.
-  Expr norm() const;
+  scalar_expr norm() const;
 
   // Cast to underlying matrix type.
   const matrix& as_matrix() const;
@@ -117,7 +117,7 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   matrix& as_matrix_mut();
 
   // Convert to vector of expressions, in row-major order.
-  std::vector<Expr> to_vector() const;
+  std::vector<scalar_expr> to_vector() const;
 };
 
 // Relative order of matrices (first by dimensions, then by lexicographical order).
@@ -130,8 +130,8 @@ struct order_struct<matrix_expr> {
 matrix_expr operator+(const matrix_expr& a, const matrix_expr& b);
 matrix_expr operator-(const matrix_expr& a, const matrix_expr& b);
 matrix_expr operator*(const matrix_expr& a, const matrix_expr& b);
-matrix_expr operator*(const matrix_expr& a, const Expr& b);
-inline matrix_expr operator*(const Expr& a, const matrix_expr& b) { return b * a; }
+matrix_expr operator*(const matrix_expr& a, const scalar_expr& b);
+inline matrix_expr operator*(const scalar_expr& a, const matrix_expr& b) { return b * a; }
 
 // ostream support
 inline std::ostream& operator<<(std::ostream& stream, const matrix_expr& x) {

--- a/components/core/wf/matrix_functions.h
+++ b/components/core/wf/matrix_functions.h
@@ -9,19 +9,19 @@ namespace wf {
 // Create a column vector from the arguments.
 template <typename... Ts>
 static matrix_expr make_vector(Ts&&... args) {
-  return matrix_expr::create(sizeof...(Ts), 1, {Expr{std::forward<Ts>(args)}...});
+  return matrix_expr::create(sizeof...(Ts), 1, {scalar_expr{std::forward<Ts>(args)}...});
 }
 
 // Create a row vector from the arguments.
 template <typename... Ts>
 static matrix_expr make_row_vector(Ts&&... args) {
-  return matrix_expr::create(1, sizeof...(Ts), {Expr{std::forward<Ts>(args)}...});
+  return matrix_expr::create(1, sizeof...(Ts), {scalar_expr{std::forward<Ts>(args)}...});
 }
 
 // Create a matrix from the arguments (args specified in row-major order).
 template <typename... Ts>
 static matrix_expr make_matrix(index_t rows, index_t cols, Ts&&... args) {
-  return matrix_expr::create(rows, cols, {Expr{std::forward<Ts>(args)}...});
+  return matrix_expr::create(rows, cols, {scalar_expr{std::forward<Ts>(args)}...});
 }
 
 // Create a matrix of symbols.
@@ -53,6 +53,6 @@ std::tuple<matrix_expr, matrix_expr, matrix_expr, matrix_expr> factorize_full_pi
     const matrix_expr& A);
 
 // Compute determinant of a matrix. Only valid for square matrices.
-Expr determinant(const matrix_expr& m);
+scalar_expr determinant(const matrix_expr& m);
 
 }  // namespace wf

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -213,6 +213,6 @@ class determine_set_visitor {
   constexpr number_set operator()(const variable& var) const noexcept { return var.set(); }
 };
 
-number_set determine_numeric_set(const Expr& x) { return visit(x, determine_set_visitor{}); }
+number_set determine_numeric_set(const scalar_expr& x) { return visit(x, determine_set_visitor{}); }
 
 }  // namespace wf

--- a/components/core/wf/operations.h
+++ b/components/core/wf/operations.h
@@ -6,21 +6,23 @@
 #include "wf/enumerations.h"
 
 namespace wf {
-class Expr;
+class scalar_expr;
 class matrix_expr;
 
 // Replace instances of `target` w/ `replacement` in the input expression tree `input`.
 // Implemented in substitute.cc
-Expr substitute(const Expr& input, const Expr& target, const Expr& replacement);
+scalar_expr substitute(const scalar_expr& input, const scalar_expr& target,
+                       const scalar_expr& replacement);
 
 // Replace all the [target, replacement] pairs in the input expression tree `input`.
 // Every `target` must be a variable.
-Expr substitute_variables(const Expr& input, absl::Span<const std::tuple<Expr, Expr>> pairs);
+scalar_expr substitute_variables(const scalar_expr& input,
+                                 absl::Span<const std::tuple<scalar_expr, scalar_expr>> pairs);
 
 // Replace all the [target, replacement] pairs in the input matrix expression tree `input`.
 // Every `target` must be a variable.
 matrix_expr substitute_variables(const matrix_expr& input,
-                                 absl::Span<const std::tuple<Expr, Expr>> pairs);
+                                 absl::Span<const std::tuple<scalar_expr, scalar_expr>> pairs);
 
 // Govern behavior of the derivative visitor when we encounter non-differentiable functions.
 // An example would be the round(x) function, which has derivatives:
@@ -37,43 +39,44 @@ enum class non_differentiable_behavior {
 
 // Take the derivative of `function` wrt `var`. The derivative is taken `reps` times.
 // Implemented in derivative.cc
-Expr diff(const Expr& function, const Expr& var, int reps, non_differentiable_behavior behavior);
+scalar_expr diff(const scalar_expr& function, const scalar_expr& var, int reps,
+                 non_differentiable_behavior behavior);
 
 // Compute the jacobian of the vector `functions` wrt the variables in `vars`.
 // If `functions` has length `N` and `vars` length `M`, the result will be NxM.
-matrix_expr jacobian(absl::Span<const Expr> functions, absl::Span<const Expr> vars,
+matrix_expr jacobian(absl::Span<const scalar_expr> functions, absl::Span<const scalar_expr> vars,
                      non_differentiable_behavior behavior);
 
 // Distribute over multiplications in the input expression.
 // Expands terms like: (a + b) * (c * d) --> a*c + a*d + b*c + b*d
 // Implemented in distribute.cc
-Expr distribute(const Expr& arg);
+scalar_expr distribute(const scalar_expr& arg);
 
 // Collect powers of the specified terms.
 // Terms are prioritized by their order in `terms`.
 // Implemented in collect.cc
-Expr collect_many(const Expr& arg, absl::Span<const Expr> terms);
+scalar_expr collect_many(const scalar_expr& arg, absl::Span<const scalar_expr> terms);
 
 // Version of `collect_many` that accepts a single term.
-Expr collect(const Expr& arg, const Expr& term);
+scalar_expr collect(const scalar_expr& arg, const scalar_expr& term);
 
 // Evaluate to a number. If the result is a matrix, returns a matrix expression of numbers.
 // Implemented in evaluate.cc
-Expr evaluate(const Expr& arg);
+scalar_expr evaluate(const scalar_expr& arg);
 
 // Take the limit of `f_of_x` as `x` goes to 0 from the right.
 // The expression `x` must be a variable.
 // Implemented in limit.cc
 // This feature is considered unstable.
-std::optional<Expr> limit(const Expr& f_of_x, const Expr& x);
+std::optional<scalar_expr> limit(const scalar_expr& f_of_x, const scalar_expr& x);
 
 // Take the limit of matrix-valued function `f_of_x` as `x` goes to 0 from the right.
 // The expression `x` must be a variable.
 // This feature is considered unstable.
-std::optional<matrix_expr> limit(const matrix_expr& f_of_x, const Expr& x);
+std::optional<matrix_expr> limit(const matrix_expr& f_of_x, const scalar_expr& x);
 
 // Determine what set of numbers an expression belongs to.
 // Returns `NumberSet::unknown` if the set cannot be determined.
-number_set determine_numeric_set(const Expr& x);
+number_set determine_numeric_set(const scalar_expr& x);
 
 }  // namespace wf

--- a/components/core/wf/ordering.cc
+++ b/components/core/wf/ordering.cc
@@ -33,11 +33,12 @@ struct order_visitor {
   }
 
   relative_order compare(const cast_bool& a, const cast_bool& b) const {
-    return order_struct<Expr>{}(a.arg(), b.arg());
+    return order_struct<scalar_expr>{}(a.arg(), b.arg());
   }
 
   relative_order compare(const conditional& a, const conditional& b) const {
-    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                     order_struct<scalar_expr>{});
   }
 
   constexpr relative_order compare(const complex_infinity&,
@@ -46,7 +47,8 @@ struct order_visitor {
   }
 
   relative_order compare(const addition& a, const addition& b) const {
-    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                     order_struct<scalar_expr>{});
   }
 
   relative_order compare(const derivative& a, const derivative& b) const {
@@ -55,15 +57,18 @@ struct order_visitor {
     } else if (a.order() > b.order()) {
       return relative_order::greater_than;
     }
-    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                     order_struct<scalar_expr>{});
   }
 
   relative_order compare(const multiplication& a, const multiplication& b) const {
-    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                     order_struct<scalar_expr>{});
   }
 
   relative_order compare(const power& a, const power& b) const {
-    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return wf::lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                     order_struct<scalar_expr>{});
   }
 
   relative_order compare(const function& a, const function& b) const {
@@ -74,7 +79,8 @@ struct order_visitor {
     } else if (name_comp < 0) {
       return relative_order::less_than;
     }
-    return lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                 order_struct<scalar_expr>{});
   }
 
   relative_order compare(const relational& a, const relational& b) const {
@@ -83,7 +89,8 @@ struct order_visitor {
     } else if (a.operation() > b.operation()) {
       return relative_order::greater_than;
     }
-    return lexicographical_order(a.begin(), a.end(), b.begin(), b.end(), order_struct<Expr>{});
+    return lexicographical_order(a.begin(), a.end(), b.begin(), b.end(),
+                                 order_struct<scalar_expr>{});
   }
 
   constexpr relative_order compare(const undefined&, const undefined&) const noexcept {
@@ -118,13 +125,14 @@ static constexpr auto get_type_order_indices(type_list<AllTypes...>,
       static_cast<uint16_t>(type_list_index_v<AllTypes, ordered_list>)...};
 }
 
-relative_order order_struct<Expr>::operator()(const Expr& a, const Expr& b) const {
+relative_order order_struct<scalar_expr>::operator()(const scalar_expr& a,
+                                                     const scalar_expr& b) const {
   using order_of_types =
       type_list<float_constant, integer_constant, rational_constant, symbolic_constant,
                 complex_infinity, variable, multiplication, addition, power, function, relational,
                 conditional, cast_bool, compound_expression_element, derivative, undefined>;
   static constexpr auto order =
-      get_type_order_indices(Expr::storage_type::types{}, order_of_types{});
+      get_type_order_indices(scalar_expr::storage_type::types{}, order_of_types{});
 
   const auto index_a = order[a.type_index()];
   const auto index_b = order[b.type_index()];

--- a/components/core/wf/output_annotations.h
+++ b/components/core/wf/output_annotations.h
@@ -22,7 +22,7 @@ class output_arg {
   constexpr output_arg(const std::string_view name, U&& u, const bool is_optional)
       : value_(std::forward<U>(u)), name_(name), is_optional_(is_optional) {}
 
-  // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.
+  // Access the output value. Typically, an `scalar_expr` or `matrix_expr`, etc.
   constexpr const T& value() const { return value_; }
 
   // Name of the argument.
@@ -60,7 +60,7 @@ class return_value {
   template <typename U, typename = enable_if_constructible_t<U>>
   explicit return_value(U&& value) : value_(std::forward<U>(value)) {}
 
-  // Access the output value. Typically, an `Expr` or `matrix_expr`, etc.
+  // Access the output value. Typically, an `scalar_expr` or `matrix_expr`, etc.
   constexpr const T& value() const { return value_; }
 
   // Convert to `output_arg`.

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -9,17 +9,17 @@
 
 namespace wf {
 
-void plain_formatter::operator()(const Expr& x) { return visit(x, *this); }
+void plain_formatter::operator()(const scalar_expr& x) { return visit(x, *this); }
 void plain_formatter::operator()(const matrix_expr& x) { operator()(x.as_matrix()); }
 
 void plain_formatter::operator()(const addition& expr) {
   WF_ASSERT_GREATER_OR_EQ(expr.size(), 2);
 
   // Sort into canonical order:
-  absl::InlinedVector<std::pair<Expr, Expr>, 16> terms;
+  absl::InlinedVector<std::pair<scalar_expr, scalar_expr>, 16> terms;
   terms.reserve(expr.size());
   std::transform(expr.begin(), expr.end(), std::back_inserter(terms),
-                 [](const Expr& x) { return as_coeff_and_mul(x); });
+                 [](const scalar_expr& x) { return as_coeff_and_mul(x); });
 
   std::sort(terms.begin(), terms.end(), [](const auto& a, const auto& b) {
     return determine_order(a.second, b.second) == relative_order::less_than;
@@ -183,7 +183,7 @@ void plain_formatter::operator()(const matrix& mat) {
   elements.resize(mat.size());
 
   // Format all the child elements up front. That way we can do alignment:
-  std::transform(mat.begin(), mat.end(), elements.begin(), [](const Expr& expr) {
+  std::transform(mat.begin(), mat.end(), elements.begin(), [](const scalar_expr& expr) {
     plain_formatter child_formatter{};
     visit(expr, child_formatter);
     return child_formatter.output_;
@@ -299,7 +299,7 @@ void plain_formatter::operator()(const undefined&) { output_.append("nan"); }
 
 void plain_formatter::operator()(const variable& var) { output_.append(var.to_string()); }
 
-void plain_formatter::format_precedence(const precedence parent, const Expr& expr) {
+void plain_formatter::format_precedence(const precedence parent, const scalar_expr& expr) {
   if (get_precedence(expr) <= parent) {
     output_ += "(";
     visit(expr, *this);
@@ -309,7 +309,7 @@ void plain_formatter::format_precedence(const precedence parent, const Expr& exp
   }
 }
 
-void plain_formatter::format_power(const Expr& base, const Expr& exponent) {
+void plain_formatter::format_power(const scalar_expr& base, const scalar_expr& exponent) {
   format_precedence(precedence::power, base);
   output_ += " ** ";
   format_precedence(precedence::power, exponent);

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -8,7 +8,7 @@ namespace wf {
 // Simple plain-text formatter.
 class plain_formatter {
  public:
-  void operator()(const Expr& x);
+  void operator()(const scalar_expr& x);
   void operator()(const matrix_expr& x);
 
   void operator()(const addition& add);
@@ -37,10 +37,10 @@ class plain_formatter {
 
  private:
   // Wrap `expr` in braces if the precedence is <= the parent.
-  void format_precedence(precedence parent, const Expr& expr);
+  void format_precedence(precedence parent, const scalar_expr& expr);
 
   // Format power operation with the appropriate operator.
-  void format_power(const Expr& Base, const Expr& Exponent);
+  void format_power(const scalar_expr& Base, const scalar_expr& Exponent);
 
   std::string output_{};
 };

--- a/components/core/wf/substitute.h
+++ b/components/core/wf/substitute.h
@@ -15,31 +15,34 @@ class substitute_variables_visitor {
 
   // Add a new substitution to the list we will apply.
   // This should be called before visiting any expressions.
-  void add_substitution(const Expr& target, Expr replacement);
+  void add_substitution(const scalar_expr& target, scalar_expr replacement);
 
   // Add a new substitution to the list we will apply.
   // Version that accepts `variable` directly.
-  void add_substitution(variable variable, Expr replacement);
+  void add_substitution(variable variable, scalar_expr replacement);
 
   // Add a new substitution to the list we will apply.
   // Version that accepts `compound_expression_element` directly.
-  void add_substitution(compound_expression_element element, Expr replacement);
+  void add_substitution(compound_expression_element element, scalar_expr replacement);
 
   // Apply the substitute variable visitor. The cache is checked first.
-  Expr operator()(const Expr& expression);
+  scalar_expr operator()(const scalar_expr& expression);
   matrix_expr operator()(const matrix_expr& expression);
   compound_expr operator()(const compound_expr& expression);
 
   template <typename T>
-  Expr operator()(const T& concrete, const Expr& abstract);
+  scalar_expr operator()(const T& concrete, const scalar_expr& abstract);
 
  private:
-  std::unordered_map<variable, Expr, hash_struct<variable>, is_identical_struct<variable>>
+  std::unordered_map<variable, scalar_expr, hash_struct<variable>, is_identical_struct<variable>>
       variable_substitutions_;
-  std::unordered_map<compound_expression_element, Expr, hash_struct<compound_expression_element>,
+  std::unordered_map<compound_expression_element, scalar_expr,
+                     hash_struct<compound_expression_element>,
                      is_identical_struct<compound_expression_element>>
       element_substitutions_;
-  std::unordered_map<Expr, Expr, hash_struct<Expr>, is_identical_struct<Expr>> cache_{};
+  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
+                     is_identical_struct<scalar_expr>>
+      cache_{};
 };
 
 }  // namespace wf

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -69,12 +69,12 @@ struct tree_formatter {
     visit_right(*it);
   }
 
-  void operator()(const Expr& x) { visit(x, *this); }
+  void operator()(const scalar_expr& x) { visit(x, *this); }
 
   void operator()(const matrix_expr& m) { operator()(m.as_matrix()); }
 
   void operator()(const addition& op) {
-    absl::InlinedVector<Expr, 16> terms;
+    absl::InlinedVector<scalar_expr, 16> terms;
     terms.reserve(op.size());
     std::copy(op.begin(), op.end(), std::back_inserter(terms));
     std::sort(terms.begin(), terms.end(), [](const auto& a, const auto& b) {
@@ -115,7 +115,7 @@ struct tree_formatter {
   }
 
   void operator()(const multiplication& op) {
-    absl::InlinedVector<Expr, 16> terms;
+    absl::InlinedVector<scalar_expr, 16> terms;
     terms.reserve(op.size());
     std::copy(op.begin(), op.end(), std::back_inserter(terms));
     std::sort(terms.begin(), terms.end(), [](const auto& a, const auto& b) {
@@ -213,7 +213,7 @@ struct tree_formatter {
   std::string output_;
 };
 
-std::string Expr::to_expression_tree_string() const {
+std::string scalar_expr::to_expression_tree_string() const {
   tree_formatter formatter{};
   visit(*this, formatter);
   return formatter.take_output();

--- a/components/core/wf/type_annotations.h
+++ b/components/core/wf/type_annotations.h
@@ -35,7 +35,7 @@ struct static_matrix {
 
   template <typename... Args>
   using enable_if_convertible_to_expr =
-      std::enable_if_t<std::conjunction_v<std::is_constructible<Expr, Args>...>>;
+      std::enable_if_t<std::conjunction_v<std::is_constructible<scalar_expr, Args>...>>;
 
   // Construct from a row-major orderd list of elements.
   template <typename... Args, typename = enable_if_convertible_to_expr<Args...>>
@@ -45,10 +45,10 @@ struct static_matrix {
                   "Wrong # of elements passed to matrix constructor.");
   }
 
-  const Expr& operator()(index_t row, index_t col) const { return expr_(row, col); }
+  const scalar_expr& operator()(index_t row, index_t col) const { return expr_(row, col); }
 
   // Access vector element.
-  const Expr& operator[](index_t element) const { return expr_[element]; }
+  const scalar_expr& operator[](index_t element) const { return expr_[element]; }
 
   // Assign from matrix_expr
   static_matrix& operator=(const matrix_expr& other) {

--- a/components/core/wf/visit.h
+++ b/components/core/wf/visit.h
@@ -67,7 +67,7 @@ compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
                              // TODO: Make `matrix_expr` derived from `expression_base`, and call
                              //  visit(...) here.
                              return overloaded_visit(
-                                 arg, [&](const Expr& x) -> any_expression { return f(x); },
+                                 arg, [&](const scalar_expr& x) -> any_expression { return f(x); },
                                  [&](const matrix_expr& x) -> any_expression {
                                    matrix m = x.as_matrix().map_children(std::forward<F>(f));
                                    return matrix_expr(std::move(m));

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -274,7 +274,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def(
           "add_output_argument",
           [](function_description& self, const std::string_view name, const bool is_optional,
-             const Expr& value) {
+             const scalar_expr& value) {
             self.add_output_argument(name, scalar_type(code_numeric_type::floating_point),
                                      is_optional, {value});
           },
@@ -291,14 +291,14 @@ void wrap_codegen_operations(py::module_& m) {
       .def(
           "add_output_argument",
           [](function_description& self, const std::string_view name, const bool is_optional,
-             const custom_type& custom_type, std::vector<Expr> expressions) {
+             const custom_type& custom_type, std::vector<scalar_expr> expressions) {
             self.add_output_argument(name, custom_type, is_optional, std::move(expressions));
           },
           py::arg("name"), py::arg("is_optional"), py::arg("custom_type"), py::arg("expressions"),
           py::doc("Record an output argument of custom type."))
       .def(
           "set_return_value",
-          [](function_description& self, const Expr& value) {
+          [](function_description& self, const scalar_expr& value) {
             self.set_return_value(scalar_type(code_numeric_type::floating_point), {value});
           },
           py::arg("value"))
@@ -311,7 +311,7 @@ void wrap_codegen_operations(py::module_& m) {
       .def(
           "set_return_value",
           [](function_description& self, const custom_type& custom_type,
-             std::vector<Expr> expressions) {
+             std::vector<scalar_expr> expressions) {
             self.set_return_value(custom_type, std::move(expressions));
           },
           py::arg("custom_type"), py::arg("expressions"));

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -18,7 +18,7 @@ namespace wf {
 
 // Get four elements from an iterable, throw if there are not four.
 static auto components_from_iterable(const py::iterable& iterable) {
-  absl::InlinedVector<Expr, 4> values;
+  absl::InlinedVector<scalar_expr, 4> values;
   cast_to_expr(iterable, values);
   if (values.size() != 4) {
     throw dimension_error("Expected 4 values but {} were provided.", values.size());
@@ -46,8 +46,8 @@ static py::array eval_quaternion(const quaternion& q) {
 
 void wrap_geometry_operations(py::module_& m) {
   py::class_<quaternion>(m, "Quaternion")
-      .def(py::init<Expr, Expr, Expr, Expr>(), "w"_a, "x"_a, "y"_a, "z"_a,
-           py::doc("Construct from wxyz elements."))
+      .def(py::init<scalar_expr, scalar_expr, scalar_expr, scalar_expr>(), "w"_a, "x"_a, "y"_a,
+           "z"_a, py::doc("Construct from wxyz elements."))
       .def(py::init<>(), py::doc("Construct as identity."))
       .def_static(
           "with_name",
@@ -117,8 +117,8 @@ void wrap_geometry_operations(py::module_& m) {
       // TODO: Stubs are wrong for these, see: https://github.com/python/mypy/pull/14934
       .def_static(
           "from_angle_axis",
-          static_cast<quaternion (*)(const Expr&, const Expr&, const Expr&, const Expr&)>(
-              &quaternion::from_angle_axis),
+          static_cast<quaternion (*)(const scalar_expr&, const scalar_expr&, const scalar_expr&,
+                                     const scalar_expr&)>(&quaternion::from_angle_axis),
           "angle"_a, "vx"_a, "vy"_a, "vz"_a,
           py::doc(
               "Create a quaternion from angle-axis parameters. Parameters [vx, vy, vz] must be a "
@@ -126,25 +126,27 @@ void wrap_geometry_operations(py::module_& m) {
               "radians."))
       .def_static(
           "from_angle_axis",
-          static_cast<quaternion (*)(const Expr&, const matrix_expr&)>(
+          static_cast<quaternion (*)(const scalar_expr&, const matrix_expr&)>(
               &quaternion::from_angle_axis),
           "angle"_a, "v"_a,
           py::doc("Create a quaternion from angle-axis parameters. Vector v must be a "
                   "unit vector, or the result does not represent a rotation. Angle is specified in "
                   "radians."))
-      .def_static("from_rotation_vector",
-                  static_cast<quaternion (*)(const Expr&, const Expr&, const Expr&,
-                                             const std::optional<Expr>&)>(
-                      &quaternion::from_rotation_vector),
-                  "x"_a, "y"_a, "z"_a, py::arg("epsilon"),
-                  py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
-                          "of radians."))
-      .def_static("from_rotation_vector",
-                  static_cast<quaternion (*)(const matrix_expr&, const std::optional<Expr>&)>(
-                      &quaternion::from_rotation_vector),
-                  "v"_a, py::arg("epsilon"),
-                  py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
-                          "of radians."))
+      .def_static(
+          "from_rotation_vector",
+          static_cast<quaternion (*)(const scalar_expr&, const scalar_expr&, const scalar_expr&,
+                                     const std::optional<scalar_expr>&)>(
+              &quaternion::from_rotation_vector),
+          "x"_a, "y"_a, "z"_a, py::arg("epsilon"),
+          py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
+                  "of radians."))
+      .def_static(
+          "from_rotation_vector",
+          static_cast<quaternion (*)(const matrix_expr&, const std::optional<scalar_expr>&)>(
+              &quaternion::from_rotation_vector),
+          "v"_a, py::arg("epsilon"),
+          py::doc("Create a quaternion from Rodrigues rotation vector, expressed in units "
+                  "of radians."))
       .def_static("from_x_angle", &quaternion::from_x_angle, "angle"_a,
                   py::doc("Construct a rotation about the x-axis. Angle is in radians."))
       .def_static("from_y_angle", &quaternion::from_y_angle, "angle"_a,
@@ -169,7 +171,7 @@ void wrap_geometry_operations(py::module_& m) {
           py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
       .def(
           "jacobian",
-          [](const quaternion& self, const std::vector<Expr>& vars, bool use_abstract) {
+          [](const quaternion& self, const std::vector<scalar_expr>& vars, bool use_abstract) {
             return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
                                                     : non_differentiable_behavior::constant);
           },

--- a/components/wrapper/pywrenfold/wrapper_utils.h
+++ b/components/wrapper/pywrenfold/wrapper_utils.h
@@ -29,7 +29,7 @@ py::class_<T> wrap_class(py::module_& m, const std::string_view name) {
   return klass;
 }
 
-// Iterate over a container and transform every element into `Expr`.
+// Iterate over a container and transform every element into `scalar_expr`.
 template <typename Container, typename Output>
 std::size_t cast_to_expr(const Container& inputs, Output& output) {
   // len_hint will get the length if possible, otherwise return 0.
@@ -43,13 +43,14 @@ std::size_t cast_to_expr(const Container& inputs, Output& output) {
   std::transform(inputs.begin(), inputs.end(), std::back_inserter(output),
                  [&](const py::handle& handle) {
                    ++count;
-                   return py::cast<Expr>(handle);
+                   return py::cast<scalar_expr>(handle);
                  });
   return count;
 }
 
-// Try converting `x` to an int or float, otherwise just return Expr.
-inline std::variant<std::int64_t, double, Expr> try_convert_to_numeric(const Expr& x) {
+// Try converting `x` to an int or float, otherwise just return scalar_expr.
+inline std::variant<std::int64_t, double, scalar_expr> try_convert_to_numeric(
+    const scalar_expr& x) {
   if (const float_constant* f = cast_ptr<const float_constant>(x); f != nullptr) {
     return f->get_value();
   } else if (const integer_constant* i = cast_ptr<const integer_constant>(x); i != nullptr) {

--- a/examples/quaternion_interpolation/quat_interpolation_expressions.h
+++ b/examples/quaternion_interpolation/quat_interpolation_expressions.h
@@ -11,8 +11,8 @@ namespace wf {
 // Interpolate between two quaternions, `q0` and `q1` (passed as scalar-last vectors).
 // Outputs the interpolated quaternion, as well as the tangent space derivatives.
 inline auto quaternion_interpolation(const ta::static_matrix<4, 1>& q0_vec,
-                                     const ta::static_matrix<4, 1>& q1_vec, const Expr& alpha,
-                                     const std::optional<Expr>& epsilon) {
+                                     const ta::static_matrix<4, 1>& q1_vec, const scalar_expr& alpha,
+                                     const std::optional<scalar_expr>& epsilon) {
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
   const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon);
@@ -32,7 +32,7 @@ inline auto quaternion_interpolation(const ta::static_matrix<4, 1>& q0_vec,
 // log(q0^-1 * q1), w/ no handling for the small angle case
 inline auto quaternion_local_coordinates(const ta::static_matrix<4, 1>& q0_vec,
                                          const ta::static_matrix<4, 1>& q1_vec,
-                                         const std::optional<Expr>& epsilon) {
+                                         const std::optional<scalar_expr>& epsilon) {
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
   const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon);

--- a/examples/quaternion_interpolation/quat_interpolation_gen.cc
+++ b/examples/quaternion_interpolation/quat_interpolation_gen.cc
@@ -17,26 +17,26 @@ int main() {
   cpp_code_generator gen{};
   generate_func(
       gen, code,
-      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, scalar_expr alpha) {
         return quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16);
       },
       "quaternion_interpolation", "q0", "q1", "alpha");
   generate_func(
       gen, code,
-      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, scalar_expr alpha) {
         return quaternion_interpolation(q0_vec, q1_vec, alpha, std::nullopt);
       },
       "quaternion_interpolation_no_conditional", "q0", "q1", "alpha");
 
   generate_func(
       gen, code,
-      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, scalar_expr alpha) {
         return std::get<0>(quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16));
       },
       "quaternion_interpolation_no_diff", "q0", "q1", "alpha");
   generate_func(
       gen, code,
-      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, Expr alpha) {
+      [](ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec, scalar_expr alpha) {
         return std::get<0>(quaternion_interpolation(q0_vec, q1_vec, alpha, std::nullopt));
       },
       "quaternion_interpolation_no_conditional_no_diff", "q0", "q1", "alpha");

--- a/examples/quaternion_interpolation/quat_interpolation_test.cc
+++ b/examples/quaternion_interpolation/quat_interpolation_test.cc
@@ -26,7 +26,7 @@ Eigen::Quaternion<Scalar> quat_interp(const Eigen::Quaternion<Scalar>& a,
 }
 
 auto quat_interpolation(ta::static_matrix<4, 1> q0_vec, ta::static_matrix<4, 1> q1_vec,
-                        Expr alpha) {
+                        scalar_expr alpha) {
   return quaternion_interpolation(q0_vec, q1_vec, alpha, 1.0e-16);
 };
 


### PR DESCRIPTION
Expr was the last type I did not rename when I switched from camel to snake case. This change does the final rename of `Expr` to `scalar_expr`. I did not yet rename the python type from `Expr` -> `ScalarExpr`. I might leave that type for the sake of brevity.