### PR TITLE
Cleanup IR code (part 2)

### DIFF
--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -137,7 +137,7 @@ struct ast_from_ir {
   // Given all the `ir::save` operations for a block, create the AST objects that represent
   // either return values, or writing to output arguments (and add them to operations_).
   void push_back_outputs(const ir::block_ptr block) {
-    for (const ir::value_ptr value : block->operations) {
+    for (const ir::value_ptr value : block->operations()) {
       if (!value->is_op<ir::save>()) {
         continue;
       }
@@ -146,7 +146,7 @@ struct ast_from_ir {
       type_constructor constructor = create_type_constructor(value->operands());
 
       if (key.usage == expression_usage::return_value) {
-        WF_ASSERT(block->descendants.empty(), "Must be the final block");
+        WF_ASSERT(block->has_no_descendents(), "Must be the final block");
         WF_ASSERT(signature_.return_type().has_value(), "Return type must be specified");
         ast::variant var = std::visit([&](const auto& x) -> ast::variant { return constructor(x); },
                                       *signature_.return_type());
@@ -188,7 +188,7 @@ struct ast_from_ir {
   //    }
   //  }
   void push_back_conditional_output_declarations(const ir::block_ptr block) {
-    for (const ir::value_ptr value : block->operations) {
+    for (const ir::value_ptr value : block->operations()) {
       if (value->is_phi()) {
         if (const bool no_declaration =
                 value->all_consumers_satisfy([](const ir::value_ptr v) { return v->is_phi(); });
@@ -209,14 +209,14 @@ struct ast_from_ir {
       return;
     }
     WF_ASSERT(block->has_no_descendents() || !block->is_empty(),
-              "Only the terminal block may be empty. block->name: {}", block->name);
+              "Only the terminal block may be empty. block->name(): {}", block->name());
 
-    operations_.reserve(operations_.capacity() + block->operations.size());
+    operations_.reserve(operations_.capacity() + block->size());
 
     std::vector<ast::assign_temporary> phi_assignments{};
-    phi_assignments.reserve(block->operations.size());
+    phi_assignments.reserve(block->size());
 
-    for (const ir::value_ptr value : block->operations) {
+    for (const ir::value_ptr value : block->operations()) {
       if (value->is_op<ir::save>()) {
         // Defer output values to the end of the block.
       } else if (value->is_phi()) {
@@ -286,34 +286,37 @@ struct ast_from_ir {
   // Determine if the provided block terminates in conditional control flow. If it does, we need to
   // branch both left and right to compute the contents of the if-else statement.
   void handle_control_flow(const ir::block_ptr block) {
-    if (block->descendants.empty()) {
+    const auto& descendents = block->descendants();
+    if (descendents.empty()) {
       // This is the terminal block - nothing to do.
       return;
     }
 
-    if (const ir::value_ptr last_op = block->operations.back();
+    if (const ir::value_ptr last_op = block->last_operation();
         !last_op->is_op<ir::jump_condition>()) {
       // just keep appending:
-      WF_ASSERT_EQUAL(1, block->descendants.size());
-      process_block(block->descendants.front());
+      WF_ASSERT_EQUAL(1, descendents.size());
+      process_block(descendents.front());
     } else {
       WF_ASSERT(last_op->is_op<ir::jump_condition>());
-      WF_ASSERT_EQUAL(2, block->descendants.size());
 
       // This over-counts a bit, since nested branches don't all run. We are just counting
       // if-statements, basically.
       operation_counts_[operation_count_label::branch]++;
 
       // Figure out where this if-else statement will terminate:
-      const ir::block_ptr merge_point = find_merge_point(
-          block->descendants[0], block->descendants[1], ir::search_direction::downwards);
+      const auto& descendants = block->descendants();
+      WF_ASSERT_EQUAL(2, descendants.size());
+
+      const ir::block_ptr merge_point =
+          find_merge_point(descendants[0], descendants[1], ir::search_direction::downwards);
       non_traversable_blocks_.insert(merge_point);
 
       // Declare any variables that will be written in both the if and else blocks:
       push_back_conditional_output_declarations(merge_point);
 
       // Descend into both branches:
-      std::vector<ast::variant> operations_true = process_nested_block(block->descendants[0]);
+      std::vector<ast::variant> operations_true = process_nested_block(descendants[0]);
 
       // We have two kinds of branches. One for optionally-computed outputs, which only has
       // an if-branch. The other is for conditional logic in computations (where both if and
@@ -329,7 +332,7 @@ struct ast_from_ir {
                                                        std::move(operations_true));
       } else {
         // Fill out operations in the else branch:
-        std::vector<ast::variant> operations_false = process_nested_block(block->descendants[1]);
+        std::vector<ast::variant> operations_false = process_nested_block(descendants[1]);
 
         // Create a conditional
         auto condition_var =

--- a/components/core/wf/code_generation/control_flow_graph.h
+++ b/components/core/wf/code_generation/control_flow_graph.h
@@ -66,9 +66,6 @@ class control_flow_graph {
                      std::vector<ir::value::unique_ptr> values)
       : blocks_(std::move(blocks)), values_(std::move(values)) {}
 
-  // Remove any values without consumers (that are not endpoints like `ir::save`).
-  void strip_unused_values();
-
   // Owns all the blocks.
   std::vector<ir::block::unique_ptr> blocks_;
 

--- a/components/core/wf/code_generation/ir_block.cc
+++ b/components/core/wf/code_generation/ir_block.cc
@@ -8,11 +8,11 @@ namespace wf::ir {
 void block::replace_descendant(ir::block_ptr target, ir::block_ptr replacement) {
   WF_ASSERT_NOT_EQUAL(target, replacement);
 
-  if (!operations.empty()) {
-    if (const ir::value_ptr jump_val = operations.back(); jump_val->is_op<ir::jump_condition>()) {
-      WF_ASSERT_EQUAL(2, descendants.size());
+  if (!operations_.empty()) {
+    if (const ir::value_ptr jump_val = operations_.back(); jump_val->is_op<ir::jump_condition>()) {
+      WF_ASSERT_EQUAL(2, descendants_.size());
     } else {
-      WF_ASSERT_GREATER_OR_EQ(1, descendants.size());
+      WF_ASSERT_GREATER_OR_EQ(1, descendants_.size());
     }
   }
 
@@ -20,27 +20,27 @@ void block::replace_descendant(ir::block_ptr target, ir::block_ptr replacement) 
   target->remove_ancestor(self);
   replacement->add_ancestor(self);
 
-  const auto it = std::find(descendants.begin(), descendants.end(), target);
-  WF_ASSERT(it != descendants.end());
+  const auto it = std::find(descendants_.begin(), descendants_.end(), target);
+  WF_ASSERT(it != descendants_.end());
   *it = replacement;
 }
 
 void block::add_ancestor(const block_ptr b) {
-  WF_ASSERT(std::find(ancestors.begin(), ancestors.end(), b) == ancestors.end(),
-            "Attempted to insert duplicate into ancestor list: {}", b->name);
-  ancestors.push_back(b);
+  WF_ASSERT(std::find(ancestors_.begin(), ancestors_.end(), b) == ancestors_.end(),
+            "Attempted to insert duplicate into ancestor list: {}", b->name());
+  ancestors_.push_back(b);
 }
 
 void block::remove_ancestor(const block_ptr b) {
-  const auto it = std::find(ancestors.begin(), ancestors.end(), b);
-  WF_ASSERT(it != ancestors.end(), "Block {} is not an ancestor of {}", b->name, name);
-  ancestors.erase(it);
+  const auto it = std::find(ancestors_.begin(), ancestors_.end(), b);
+  WF_ASSERT(it != ancestors_.end(), "Block {} is not an ancestor of {}", b->name(), name());
+  ancestors_.erase(it);
 }
 
 void block::add_descendant(const block_ptr b) {
-  WF_ASSERT(std::find(descendants.begin(), descendants.end(), b) == descendants.end(),
-            "Block {} already exists in descendants list: {},", b, fmt::join(descendants, ", "));
-  descendants.push_back(b);
+  WF_ASSERT(std::find(descendants_.begin(), descendants_.end(), b) == descendants_.end(),
+            "Block {} already exists in descendants list: {},", b, fmt::join(descendants_, ", "));
+  descendants_.push_back(b);
   b->add_ancestor(ir::block_ptr{this});
 }
 
@@ -67,11 +67,11 @@ ir::block_ptr find_merge_point(const ir::block_ptr left, const ir::block_ptr rig
       return b;
     }
     if (direction == search_direction::downwards) {
-      for (ir::block_ptr child : b->descendants) {
+      for (ir::block_ptr child : b->descendants()) {
         queue.emplace_back(child, color);
       }
     } else {
-      for (ir::block_ptr ancestor : b->ancestors) {
+      for (ir::block_ptr ancestor : b->ancestors()) {
         queue.emplace_back(ancestor, color);
       }
     }

--- a/components/core/wf/code_generation/ir_block.h
+++ b/components/core/wf/code_generation/ir_block.h
@@ -8,37 +8,28 @@
 
 namespace wf::ir {
 
-// A block of operations:
+// A block of operations in the control flow graph.
 class block {
  public:
   using unique_ptr = std::unique_ptr<block>;
 
-  // Construct w/ counter.
-  explicit block(const std::size_t name) noexcept : name(name) {}
+  // Construct w/ name.
+  explicit block(const std::size_t name) noexcept : name_(name) {}
 
-  // Unique number to refer to the block (a counter).
-  std::size_t name;
-
-  // All the operations in the block, in order.
-  // TODO: There is an argument to be made that this should be an intrusive double-linked-list.
-  // For now I'm going with vec of pointers, since this is simpler to get started, even though it
-  // means we'll have some O(N) operations (for moderately small N).
-  std::vector<value_ptr> operations{};
-
-  // Ancestor blocks (blocks that preceded this one).
-  std::vector<block_ptr> ancestors{};
-
-  // Descendants of this block (blocks we jump to from this one).
-  std::vector<block_ptr> descendants{};
+  // Unique number assigned to the block to identify it.
+  constexpr std::size_t name() const noexcept { return name_; }
 
   // True if the block has no operations.
-  bool is_empty() const noexcept { return operations.empty(); }
+  bool is_empty() const noexcept { return operations_.empty(); }
+
+  // Number of operations.
+  std::size_t size() const noexcept { return operations_.size(); }
 
   // True if this block has no ancestors (typically only true for the starting block).
-  bool has_no_ancestors() const noexcept { return ancestors.empty(); }
+  bool has_no_ancestors() const noexcept { return ancestors_.empty(); }
 
   // True if this block has no descendents.
-  bool has_no_descendents() const noexcept { return descendants.empty(); }
+  bool has_no_descendents() const noexcept { return descendants_.empty(); }
 
   // Replace descendant `target` w/ `replacement`.
   void replace_descendant(ir::block_ptr target, ir::block_ptr replacement);
@@ -52,9 +43,69 @@ class block {
   // Add `b` as a descendant, and add `this` as an ancestor of b.
   void add_descendant(ir::block_ptr b);
 
+  // Push a new operation at the end of the block.
+  const value_ptr& push(const ir::value_ptr val) {
+    operations_.push_back(val);
+    return operations_.back();
+  }
+
+  // Insert at the front of the operation vector.
+  template <typename Iterator>
+  void insert_front(Iterator begin, Iterator end) {
+    operations_.insert(operations_.begin(), begin, end);
+  }
+
+  // Remove all operations that match predicate `func`.
+  template <typename Func>
+  void remove_operation_if(Func func) {
+    operations_.erase(std::remove_if(operations_.begin(), operations_.end(), std::move(func)),
+                      operations_.end());
+  }
+
+  // Remove all operations that match predicate `func`, traversing in reverse order.
+  template <typename Func>
+  void reverse_remove_operation_if(Func func) {
+    // Somewhat lazy: Reverse the operations so that we can use forward iterator, then reverse back.
+    std::reverse(operations_.begin(), operations_.end());
+    operations_.erase(std::remove_if(operations_.begin(), operations_.end(), std::move(func)),
+                      operations_.end());
+    std::reverse(operations_.begin(), operations_.end());
+  }
+
+  // Get the last operation in the block.
+  value_ptr last_operation() const {
+    WF_ASSERT(!is_empty(), "Block is empty: {}", name_);
+    return operations_.back();
+  }
+
   // Count instances of operation of type `T`.
   template <typename Func>
   std::size_t count_operation(Func&& func) const;
+
+  // Access operations.
+  constexpr const auto& operations() const noexcept { return operations_; }
+
+  // Access descendents.
+  constexpr const auto& descendants() const noexcept { return descendants_; }
+
+  // Access ancestors.
+  constexpr const auto& ancestors() const noexcept { return ancestors_; }
+
+ private:
+  // Unique number to refer to the block (a counter).
+  std::size_t name_;
+
+  // All the operations in the block, in order.
+  // TODO: There is an argument to be made that this should be an intrusive double-linked-list.
+  // For now I'm going with vec of pointers, since this is simpler to get started, even though it
+  // means we'll have some O(N) operations (for moderately small N).
+  std::vector<value_ptr> operations_{};
+
+  // Ancestor blocks (blocks that preceded this one).
+  std::vector<block_ptr> ancestors_{};
+
+  // Descendants of this block (blocks we jump to from this one).
+  std::vector<block_ptr> descendants_{};
 };
 
 // Create an `ir::value` in the specified block using operation `OpType`.
@@ -66,11 +117,11 @@ ir::value_ptr create_operation(std::vector<ir::value::unique_ptr>& values,
   const uint32_t name = values.empty() ? 0 : values.back()->name() + 1;
   std::unique_ptr<ir::value> value = std::make_unique<ir::value>(
       name, block, std::forward<OpType>(op), std::move(type), std::forward<Args>(args)...);
-  // Insert int the provided block:
-  block->operations.emplace_back(value.get());
+  // Insert in the provided block:
+  const ir::value_ptr& last = block->push(value.get());
   // This is owned by the `values` vector:
   values.push_back(std::move(value));
-  return block->operations.back();
+  return last;
 }
 
 // Argument to `find_merge_point`.
@@ -89,19 +140,23 @@ ir::block_ptr find_merge_point(ir::block_ptr left, ir::block_ptr right, search_d
 // Defined here so that we can use methods on `value`.
 template <typename Func>
 std::size_t block::count_operation(Func&& func) const {
-  return std::count_if(operations.begin(), operations.end(),
-                       [&func](const ir::value_ptr v) -> bool {
-                         return std::visit(
-                             [&func](const auto& op) -> bool {
-                               using arg_type = std::decay_t<decltype(op)>;
-                               if constexpr (is_invocable_v<Func, const arg_type&>) {
-                                 return func(op);
-                               } else {
-                                 return false;
-                               }
-                             },
-                             v->value_op());
-                       });
+  if constexpr (is_invocable_v<Func, ir::value_ptr>) {
+    return std::count_if(operations_.begin(), operations_.end(), std::forward<Func>(func));
+  } else {
+    return std::count_if(operations_.begin(), operations_.end(),
+                         [&func](const ir::value_ptr v) -> bool {
+                           return std::visit(
+                               [&func](const auto& op) -> bool {
+                                 using arg_type = std::decay_t<decltype(op)>;
+                                 if constexpr (is_invocable_v<Func, const arg_type&>) {
+                                   return func(op);
+                                 } else {
+                                   return false;
+                                 }
+                               },
+                               v->value_op());
+                         });
+  }
 }
 
 }  // namespace wf::ir
@@ -113,6 +168,6 @@ struct fmt::formatter<wf::ir::block_ptr, char> {
 
   template <typename FormatContext>
   auto format(const wf::ir::block_ptr x, FormatContext& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "block_{}", x->name);
+    return fmt::format_to(ctx.out(), "block_{}", x->name());
   }
 };

--- a/components/core/wf/code_generation/ir_control_flow_converter.cc
+++ b/components/core/wf/code_generation/ir_control_flow_converter.cc
@@ -47,8 +47,7 @@ ir_control_flow_converter::ir_control_flow_converter(control_flow_graph&& input)
   input_block_ = std::move(input.blocks_.front());
   input.blocks_.clear();
 
-  // Discard all references the input block has to values, since we are going to reassign them.
-  input_block_->operations.clear();
+  // input_block_ will be destroyed on destruction of this object, which occurs after convert().
 }
 
 control_flow_graph ir_control_flow_converter::convert() && {
@@ -139,11 +138,11 @@ static bool parent_is_on_all_paths_through_block(const ir::block_ptr test_block,
   if (test_block == parent_block) {
     return true;
   }
-  return !test_block->ancestors.empty() &&
-         std::all_of(test_block->ancestors.begin(), test_block->ancestors.end(),
-                     [&](const ir::block_ptr b) {
-                       return parent_is_on_all_paths_through_block(b, parent_block);
-                     });
+  const auto& ancestors = test_block->ancestors();
+  return !ancestors.empty() &&
+         std::all_of(ancestors.begin(), ancestors.end(), [&](const ir::block_ptr b) {
+           return parent_is_on_all_paths_through_block(b, parent_block);
+         });
 }
 
 std::vector<ir::value_ptr> ir_control_flow_converter::process_non_conditionals(
@@ -172,10 +171,11 @@ std::vector<ir::value_ptr> ir_control_flow_converter::process_non_conditionals(
     // if `output_block` is on all paths through the downstream consumer blocks. This check
     // ensures we don't write the computation of a value into a scope that isn't visible by all
     // other scopes that need this value.
-    const bool is_valid_to_insert = top->all_consumers_satisfy([&](const ir::value_ptr consumer) {
-      return parent_is_on_all_paths_through_block(consumer->parent(), output_block);
-    });
-    if (!is_valid_to_insert) {
+    if (const bool is_valid_to_insert =
+            top->all_consumers_satisfy([&](const ir::value_ptr consumer) {
+              return parent_is_on_all_paths_through_block(consumer->parent(), output_block);
+            });
+        !is_valid_to_insert) {
       deferred.push_back(top);
       continue;
     }
@@ -194,8 +194,7 @@ std::vector<ir::value_ptr> ir_control_flow_converter::process_non_conditionals(
   }
 
   // Flip things back when inserting into the actual block operations:
-  output_block->operations.insert(output_block->operations.begin(), output_reversed.rbegin(),
-                                  output_reversed.rend());
+  output_block->insert_front(output_reversed.rbegin(), output_reversed.rend());
   return queued_conditionals;
 }
 
@@ -285,11 +284,10 @@ ir::block_ptr ir_control_flow_converter::process(std::deque<ir::value_ptr> queue
   }
 
   // Insert the phi functions at the top of the block:
-  output_block->operations.insert(output_block->operations.begin(), grouped_conditionals.rbegin(),
-                                  grouped_conditionals.rend());
+  output_block->insert_front(grouped_conditionals.rbegin(), grouped_conditionals.rend());
 
   // Save the ancestor vector before modifying it by creating jumps:
-  const std::vector<ir::block_ptr> previous_ancestors = output_block->ancestors;
+  const std::vector<ir::block_ptr> previous_ancestors = output_block->ancestors();
 
   left_block_tail->add_descendant(output_block);
   right_block_tail->add_descendant(output_block);
@@ -305,7 +303,7 @@ ir::block_ptr ir_control_flow_converter::process(std::deque<ir::value_ptr> queue
   // Any blocks that jumped to `output_block` should now jump to `jump_block` instead:
   for (const ir::block_ptr ancestor : previous_ancestors) {
     // If this block is our ancestor, it must contain a jump at the end:
-    WF_ASSERT(!ancestor->operations.empty() && !ancestor->descendants.empty(),
+    WF_ASSERT(!ancestor->is_empty() && !ancestor->has_no_descendents(),
               "block cannot be empty, must contain a jump");
     ancestor->replace_descendant(output_block, jump_block);
   }
@@ -331,19 +329,15 @@ ir::block_ptr ir_control_flow_converter::process(std::deque<ir::value_ptr> queue
 // ReSharper disable once CppMemberFunctionMayBeConst
 void ir_control_flow_converter::eliminate_useless_copies() {
   for (const auto& block : blocks_) {
-    const auto new_end =
-        std::remove_if(block->operations.begin(), block->operations.end(), [&](ir::value_ptr v) {
-          // A copy is useless if we are duplicating a value in our current block:
-          const bool should_eliminate =
-              v->is_op<ir::copy>() && v->first_operand()->parent() == v->parent();
-          if (should_eliminate) {
-            v->replace_with(v->first_operand());
-            v->remove();
-            return true;
-          }
-          return false;
-        });
-    block->operations.erase(new_end, block->operations.end());
+    block->remove_operation_if([&](const ir::value_ptr v) {
+      // A copy is useless if we are duplicating a value in our current block:
+      if (v->is_op<ir::copy>() && v->first_operand()->parent() == v->parent()) {
+        v->replace_with(v->first_operand());
+        v->remove();
+        return true;
+      }
+      return false;
+    });
   }
 }
 

--- a/components/core/wf/code_generation/ir_value.h
+++ b/components/core/wf/code_generation/ir_value.h
@@ -46,10 +46,10 @@ class value {
   // Access underlying operation
   constexpr const operation& value_op() const noexcept { return op_; }
 
-  // True if the underlying operation is `T`.
-  template <typename T>
+  // True if the underlying operation is one of `Ts`.
+  template <typename... Ts>
   constexpr bool is_op() const noexcept {
-    return std::holds_alternative<T>(op_);
+    return (std::holds_alternative<Ts>(op_) || ...);
   }
 
   // Cast the operation to the specified type.


### PR DESCRIPTION
Following up on https://github.com/gareth-cross/wrenfold/pull/97, this change contains a few more cleanup/reorg tasks relevant to the intermediate representation code:
- Add accessors to the `block` type, make the members private.
- Get rid of redundant constructor on `value`.
- De-dup some shared code between `value` constructor and `set_operation`.