### PR TITLE
Replace == operator with `sym.equals`

### DIFF
--- a/components/wrapper/python_test/matrix_wrapper_test.py
+++ b/components/wrapper/python_test/matrix_wrapper_test.py
@@ -1,5 +1,8 @@
 """
 Test of matrix-specific functionality.
+
+These tests are here to make sure that wrapped methods behave as expected, and that we
+don't accidentally remove any. Algorithmic tests are in C++.
 """
 import numpy as np
 import typing as T
@@ -95,6 +98,24 @@ class MatrixWrapperTest(MathTestBase):
             sym.DimensionError,
             lambda: sym.matrix([(a, sym.pi, sym.euler), (x, 5, z, b)]),
         )
+
+    def test_is_identical_to(self):
+        """Test that __eq__ is defined, and implements is_identical_to."""
+        u = sym.vector(10, -3, 5)
+        v = sym.vector(0, 27, 91)
+        self.assertTrue(u == u)
+        self.assertFalse(u == v)
+
+    def test_hash(self):
+        """Test calling __hash__ on matrix expressions."""
+        x, y, z = sym.symbols("x, y, z")
+        v = sym.vector(x * 1, -y, z + 2)
+        u = sym.vector(x * y, sym.cos(x), 0)
+        self.assertNotEqual(hash(v), hash(u))  # Not likely.
+        # Use matrix expressions as keys in a dict:
+        storage = {v: 1939, u: 1984}
+        self.assertEqual(1939, storage[v])
+        self.assertEqual(1984, storage[u])
 
     def test_matrix_repr(self):
         """Test matrix __repr__."""

--- a/components/wrapper/pywrenfold/compound_expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/compound_expression_wrapper.cc
@@ -5,6 +5,7 @@
 
 #include "wf/code_generation/types.h"  //  Required for definition of custom_type.
 #include "wf/compound_expression.h"
+#include "wrapper_utils.h"
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -12,16 +13,10 @@ using namespace py::literals;
 namespace wf {
 
 void wrap_compound_expression(py::module_& m) {
-  py::class_<compound_expr>(m, "CompoundExpr")
-      .def("is_identical_to", &are_identical<compound_expr>, py::arg("other"),
-           py::doc("Check if two compound expressions are strictly identical."))
+  wrap_class<compound_expr>(m, "CompoundExpr")
       .def_property_readonly("type_name",
                              [](const compound_expr& self) { return self.type_name(); })
       .def("__repr__", &compound_expr::to_string)
-      .def("__hash__", &hash<compound_expr>)
-      .def("__eq__", &are_identical<compound_expr>, py::is_operator(),
-           py::doc("Check if two compound expressions are strictly identical. This is not "
-                   "mathematical equivalence."))
       .def("__bool__", [](const compound_expr&) {
         throw type_error("CompoundExpr cannot be coerced to boolean.");
       });

--- a/components/wrapper/pywrenfold/expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/expression_wrapper.cc
@@ -110,7 +110,7 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
   using namespace wf;
 
   // Primary expression type:
-  py::class_<scalar_expr>(m, "Expr")
+  wrap_class<scalar_expr>(m, "Expr")
       // Implicit construction from numerics:
       .def(py::init<std::int64_t>())
       .def(py::init<double>())
@@ -118,12 +118,6 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       .def("__repr__", &scalar_expr::to_string)
       .def("expression_tree_str", &scalar_expr::to_expression_tree_string,
            "Retrieve the expression tree as a pretty-printed string.")
-      .def(
-          "is_identical_to",
-          [](const scalar_expr& self, const scalar_expr& other) {
-            return self.is_identical_to(other);
-          },
-          "other"_a, "Test if two expressions have identical expression trees.")
       .def_property_readonly("type_name", [](const scalar_expr& self) { return self.type_name(); })
       // Operations:
       .def(
@@ -162,7 +156,6 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       .def(py::self >= py::self)
       .def(py::self < py::self)
       .def(py::self <= py::self)
-      .def(py::self == py::self)
       // Operators involving integers (int on left side):
       .def(std::int64_t() + py::self)
       .def(std::int64_t() - py::self)
@@ -172,7 +165,6 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       .def(std::int64_t() >= py::self)
       .def(std::int64_t() < py::self)
       .def(std::int64_t() <= py::self)
-      .def(std::int64_t() == py::self)
       // Operators involving doubles (double on left side):
       .def(double() + py::self)
       .def(double() - py::self)
@@ -182,7 +174,6 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       .def(double() >= py::self)
       .def(double() < py::self)
       .def(double() <= py::self)
-      .def(double() == py::self)
       // Override conversion to boolean, so we don't coerce non-boolean expressions.
       .def("__bool__", &convert_expr_to_bool, py::doc("Coerce expression to bool."));
 
@@ -221,6 +212,9 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
         static_cast<scalar_expr (*)(const scalar_expr&, const scalar_expr&, const scalar_expr&)>(
             &wf::where),
         "condition"_a, "if_true"_a, "if_false"_a, "If-else statement.");
+
+  m.def("equals", static_cast<scalar_expr (*)(const scalar_expr&, const scalar_expr&)>(&operator==),
+        "a"_a, "b"_a, py::doc("Boolean expression that is true when both operands are equal."));
 
   m.def("cast_int_from_bool", &wf::cast_int_from_bool, "arg"_a,
         "Convert a boolean expression to an integer.");

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -357,17 +357,11 @@ py::array numpy_from_matrix(const matrix_expr& self) {
 
 void wrap_matrix_operations(py::module_& m) {
   // Matrix expression type.
-  py::class_<matrix_expr>(m, "MatrixExpr")
+  wrap_class<matrix_expr>(m, "MatrixExpr")
       // scalar_expr inherited properties:
       .def("__repr__", &matrix_expr::to_string)
       .def("expression_tree_str", &matrix_expr::to_expression_tree_string,
            "Retrieve the expression tree as a pretty-printed string.")
-      .def(
-          "is_identical_to",
-          [](const matrix_expr& self, const matrix_expr& other) {
-            return self.is_identical_to(other);
-          },
-          "other"_a, "Test if two matrix expressions have identical expression trees.")
       .def_property_readonly("type_name", [](const matrix_expr& self) { return self.type_name(); })
       // Operations:
       .def(


### PR DESCRIPTION
Using `==` as the mathematical equality operation does not work well, because python expects `__eq__` to implement strict equality (for example in the context of checking for collisions in a dictionary).

This change:
- Replaces `==` with `sym.equals`
- Makes sure `__eq__` is implemented to match `is_identical_to` on `scalar_expr`, `matrix_expr`, and `compound_expr`