### PR TITLE
Add benchmark to distribute operation 

### DIFF
--- a/components/core/benchmarks/CMakeLists.txt
+++ b/components/core/benchmarks/CMakeLists.txt
@@ -12,5 +12,6 @@ endfunction()
 
 # Add all of our benchmarks:
 add_benchmark(bench_add_mul.cc)
-add_benchmark(bench_jacobian.cc)
 add_benchmark(bench_code_generation.cc)
+add_benchmark(bench_distribute.cc)
+add_benchmark(bench_jacobian.cc)

--- a/components/core/benchmarks/bench_distribute.cc
+++ b/components/core/benchmarks/bench_distribute.cc
@@ -1,0 +1,32 @@
+// Benchmark distribution.
+#include <benchmark/benchmark.h>
+
+#include "wf/expression.h"
+#include "wf/fmt_imports.h"
+
+namespace wf {
+using namespace custom_literals;
+
+// Benchmark the distribute operation.
+static void BM_Distribute(benchmark::State& state) {
+  constexpr int num_multiplied_series = 6;
+
+  // Create a bunch of quadratic terms multiplied together:
+  // (c0 * x00^2 + c1 * x00 + c2) * (k0 * x01^2 + k1*x01 + k2) * (...)
+  scalar_expr input_mul = 1;
+  for (int i = 0; i < num_multiplied_series; ++i) {
+    const scalar_expr var{fmt::format("x{:02}", i)};
+    const scalar_expr sum = 1_s / (i + 1) * var * var + (i + 1) * var + i * 3;
+    input_mul = input_mul * sum;
+  }
+
+  for (auto _ : state) {
+    scalar_expr output = input_mul.distribute();
+    benchmark::DoNotOptimize(output);
+  }
+}
+BENCHMARK(BM_Distribute)->Iterations(2000)->Unit(benchmark::kMillisecond);
+
+}  // namespace wf
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Add a simple benchmark case for the `distribute()` operation. 