### PR TITLE
Improve visitor performance

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(
   wf/expression.cc
   wf/expression.h
   wf/expression_variant.h
+  wf/expression_visitor.h
   wf/expressions/addition.cc
   wf/expressions/addition.h
   wf/expressions/all_expressions.h

--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -5,9 +5,9 @@
 #include "wf/code_generation/function_evaluator.h"
 #include "wf/evaluate.h"
 #include "wf/expression.h"
+#include "wf/expression_visitor.h"
 #include "wf/substitute.h"
 #include "wf/type_annotations.h"
-#include "wf/visit.h"
 
 // Utilities for evaluating symbolic functions into numeric values (like double, or Eigen::Matrix).
 // This is for unit testing code-generated methods against numeric evaluation of the symbolic graph.

--- a/components/core/wf/code_generation/ast_visitor.h
+++ b/components/core/wf/code_generation/ast_visitor.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "wf/code_generation/ast.h"
+#include "wf/visit.h"
 
 namespace wf::ast {
 namespace detail {
@@ -19,28 +20,16 @@ const auto& cast_to_index(const ast_element& element) noexcept {
   static_assert(I < type_list_size_v<types>, "Index exceeds number of types");
   return cast_to_type<const type_list_element_t<I, types>>(element);
 }
-
-// If index `I` matches the internal index, call function `f` on it - otherwise recurse to the
-// next index.
-template <std::size_t I, typename F>
-auto visit_recurse(const ast_element& element, F&& f) {
-  using types = ast_element::types;
-  if (element.index() == I) {
-    return f(detail::cast_to_index<I>(element));
-  } else if constexpr (I + 1 < type_list_size_v<types>) {
-    return visit_recurse<I + 1>(element, std::forward<F>(f));
-  } else {
-    return f(detail::cast_to_index<type_list_size_v<types> - 1>(element));
-  }
-}
-
 }  // namespace detail
 
-// If index `I` matches the internal index, call function `f` on it - otherwise recurse to the
-// next index.
+// Visit `ast_element` with `f`. The visitor is passed a const reference.
 template <typename F>
 auto visit(const ast_element& element, F&& f) {
-  return detail::visit_recurse<0>(element, std::forward<F>(f));
+  constexpr std::size_t num_types = type_list_size_v<ast_element::types>;
+  return wf::detail::visit_switch<num_types>(element.index(), [&](const auto integral_constant) {
+    constexpr std::size_t type_index = integral_constant();
+    return f(detail::cast_to_index<type_index>(element));
+  });
 }
 
 // If the underlying type is `T`, return a const pointer to it. Otherwise return nullptr.

--- a/components/core/wf/code_generation/control_flow_graph.cc
+++ b/components/core/wf/code_generation/control_flow_graph.cc
@@ -9,9 +9,9 @@
 #include "wf/code_generation/ir_control_flow_converter.h"
 #include "wf/code_generation/ir_form_visitor.h"
 #include "wf/common_visitors.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/hashing.h"
-#include "wf/visit.h"
 
 namespace wf {
 namespace ir {

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -2,7 +2,7 @@
 #include "wf/code_generation/ir_form_visitor.h"
 
 #include "wf/common_visitors.h"
-#include "wf/visit.h"
+#include "wf/expression_visitor.h"
 
 namespace wf {
 

--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -1,8 +1,8 @@
 // Copyright 2023 Gareth Cross
 #include <algorithm>
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/common_visitors.h
+++ b/components/core/wf/common_visitors.h
@@ -2,10 +2,10 @@
 #pragma once
 #include <algorithm>
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/multiplication.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/power.h"
-#include "wf/visit.h"
 
 // This file is intended to contain common utility visitors.
 namespace wf {

--- a/components/core/wf/compound_expression.cc
+++ b/components/core/wf/compound_expression.cc
@@ -1,9 +1,9 @@
 // Copyright 2024 Gareth Cross
 #include "wf/compound_expression.h"
 
+#include "wf/expression_visitor.h"
 #include "wf/index_range.h"
 #include "wf/plain_formatter.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -4,9 +4,9 @@
 #include <algorithm>
 
 #include "wf/error_types.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/matrix_expression.h"
-#include "wf/visit.h"
 #include "wf_runtime/span.h"
 
 namespace wf {

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -2,8 +2,8 @@
 #include <algorithm>
 
 #include "wf/assertions.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/evaluate.cc
+++ b/components/core/wf/evaluate.cc
@@ -1,7 +1,7 @@
 // Copyright 2023 Gareth Cross
 #include "wf/evaluate.h"
 #include "wf/expression.h"
-#include "wf/visit.h"
+#include "wf/expression_visitor.h"
 
 namespace wf {
 

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -2,9 +2,9 @@
 
 #include "wf/assertions.h"
 #include "wf/constants.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/plain_formatter.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expression_visitor.h
+++ b/components/core/wf/expression_visitor.h
@@ -1,0 +1,98 @@
+// Copyright 2023 Gareth Cross
+#pragma once
+#include "wf/expression_variant.h"
+#include "wf/template_utils.h"
+#include "wf/visit.h"
+
+// All expression definitions need to be available to static_cast.
+#include "wf/expressions/all_expressions.h"
+
+namespace wf {
+
+// Visit the specified expression with `visitor`. The visitor will be passed a
+// const reference to the concrete underlying contents of the abstract expression.
+//
+// The signature of `visitor` can take one of two forms:
+//
+//  (1) ret operator()(const T&);
+//  (2) ret operator()(const T&, const D&);
+//
+// Where `T` is the concrete inner type of the expression, and `D` is the outer
+// abstract expression type.
+//
+// The return type will be deduced from the visitor itself.
+template <typename D, typename M, typename F>
+auto visit(const expression_base<D, M>& expr, F&& visitor) {
+  using types = typename expression_base<D, M>::types;
+
+  return detail::visit_switch<type_list_size_v<types>>(
+      expr.type_index(), [&visitor, &expr](const auto integral_constant) {
+        constexpr std::size_t idx = integral_constant();
+        using T = type_list_element_t<idx, types>;
+
+        // Make sure this is not ambiguous:
+        static_assert(is_invocable_v<F, const T&, const D&> || is_invocable_v<F, const T&>,
+                      "Visitor must support at least one version of operator().");
+        static_assert(is_invocable_v<F, const T&, const D&> != is_invocable_v<F, const T&>,
+                      "Visitor must support either unary or binary operator(), but not both.");
+
+        if constexpr (is_invocable_v<F, const T&, const D&>) {
+          return visitor(detail::cast_to_index<idx>(expr.impl()), expr.as_derived());
+        } else {
+          return visitor(detail::cast_to_index<idx>(expr.impl()));
+        }
+      });
+}
+
+// Visit a std::variant of different `expression_base` types.
+template <typename... Ts, typename F>
+auto visit(const std::variant<Ts...>& variant, F&& visitor) {
+  return std::visit(
+      [&visitor](const auto& x) {
+        using T = std::decay_t<decltype(x)>;
+        static_assert(inherits_expression_base_v<T>);
+        return visit(x, std::forward<F>(visitor));
+      },
+      variant);
+}
+
+// Visit two expressions with an invocable that accepts two concrete types in its operator()(...)
+// signature.
+template <typename U, typename V, typename VisitorType>
+auto visit_binary(const U& u, const V& v, VisitorType&& handler) {
+  return visit(u, [&handler, &v](const auto& typed_u) {
+    return visit(v, [&handler, &typed_u](const auto& typed_v) {
+      // Check if we can visit
+      using TypeU = std::decay_t<decltype(typed_u)>;
+      using TypeV = std::decay_t<decltype(typed_v)>;
+      static_assert(is_invocable_v<VisitorType, const TypeU&, const TypeV&>,
+                    "Binary visitor fails to implement a required operator() method.");
+      return handler(typed_u, typed_v);
+    });
+  });
+}
+
+// TODO: Document.
+template <typename F>
+compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
+  return visit(expr, make_overloaded(
+                         [&](const external_function_invocation& invocation) {
+                           return invocation.map_children([&](const any_expression& arg) {
+                             // TODO: Make `matrix_expr` derived from `expression_base`, and call
+                             //  visit(...) here.
+                             return overloaded_visit(
+                                 arg, [&](const scalar_expr& x) -> any_expression { return f(x); },
+                                 [&](const matrix_expr& x) -> any_expression {
+                                   matrix m = x.as_matrix().map_children(std::forward<F>(f));
+                                   return matrix_expr(std::move(m));
+                                 },
+                                 [&](const compound_expr& x) -> any_expression { return f(x); });
+                           });
+                         },
+                         [&](const custom_type_argument&) { return expr; },
+                         [&](const custom_type_construction& construct) {
+                           return construct.map_children(std::forward<F>(f));
+                         }));
+}
+
+}  // namespace wf

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -3,11 +3,11 @@
 
 #include <algorithm>
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/matrix.h"
 #include "wf/expressions/multiplication.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/special_constants.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/custom_type_expressions.cc
+++ b/components/core/wf/expressions/custom_type_expressions.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Gareth Cross
 #include "wf/expressions/custom_type_expressions.h"
 
-#include "wf/visit.h"
+#include "wf/expression_visitor.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/matrix.cc
+++ b/components/core/wf/expressions/matrix.cc
@@ -1,9 +1,9 @@
 // Copyright 2023 Gareth Cross
 #include "wf/expressions/matrix.h"
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/addition.h"
 #include "wf/matrix_functions.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -4,9 +4,9 @@
 #include <algorithm>
 
 #include "wf/common_visitors.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/integer_utils.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/power.cc
+++ b/components/core/wf/expressions/power.cc
@@ -3,10 +3,10 @@
 
 #include <algorithm>
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/multiplication.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/integer_utils.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/relational.cc
+++ b/components/core/wf/expressions/relational.cc
@@ -2,9 +2,9 @@
 #include "wf/expressions/relational.h"
 
 #include "wf/constants.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/integer_utils.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/external_function.cc
+++ b/components/core/wf/external_function.cc
@@ -2,7 +2,7 @@
 #include "wf/external_function.h"
 
 #include "wf/code_generation/ast_formatters.h"
-#include "wf/visit.h"
+#include "wf/expression_visitor.h"
 
 namespace wf {
 

--- a/components/core/wf/limits.cc
+++ b/components/core/wf/limits.cc
@@ -2,10 +2,10 @@
 #include <algorithm>
 
 #include "wf/common_visitors.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/matrix_expression.h"
 #include "wf/operations.h"
-#include "wf/visit.h"
 
 namespace wf {
 using namespace wf::custom_literals;

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -1,8 +1,8 @@
 // Copyright 2023 Gareth Cross
 #include "wf/enumerations.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/operations.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/ordering.cc
+++ b/components/core/wf/ordering.cc
@@ -2,8 +2,8 @@
 #include "wf/ordering.h"
 
 #include "wf/expression.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -4,8 +4,8 @@
 
 #include "wf/assertions.h"
 #include "wf/common_visitors.h"
+#include "wf/expression_visitor.h"
 #include "wf/fmt_imports.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/substitute.cc
+++ b/components/core/wf/substitute.cc
@@ -3,10 +3,10 @@
 
 #include <unordered_map>
 
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/matrix_expression.h"
 #include "wf/substitute.h"
-#include "wf/visit.h"
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/components/core/wf/template_utils.h
+++ b/components/core/wf/template_utils.h
@@ -1,5 +1,7 @@
 // Copyright 2022 Gareth Cross
 #pragma once
+#include <functional>  //  std::invoke
+
 #include "wf/traits.h"
 
 namespace wf {

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -3,10 +3,10 @@
 
 #include "wf/compound_expression.h"
 #include "wf/expression.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/fmt_imports.h"
 #include "wf/matrix_expression.h"
-#include "wf/visit.h"
 
 namespace wf {
 

--- a/components/core/wf/visit.h
+++ b/components/core/wf/visit.h
@@ -1,84 +1,87 @@
-// Copyright 2023 Gareth Cross
+// Copyright 2024 Gareth Cross
 #pragma once
-#include "wf/expression_variant.h"
-#include "wf/template_utils.h"
-
-// All expression definitions need to be available to static_cast.
-#include "wf/expressions/all_expressions.h"
+#include <type_traits>  //  std::integral_constant
 
 namespace wf {
 
-// Accepts a visitor struct or lambda and applies it to the provided expression.
-// The return type will be deduced from the visitor itself.
-template <typename D, typename M, typename F>
-auto visit(const expression_base<D, M>& expr, F&& visitor) {
-  return expr.impl().visit([&visitor, &expr](const auto& contents) {
-    using T = std::decay_t<decltype(contents)>;
-
-    // Make sure this is not ambiguous:
-    static_assert(is_invocable_v<F, const T&, const D&> || is_invocable_v<F, const T&>,
-                  "Visitor must support at least one version of operator().");
-    static_assert(is_invocable_v<F, const T&, const D&> != is_invocable_v<F, const T&>,
-                  "Visitor must support either unary or binary operator(), but not both.");
-
-    if constexpr (is_invocable_v<F, const T&, const D&>) {
-      return visitor(contents, expr.as_derived());
-    } else {
-      return visitor(contents);
-    }
-  });
+// Designate an unreachable block of code. Based on cppreference.com implementation.
+[[noreturn]] inline void unreachable() {
+#if defined(_MSC_VER) && !defined(__clang__)
+  __assume(false);
+#else  // GCC, Clang
+  __builtin_unreachable();
+#endif
 }
 
-// Visit a variant of different `expression_base` types.
-// We use enable_if to disallow implicit conversion to the variant type.
-template <typename Var, typename F, typename = std::enable_if_t<is_variant_v<Var>>>
-auto visit(const Var& variant, F&& visitor) {
-  return std::visit(
-      [&visitor](const auto& x) {
-        using T = std::decay_t<decltype(x)>;
-        static_assert(inherits_expression_base_v<T>);
-        return visit(x, std::forward<F>(visitor));
-      },
-      variant);
+#define _switch_cases_4(_i, num_cases, stamp) \
+  stamp(_i + 0, num_cases);                   \
+  stamp(_i + 1, num_cases);                   \
+  stamp(_i + 2, num_cases);                   \
+  stamp(_i + 3, num_cases)
+
+#define _switch_cases_16(_i, num_cases, stamp) \
+  _switch_cases_4(_i + 0, num_cases, stamp);   \
+  _switch_cases_4(_i + 4, num_cases, stamp);   \
+  _switch_cases_4(_i + 8, num_cases, stamp);   \
+  _switch_cases_4(_i + 12, num_cases, stamp)
+
+#define _switch_cases_64(_i, num_cases, stamp) \
+  _switch_cases_16(_i + 0, num_cases, stamp);  \
+  _switch_cases_16(_i + 16, num_cases, stamp); \
+  _switch_cases_16(_i + 32, num_cases, stamp); \
+  _switch_cases_16(_i + 48, num_cases, stamp)
+
+#define _switch_cases_256(_i, num_cases, stamp) \
+  _switch_cases_64(_i + 0, num_cases, stamp);   \
+  _switch_cases_64(_i + 64, num_cases, stamp);  \
+  _switch_cases_64(_i + 128, num_cases, stamp); \
+  _switch_cases_64(_i + 192, num_cases, stamp)
+
+// Create a single switch case. We pass this macro to the `_switch_cases_N` macro,
+// which in turn "invokes it" with an index `_i`.
+#define _single_switch_case(_i, num_cases)                    \
+  case _i: {                                                  \
+    if constexpr (_i < num_cases) {                           \
+      return func(std::integral_constant<std::size_t, _i>()); \
+    }                                                         \
+  } break;
+
+#define _make_switch_case(index_var, num_cases, max_cases)        \
+  switch (index_var) {                                            \
+    _switch_cases_##max_cases(0, num_cases, _single_switch_case); \
+    default:                                                      \
+      break;                                                      \
+  }
+
+namespace detail {
+
+// Generate a switch statement over variable `index` with `Num` cases.
+// `func` will be invoked in each switch case with a std::integral_constant for that index.
+// This function expands to a jump table. Last tested under gcc 12.3.0, clang 16.0.6, and
+// MSVC 19.37.32822. The return type of this function is the same as that of `func` itself.
+// This implementation is based on the standard library implementation for std::variant.
+template <std::size_t Num, typename F>
+constexpr auto visit_switch(const std::size_t index, F&& func) {
+  static_assert(Num <= 256, "Max number of cases is 256.");
+  // Depending on how many cases there, make the switch statement longer.
+  if constexpr (Num <= 4) {
+    _make_switch_case(index, Num, 4);
+  } else if constexpr (Num <= 16) {
+    _make_switch_case(index, Num, 16);
+  } else if constexpr (Num <= 64) {
+    _make_switch_case(index, Num, 64);
+  } else {
+    _make_switch_case(index, Num, 256);
+  }
+  wf::unreachable();
 }
 
-// Visit two expressions with an invocable that accepts two concrete types in its operator()(...)
-// signature.
-template <typename U, typename V, typename VisitorType>
-auto visit_binary(const U& u, const V& v, VisitorType&& handler) {
-  return visit(u, [&handler, &v](const auto& typed_u) {
-    return visit(v, [&handler, &typed_u](const auto& typed_v) {
-      // Check if we can visit
-      using TypeU = std::decay_t<decltype(typed_u)>;
-      using TypeV = std::decay_t<decltype(typed_v)>;
-      static_assert(is_invocable_v<VisitorType, const TypeU&, const TypeV&>,
-                    "Binary visitor fails to implement a required operator() method.");
-      return handler(typed_u, typed_v);
-    });
-  });
-}
+}  // namespace detail
 
-// TODO: Document.
-template <typename F>
-compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
-  return visit(expr, make_overloaded(
-                         [&](const external_function_invocation& invocation) {
-                           return invocation.map_children([&](const any_expression& arg) {
-                             // TODO: Make `matrix_expr` derived from `expression_base`, and call
-                             //  visit(...) here.
-                             return overloaded_visit(
-                                 arg, [&](const scalar_expr& x) -> any_expression { return f(x); },
-                                 [&](const matrix_expr& x) -> any_expression {
-                                   matrix m = x.as_matrix().map_children(std::forward<F>(f));
-                                   return matrix_expr(std::move(m));
-                                 },
-                                 [&](const compound_expr& x) -> any_expression { return f(x); });
-                           });
-                         },
-                         [&](const custom_type_argument&) { return expr; },
-                         [&](const custom_type_construction& construct) {
-                           return construct.map_children(std::forward<F>(f));
-                         }));
-}
+#undef _make_switch_case
+#undef _switch_cases_256
+#undef _switch_cases_64
+#undef _switch_cases_16
+#undef _switch_cases_4
 
 }  // namespace wf


### PR DESCRIPTION
The previous visitor implementation looked something like:
```cpp
 template <std::size_t I, typename F>
  auto visit_impl(F&& f) const {
    if (index() == I) {
      return f(cast_to_index<I>());
    } else if constexpr (I + 1 < type_list_size_v<types>) {
      return visit_impl<I + 1>(std::forward<F>(f));
    } else {
      return f(cast_to_index<type_list_size_v<types> - 1>());
    }
  }
```
clang is smart enough to convert this into a jump table, but it appears that MSVC and gcc fail to do so and just generate an if-else sequence of blocks.

After looking at what the STL does for `std::variant`, I implemented `visit_switch` in `visit.h`. This approach uses a bit of macro logic to declare switch cases. I inspected this approach using godbolt on GCC, clang, and MSVC. All three produce a jump table when the switch-case is used instead.

This produces some nice performance wins, particularly under MSVC:
```
BEFORE:
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
BM_CreateFlatIrLowComplexity/iterations:200       12.9 ms         12.7 ms          200
BM_ConvertIrLowComplexity/iterations:200         0.573 ms        0.469 ms          200
BM_GenerateCpp/iterations:200                     2.70 ms         2.66 ms          200

AFTER:
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
BM_CreateFlatIrLowComplexity/iterations:200       8.02 ms         7.66 ms          200
BM_ConvertIrLowComplexity/iterations:200         0.565 ms        0.391 ms          200
BM_GenerateCpp/iterations:200                     1.99 ms         1.80 ms          200
```

Improvement of around ~50% to `BM_CreateFlatIrLowComplexity`. GCC 12.3 (Ubuntu 22.04) had some more modest improvements:
```
BM_ScalarMultiplication: 0.175 -> 0.160 ms
BM_QuaternionInterpolateJacobian: 0.814 -> 0.78ms
BM_CreateFlatIrLowComplexity: 9.01ms -> 8.5ms
```
