### PR TITLE
Eliminate `ast::variant` and replace with `ast::ast_element`.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   wf/code_generation/ast.h
   wf/code_generation/ast_conversion.cc
   wf/code_generation/ast_conversion.h
+  wf/code_generation/ast_element.h
   wf/code_generation/ast_formatters.h
   wf/code_generation/code_formatter.h
   wf/code_generation/control_flow_graph.cc

--- a/components/core/wf/code_generation/ast.cc
+++ b/components/core/wf/code_generation/ast.cc
@@ -6,15 +6,6 @@
 
 namespace wf::ast {
 
-assign_output_matrix::assign_output_matrix(argument arg, construct_matrix&& value)
-    : arg(std::move(arg)), value(std::make_shared<construct_matrix>(std::move(value))) {}
-
-assign_output_struct::assign_output_struct(argument arg, construct_custom_type&& value)
-    : arg(std::move(arg)), value(std::make_shared<construct_custom_type>(std::move(value))) {}
-
-assign_temporary::assign_temporary(std::string left, variant_ptr right)
-    : left(std::move(left)), right(std::move(right)) {}
-
 std::vector<std::string> comment::split_lines() const {
   // Remove windows carriage return.
   const std::string content_no_cr = std::regex_replace(content, std::regex("\r\n"), "\n");
@@ -27,7 +18,7 @@ std::vector<std::string> comment::split_lines() const {
   return lines;
 }
 
-maybe_null<const ast::variant*> construct_custom_type::get_field_by_name(
+maybe_null<const ast_element*> construct_custom_type::get_field_by_name(
     std::string_view name) const {
   const auto it = std::find_if(field_values.begin(), field_values.end(),
                                [&](const auto& tuple) { return std::get<0>(tuple) == name; });
@@ -36,14 +27,6 @@ maybe_null<const ast::variant*> construct_custom_type::get_field_by_name(
   }
   return &std::get<1>(*it);
 }
-
-declaration::declaration(std::string name, type_variant type, variant_ptr value)
-    : name(std::move(name)),
-      type(declaration_type_annotation{std::move(type)}),
-      value(std::move(value)) {}
-
-declaration::declaration(std::string name, type_variant type)
-    : name(std::move(name)), type(declaration_type_annotation{std::move(type)}) {}
 
 std::vector<argument> function_signature::matrix_args() const {
   std::vector<argument> result{};

--- a/components/core/wf/code_generation/ast_element.h
+++ b/components/core/wf/code_generation/ast_element.h
@@ -1,0 +1,128 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include <memory>
+
+#include "wf/type_list.h"
+
+namespace wf::ast {
+class ast_element;
+
+namespace detail {
+// Forward declare.
+template <typename T>
+const auto& cast_to_type(const ast_element& element) noexcept;
+}  // namespace detail
+
+// A list of (most of) the types that appear in the output AST. We store these inside `ast_element`.
+// clang-format off
+using ast_element_types = type_list<
+    struct add,
+    struct assign_temporary,
+    struct assign_output_matrix,
+    struct assign_output_scalar,
+    struct assign_output_struct,
+    struct branch,
+    struct call_external_function,
+    struct call_std_function,
+    struct cast,
+    struct comment,
+    struct compare,
+    struct construct_custom_type,
+    struct construct_matrix,
+    struct declaration,
+    struct divide,
+    struct float_literal,
+    struct get_argument,
+    struct get_field,
+    struct get_matrix_element,
+    struct integer_literal,
+    struct multiply,
+    struct negate,
+    struct optional_output_branch,
+    struct special_constant,
+    struct return_object,
+    struct variable_ref
+    >;
+// clang-format on
+
+// Store an immutable type-erased instance of one of the types in `ast_element_types`. Alongside the
+// object contents, we store an index (similar to a variant) and provide a `visit` method for
+// accessing the underlying ast type. This object is reference counted, since the same ast element
+// may appear more than once in the output.
+// TODO: This type bears a lot of similarities to expression_variant. There may be a path to
+//  depuplicating these a bit.
+class ast_element {
+ public:
+  using types = ast_element_types;
+
+  // Check if the decayed type `T` is in our list of supported types.
+  template <typename T>
+  using enable_if_is_constructible_t = enable_if_contains_type_t<std::decay_t<T>, types>;
+
+  // Copy or move construct from an instance of type `T`.
+  template <typename T, typename U = std::decay_t<T>, typename = enable_if_is_constructible_t<T>>
+  explicit ast_element(T&& value) noexcept(std::is_nothrow_constructible_v<U, decltype(value)>)
+      : ptr_{std::make_shared<const model<U>>(std::forward<T>(value))} {}
+
+  // In-place construct type `T` from `Args`.
+  template <typename T, typename... Args, typename = enable_if_is_constructible_t<T>>
+  explicit ast_element(std::in_place_type_t<T>, Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<T, decltype(args)...>)
+      : ptr_{std::make_shared<const model<T>>(std::in_place_t{}, std::forward<Args>(args)...)} {}
+
+  // Return index indicating which type is stored.
+  std::size_t index() const noexcept { return ptr_->index(); }
+
+  // Access the underlying shared pointer.
+  constexpr const auto& impl() const noexcept { return ptr_; }
+
+ private:
+  // Abstract base type for our contents.
+  class concept_base {
+   public:
+    virtual ~concept_base() = default;
+
+    template <typename T>
+    explicit concept_base(std::in_place_type_t<T>) noexcept
+        : index_(type_list_index_v<T, ast_element_types>) {}
+
+    // Index of the ast element in `ast_element_types`.
+    constexpr std::size_t index() const noexcept { return index_; }
+
+   private:
+    std::size_t index_;
+  };
+
+  // Concrete storage of the underlying value of type T.
+  template <typename T>
+  class model final : public concept_base {
+   public:
+    using value_type = T;
+
+    // Copy or move construct.
+    explicit model(value_type contents) noexcept(std::is_nothrow_move_constructible_v<value_type>)
+        : concept_base(std::in_place_type_t<T>{}), contents_(std::move(contents)) {}
+
+    // In-place construction of contents.
+    template <typename... Args>
+    explicit model(std::in_place_t, Args&&... args) noexcept(
+        std::is_nothrow_constructible_v<value_type, decltype(args)...>)
+        : concept_base(std::in_place_type_t<T>{}), contents_{std::forward<Args>(args)...} {}
+
+    constexpr const value_type& contents() const noexcept { return contents_; }
+    constexpr value_type& contents() noexcept { return contents_; }
+
+   private:
+    T contents_;
+  };
+
+  // Cast with no type-checking.
+  template <typename T>
+  friend const auto& ::wf::ast::detail::cast_to_type(const ast_element& element) noexcept;
+
+  // Our storage, which cannot be null. We use shared-ptr since the same AST element can be
+  // re-used in some places. TODO: Support small object optimization?
+  std::shared_ptr<const concept_base> ptr_;
+};
+
+}  // namespace wf::ast

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "wf/code_generation/ast.h"
+#include "wf/code_generation/ast_visitor.h"
 #include "wf/code_generation/string_util.h"
 
 // Formatters for the ast types. These are defined primarily so that we can implement repr() in
@@ -26,32 +27,32 @@ auto format_ast(Iterator it, const wf::ast::variable_ref& v) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::add& v) {
-  return fmt::format_to(it, "({}, {})", *v.left, *v.right);
+  return fmt::format_to(it, "({}, {})", v.left, v.right);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::assign_output_matrix& v) {
-  return fmt::format_to(it, "({} = <{} values>)", v.arg.name(), v.value->args.size());
+  return fmt::format_to(it, "({} = <{} values>)", v.arg.name(), v.value.args.size());
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::assign_output_scalar& v) {
-  return fmt::format_to(it, "({} = {})", v.arg.name(), *v.value);
+  return fmt::format_to(it, "({} = {})", v.arg.name(), v.value);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::assign_output_struct& v) {
-  return fmt::format_to(it, "({} = {})", v.arg.name(), *v.value);
+  return fmt::format_to(it, "({} = {})", v.arg.name(), v.value);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::assign_temporary& v) {
-  return fmt::format_to(it, "({} = {})", v.left, *v.right);
+  return fmt::format_to(it, "({} = {})", v.left, v.right);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::branch& d) {
-  return fmt::format_to(it, "(if {} {{ {} statements }} else {{ {} statements }})", *d.condition,
+  return fmt::format_to(it, "(if {} {{ {} statements }} else {{ {} statements }})", d.condition,
                         d.if_branch.size(), d.else_branch.size());
 }
 
@@ -68,7 +69,7 @@ auto format_ast(Iterator it, const wf::ast::call_std_function& c) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::cast& c) {
-  return fmt::format_to(it, "({}, {})", string_from_code_numeric_type(c.destination_type), *c.arg);
+  return fmt::format_to(it, "({}, {})", string_from_code_numeric_type(c.destination_type), c.arg);
 }
 
 template <typename Iterator>
@@ -78,8 +79,8 @@ auto format_ast(Iterator it, const wf::ast::comment& c) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::compare& c) {
-  return fmt::format_to(it, "({} {} {})", *c.left, string_from_relational_operation(c.operation),
-                        *c.right);
+  return fmt::format_to(it, "({} {} {})", c.left, string_from_relational_operation(c.operation),
+                        c.right);
 }
 
 template <typename Iterator>
@@ -112,7 +113,7 @@ auto format_ast(Iterator it, const wf::ast::declaration_type_annotation& d) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::divide& d) {
-  return fmt::format_to(it, "({}, {})", *d.left, *d.right);
+  return fmt::format_to(it, "({}, {})", d.left, d.right);
 }
 
 template <typename Iterator>
@@ -138,12 +139,12 @@ auto format_ast(Iterator it, const wf::ast::get_argument& r) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::get_field& r) {
-  return fmt::format_to(it, "({}, {})", *r.arg, r.field);
+  return fmt::format_to(it, "({}, {})", r.arg, r.field);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::get_matrix_element& r) {
-  return fmt::format_to(it, "({}, [{}, {}])", *r.arg, r.row, r.col);
+  return fmt::format_to(it, "({}, [{}, {}])", r.arg, r.row, r.col);
 }
 
 template <typename Iterator>
