### PR TITLE
Distribute operation handles integer and rational powers 

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
   wf/derivative.cc
   wf/derivative.h
   wf/distribute.cc
+  wf/distribute.h
   wf/enumerations.h
   wf/error_types.h
   wf/evaluate.cc

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -151,8 +151,8 @@ scalar_expr derivative_visitor::operator()(const function& func) {
   std::transform(func.begin(), func.end(), std::back_inserter(d_args),
                  [this](const scalar_expr& arg) { return apply(arg); });
 
-  const bool all_derivatives_zero = std::all_of(d_args.begin(), d_args.end(), &is_zero);
-  if (all_derivatives_zero) {
+  if (const bool all_derivatives_zero = std::all_of(d_args.begin(), d_args.end(), &is_zero);
+      all_derivatives_zero) {
     // If zero, we don't need to do any further operations.
     return constants::zero;
   }

--- a/components/core/wf/distribute.h
+++ b/components/core/wf/distribute.h
@@ -1,0 +1,50 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include <unordered_map>
+
+#include "wf/compound_expression.h"
+#include "wf/expression.h"
+
+namespace wf {
+
+// Visitor for distributing terms in multiplications:
+// (a + b) * (x + y) = a*x + a*y + b*x + b*y
+// (a + b)^2 = a^2 + 2*a*b + b^2
+class distribute_visitor {
+ public:
+  scalar_expr operator()(const scalar_expr& x);
+  compound_expr operator()(const compound_expr& x);
+
+  scalar_expr operator()(const addition& add);
+  scalar_expr operator()(const cast_bool& cast);
+  scalar_expr operator()(const compound_expression_element& el);
+  scalar_expr operator()(const complex_infinity&, const scalar_expr& arg) const;
+  scalar_expr operator()(const conditional& conditional);
+  scalar_expr operator()(const derivative& diff);
+  scalar_expr operator()(const integer_constant&, const scalar_expr& arg) const;
+  scalar_expr operator()(const float_constant&, const scalar_expr& arg) const;
+  scalar_expr operator()(const function& f);
+  scalar_expr operator()(const multiplication& mul);
+  scalar_expr operator()(const power& pow);
+  scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const;
+  scalar_expr operator()(const relational& relation);
+  scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const;
+  scalar_expr operator()(const undefined&) const;
+  scalar_expr operator()(const variable&, const scalar_expr& arg) const;
+
+ private:
+  // Expand base^power.
+  static scalar_expr distribute_power(scalar_expr base, std::size_t power);
+
+  // Expand the multiplication `a * b`. If either of `a` or `b` is an addition, we distribute terms.
+  static scalar_expr distribute_multiplied_terms(const scalar_expr& a, const scalar_expr& b);
+
+  template <typename Container>
+  scalar_expr distribute_multiplied_terms(const Container& multiplied_terms);
+
+  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
+                     is_identical_struct<scalar_expr>>
+      cache_;
+};
+
+}  // namespace wf

--- a/components/core/wf/expressions/addition.h
+++ b/components/core/wf/expressions/addition.h
@@ -43,6 +43,9 @@ class addition {
   container_type::const_iterator begin() const noexcept { return terms_.begin(); }
   container_type::const_iterator end() const noexcept { return terms_.end(); }
 
+  // Get span over terms.
+  absl::Span<const scalar_expr> as_span() const noexcept { return {terms_}; }
+
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {

--- a/components/core/wf/expressions/power.cc
+++ b/components/core/wf/expressions/power.cc
@@ -157,8 +157,8 @@ struct PowerNumerics {
 
       // There is still the business of the fractional part to deal with:
       if (fractional_part.numerator() != 0) {
-        scalar_expr base = scalar_expr(f.base);
-        scalar_expr exponent = scalar_expr(fractional_part);
+        scalar_expr base(f.base);
+        scalar_expr exponent(fractional_part);
         operands.push_back(make_expr<power>(std::move(base), std::move(exponent)));
       }
     }
@@ -221,15 +221,14 @@ static bool can_multiply_exponents(const power& base_pow, const scalar_expr& out
   // Unless:
   //  - `y` is an integer
   //  - `x` is real and non-negative
-  const scalar_expr& inner_exp = base_pow.exponent();
-  if (magnitude_less_than_one(inner_exp)) {
+  if (const scalar_expr& inner_exp = base_pow.exponent(); magnitude_less_than_one(inner_exp)) {
     return true;
   }
   if (outer_exp.is_type<integer_constant>()) {
     return true;
   }
-  const number_set base_set = determine_numeric_set(base_pow.base());
-  if (base_set == number_set::real_non_negative || base_set == number_set::real_positive) {
+  if (const number_set base_set = determine_numeric_set(base_pow.base());
+      base_set == number_set::real_non_negative || base_set == number_set::real_positive) {
     return true;
   }
   return false;
@@ -237,9 +236,9 @@ static bool can_multiply_exponents(const power& base_pow, const scalar_expr& out
 
 scalar_expr power::create(scalar_expr a, scalar_expr b) {
   // Check for numeric quantities.
-  std::optional<scalar_expr> numeric_pow = visit_binary(a, b, PowerNumerics{});
-  if (numeric_pow) {
-    return *numeric_pow;
+  if (std::optional<scalar_expr> numeric_pow = visit_binary(a, b, PowerNumerics{});
+      numeric_pow.has_value()) {
+    return *std::move(numeric_pow);
   }
 
   if ((is_one(a) || is_negative_one(a)) && is_complex_infinity(b)) {

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -5,6 +5,7 @@
 
 #include "wf/constants.h"
 #include "wf/derivative.h"
+#include "wf/distribute.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/functions.h"
 #include "wf/plain_formatter.h"
@@ -114,7 +115,7 @@ matrix_expr matrix_expr::jacobian(const matrix_expr& vars,
 }
 
 matrix_expr matrix_expr::distribute() const {
-  return matrix_expr{as_matrix().map_children(&wf::distribute)};
+  return matrix_expr{as_matrix().map_children(distribute_visitor{})};
 }
 
 matrix_expr matrix_expr::subs(const scalar_expr& target, const scalar_expr& replacement) const {


### PR DESCRIPTION
- Update the distribute visitor to support integer and rational powers.
- Refactor and simplify handling of multiplications as well. Performance on `bench_distribute` improved by ~15%.
- Add more test cases for the distribute operation.
- Add caching of scalar operations to `distribute_visitor`.
- Use cached visitor when calling `distribute()` on `matrix_expr`.