### PR TITLE
Get rid of `for_each` methods on scalar expressions

### DIFF
--- a/components/core/wf/expressions/addition.h
+++ b/components/core/wf/expressions/addition.h
@@ -51,12 +51,6 @@ class addition {
     return std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(begin(), end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/casts.h
+++ b/components/core/wf/expressions/casts.h
@@ -26,12 +26,6 @@ class cast_bool {
     return arg_[0].is_identical_to(other.arg_[0]);
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(begin(), end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/conditional.h
+++ b/components/core/wf/expressions/conditional.h
@@ -18,12 +18,6 @@ class conditional {
                       is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(children_.begin(), children_.end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/derivative_expression.h
+++ b/components/core/wf/expressions/derivative_expression.h
@@ -37,12 +37,6 @@ class derivative {
            std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(begin(), end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/function_expressions.h
+++ b/components/core/wf/expressions/function_expressions.h
@@ -48,12 +48,6 @@ class function {
            std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(begin(), end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename F>
   scalar_expr map_children(F&& f) const {

--- a/components/core/wf/expressions/matrix.h
+++ b/components/core/wf/expressions/matrix.h
@@ -35,12 +35,6 @@ class matrix {
                       is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(data_.begin(), data_.end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   matrix map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -51,12 +51,6 @@ class multiplication {
     return std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(begin(), end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/power.h
+++ b/components/core/wf/expressions/power.h
@@ -18,12 +18,6 @@ class power {
     return base().is_identical_to(other.base()) && exponent().is_identical_to(other.exponent());
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(children_.begin(), children_.end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/relational.h
+++ b/components/core/wf/expressions/relational.h
@@ -19,12 +19,6 @@ class relational {
            right().is_identical_to(other.right());
   }
 
-  // Implement ExpressionImpl::Iterate
-  template <typename Operation>
-  void for_each(Operation&& operation) const {
-    std::for_each(children_.begin(), children_.end(), std::forward<Operation>(operation));
-  }
-
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {


### PR DESCRIPTION
These were unused and rendered superfluous by the fact that all concrete expressions expose `begin()` and `end()` iterators now.