@@ -153,12 +154,12 @@ auto format_ast(Iterator it, const wf::ast::integer_literal& c) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::multiply& m) {
-  return fmt::format_to(it, "({}, {})", *m.left, *m.right);
+  return fmt::format_to(it, "({}, {})", m.left, m.right);
 }
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::negate& n) {
-  return fmt::format_to(it, "({})", *n.arg);
+  return fmt::format_to(it, "({})", n.arg);
 }
 
 template <typename Iterator>
@@ -177,7 +178,7 @@ auto format_ast(Iterator it, const wf::ast::return_type_annotation& r) {
 
 template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::return_object& r) {
-  return fmt::format_to(it, "({})", *r.value);
+  return fmt::format_to(it, "({})", r.value);
 }
 
 template <typename Iterator>
@@ -210,11 +211,11 @@ struct fmt::formatter<T, wf::ast::enable_if_is_formattable_t<T, char>> {
 };
 
 template <>
-struct fmt::formatter<wf::ast::variant, char> {
+struct fmt::formatter<wf::ast::ast_element, char> {
   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
-  template <typename Arg, typename FormatContext>
-  auto format(const Arg& v, FormatContext& ctx) const -> decltype(ctx.out()) {
-    return std::visit([&](const auto& x) { return fmt::format_to(ctx.out(), "{}", x); }, v);
+  template <typename FormatContext>
+  auto format(const wf::ast::ast_element& el, FormatContext& ctx) const -> decltype(ctx.out()) {
+    return wf::ast::visit(el, [&](const auto& x) { return fmt::format_to(ctx.out(), "{}", x); });
   }
 };

--- a/components/core/wf/code_generation/ast_visitor.h
+++ b/components/core/wf/code_generation/ast_visitor.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "wf/code_generation/ast.h"
+
+namespace wf::ast {
+namespace detail {
+
+// Cast with no type-checking.
+template <typename T>
+const auto& cast_to_type(const ast_element& element) noexcept {
+  const ast_element::model<T>* model =
+      static_cast<const ast_element::model<T>*>(element.impl().get());
+  return model->contents();
+}
+
+// Cast to const-reference of the type at index `I` in list `types`.
+template <std::size_t I>
+const auto& cast_to_index(const ast_element& element) noexcept {
+  using types = ast_element::types;
+  static_assert(I < type_list_size_v<types>, "Index exceeds number of types");
+  return cast_to_type<const type_list_element_t<I, types>>(element);
+}
+
+// If index `I` matches the internal index, call function `f` on it - otherwise recurse to the
+// next index.
+template <std::size_t I, typename F>
+auto visit_recurse(const ast_element& element, F&& f) {
+  using types = ast_element::types;
+  if (element.index() == I) {
+    return f(detail::cast_to_index<I>(element));
+  } else if constexpr (I + 1 < type_list_size_v<types>) {
+    return visit_recurse<I + 1>(element, std::forward<F>(f));
+  } else {
+    return f(detail::cast_to_index<type_list_size_v<types> - 1>(element));
+  }
+}
+
+}  // namespace detail
+
+// If index `I` matches the internal index, call function `f` on it - otherwise recurse to the
+// next index.
+template <typename F>
+auto visit(const ast_element& element, F&& f) {
+  return detail::visit_recurse<0>(element, std::forward<F>(f));
+}
+
+// If the underlying type is `T`, return a const pointer to it. Otherwise return nullptr.
+template <typename T>
+maybe_null<const T*> get_if(const ast_element& element) noexcept {
+  using types = ast_element::types;
+  static_assert(type_list_contains_v<T, types>);
+  if (element.index() == type_list_index_v<T, types>) {
+    return &detail::cast_to_type<T>(element);
+  }
+  return nullptr;
+}
+
+}  // namespace wf::ast

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -76,15 +76,8 @@ class cpp_code_generator {
 
   virtual std::string operator()(const ast::variable_ref& x) const;
 
-  // Accept ast::variant and delegate formatting of the stored type to our derived class.
-  // Using enable_if here to prevent implicit conversion to the variant type.
-  template <typename T, typename = enable_if_same_t<T, ast::variant>>
-  auto operator()(const T& var) const {
-    return std::visit(*this, var);
-  }
-
-  // Accept non_null<ast::variant_ptr>
-  auto operator()(const non_null<ast::variant_ptr>& var) const { return std::visit(*this, *var); }
+  // Accept `ast_element`.
+  std::string operator()(const ast::ast_element& element) const;
 
  protected:
   // Create a fmt_view. All args will be forwarded back to the operator on this class that matches

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -1,6 +1,5 @@
 // Copyright 2023 Gareth Cross
 #pragma once
-#include "wf/assertions.h"
 #include "wf/code_generation/ast.h"
 #include "wf/code_generation/code_formatter.h"
 
@@ -77,15 +76,8 @@ class rust_code_generator {
 
   virtual std::string operator()(const ast::variable_ref& x) const;
 
-  // Accept ast::variant and delegate formatting of the stored type to our derived class.
-  // Using enable_if here to prevent implicit conversion to the variant type.
-  template <typename T, typename = enable_if_same_t<T, ast::variant>>
-  auto operator()(const T& var) const {
-    return std::visit(*this, var);
-  }
-
-  // Accept non_null<ast::variant_ptr>
-  auto operator()(const non_null<ast::variant_ptr>& var) const { return std::visit(*this, *var); }
+  // Accept `ast_element`.
+  std::string operator()(const ast::ast_element& element) const;
 
  protected:
   // Create a fmt_view that can be passed to code_formatter. All args will be

--- a/components/core/wf/code_generation/type_registry.h
+++ b/components/core/wf/code_generation/type_registry.h
@@ -208,7 +208,7 @@ struct record_type<T, enable_if_implements_custom_type_registrant_t<T>> {
     // Check if this type has already been registered:
     if (std::optional<custom_type> existing_type = registry.find_type<T>();
         existing_type.has_value()) {
-      return annotated_custom_type<T>{std::move(*existing_type)};
+      return annotated_custom_type<T>{*std::move(existing_type)};
     }
     // The registrant should return `custom_type_builder<T>`:
     custom_type type = custom_type_registrant<T>{}(registry).finalize();

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -211,7 +211,7 @@ class CustomCppGenerator(CppGenerator):
                                      element: code_generation.codegen.ConstructCustomType) -> str:
         if element.type.python_type is EigenQuaternion:
             # Eigen quaternion expects constructor args in order (w, x, y, z)
-            arg_dict = {k: v for (k, v) in element.field_values}
+            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ', '.join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
             # We normalize numerically on construction, rather than symbolically. This avoids introducing
             # superfluous operations into the symbolic math tree, which saves on generated operations.
@@ -258,7 +258,7 @@ class CustomRustGenerator(RustGenerator):
             return f'crate::geo::Pose3d::new(\n  {r},\n  {t}\n)'
         elif element.type.python_type is EigenQuaternion:
             # Order for nalgebra is [w, x, y, z]
-            arg_dict = {k: v for (k, v) in element.field_values}
+            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ', '.join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
             return f'nalgebra::Unit::new_normalize(nalgebra::Quaternion::<f64>::new({formatted_args}))'
         return self.super_format(element)


### PR DESCRIPTION
The AST types were originally stored in a `std::variant`, which offered a couple of appealing properties:
- `pybind11` automatically converts `std::variant` to `T.Union[...]` in python, which is nice.
- Adjacent elements in a `std::vector<ast::variant>` are stored sequentially in memory.

However, `ast.h` was _possibly_ abusing the C++ standard a bit since the recursive nature of the ast types meant that the variant declaration had to occur before the body of every type was visible. This mostly worked on MSVC/GCC/Clang, but made the file very brittle. Small changes would periodically fail because an STL template would invoke a compiler intrinsic that required the body of the types be visible prior to the definition of the variant.

I've opted to kill off the use of variant, and instead introduce a type-erased container `ast::ast_element`. A few side benefits in terms of code organization:
- Get rid of the need for `ast::variant` and `std::shared_ptr<const ast::variant>` both being present in the ast structs.
- Eliminate some manual `make_shared` and de-reference stuff that was no longer required.
- The pybind11 types now use `return_value_policy::reference` and `py::keep_alive`, which should reduce copies when returning things into python.

There is a smallish (I measured ~5%) performance regression on C++ emission time (just the time to create the ast and write it out), possibly stemming from increased pointer indirections. That said, I think there are some paths to reclaiming that in the future.