### PR TITLE
Create a header for the tree_formatter_visitor

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(
   wf/assertions.h
   wf/checked_int.h
   wf/checked_pointers.h
+  wf/code_generation/ast.cc
+  wf/code_generation/ast.h
   wf/code_generation/ast_conversion.cc
   wf/code_generation/ast_conversion.h
   wf/code_generation/ast_element.h
   wf/code_generation/ast_formatters.h
-  wf/code_generation/ast.cc
-  wf/code_generation/ast.h
   wf/code_generation/code_formatter.h
   wf/code_generation/control_flow_graph.cc
   wf/code_generation/control_flow_graph.h
@@ -52,10 +52,10 @@ add_library(
   wf/enumerations.h
   wf/error_types.h
   wf/evaluate.cc
-  wf/expression_variant.h
-  wf/expression_visitor.h
   wf/expression.cc
   wf/expression.h
+  wf/expression_variant.h
+  wf/expression_visitor.h
   wf/expressions/addition.cc
   wf/expressions/addition.h
   wf/expressions/all_expressions.h
@@ -108,6 +108,7 @@ add_library(
   wf/template_utils.h
   wf/traits.h
   wf/tree_formatter.cc
+  wf/tree_formatter.h
   wf/type_annotations.h
   wf/type_list.h
   wf/visit.h)

--- a/components/core/wf/compound_expression.cc
+++ b/components/core/wf/compound_expression.cc
@@ -4,12 +4,19 @@
 #include "wf/expression_visitor.h"
 #include "wf/index_range.h"
 #include "wf/plain_formatter.h"
+#include "wf/tree_formatter.h"
 
 namespace wf {
 
 std::string compound_expr::to_string() const {
   plain_formatter formatter{};
   visit(*this, formatter);
+  return formatter.take_output();
+}
+
+std::string compound_expr::to_expression_tree_string() const {
+  tree_formatter_visitor formatter{};
+  formatter(*this);
   return formatter.take_output();
 }
 

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -5,6 +5,7 @@
 #include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/plain_formatter.h"
+#include "wf/tree_formatter.h"
 
 namespace wf {
 
@@ -41,7 +42,13 @@ scalar_expr scalar_expr::from_int(const checked_int x) {
 
 std::string scalar_expr::to_string() const {
   plain_formatter formatter{};
-  visit(*this, formatter);
+  formatter(*this);
+  return formatter.take_output();
+}
+
+std::string scalar_expr::to_expression_tree_string() const {
+  tree_formatter_visitor formatter{};
+  formatter(*this);
   return formatter.take_output();
 }
 

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -65,7 +65,6 @@ class scalar_expr final : public expression_base<scalar_expr, scalar_meta_type> 
   std::string to_string() const;
 
   // Convert to string of the expression tree.
-  // Defined in tree_formatter.cc
   std::string to_expression_tree_string() const;
 
   // Negation operator.

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -11,7 +11,13 @@
 
 namespace wf {
 
-scalar_expr addition::from_operands(absl::Span<const scalar_expr> args) {
+std::vector<scalar_expr> addition::sorted_terms() const {
+  std::vector<scalar_expr> result{terms_.begin(), terms_.end()};
+  std::sort(result.begin(), result.end(), wf::expression_order_struct{});
+  return result;
+}
+
+scalar_expr addition::from_operands(const absl::Span<const scalar_expr> args) {
   WF_ASSERT(!args.empty(), "Cannot call from_operands with an empty span.");
   if (args.size() < 2) {
     return args.front();

--- a/components/core/wf/expressions/addition.h
+++ b/components/core/wf/expressions/addition.h
@@ -46,6 +46,9 @@ class addition {
   // Get span over terms.
   absl::Span<const scalar_expr> as_span() const noexcept { return {terms_}; }
 
+  // Get terms in the addition, sorted into canonical order.
+  std::vector<scalar_expr> sorted_terms() const;
+
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {
@@ -56,7 +59,7 @@ class addition {
 
   // Construct from a span of operands.
   // The result is automatically simplified, and may not be an addition.
-  static scalar_expr from_operands(absl::Span<const scalar_expr> span);
+  static scalar_expr from_operands(absl::Span<const scalar_expr> args);
 
  private:
   container_type terms_;

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -30,6 +30,12 @@ static inline scalar_expr multiply_into_addition(const addition& add,
   return addition::from_operands(add_args);  // TODO: make this a move!
 }
 
+std::vector<scalar_expr> multiplication::sorted_terms() const {
+  std::vector<scalar_expr> result{begin(), end()};
+  std::sort(result.begin(), result.end(), expression_order_struct{});
+  return result;
+}
+
 scalar_expr multiplication::from_operands(absl::Span<const scalar_expr> args) {
   WF_ASSERT(!args.empty());
   if (args.size() < 2) {

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -43,13 +43,8 @@ class multiplication {
   container_type::const_iterator begin() const noexcept { return terms_.begin(); }
   container_type::const_iterator end() const noexcept { return terms_.end(); }
 
-  // All terms must be identical.
-  bool is_identical_to(const multiplication& other) const {
-    if (size() != other.size()) {
-      return false;
-    }
-    return std::equal(begin(), end(), other.begin(), is_identical_struct<scalar_expr>{});
-  }
+  // Get terms in the multiplication, sorted into canonical order.
+  std::vector<scalar_expr> sorted_terms() const;
 
   // Implement ExpressionImpl::Map
   template <typename Operation>

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -1,14 +1,14 @@
 // Copyright 2023 Gareth Cross
 #include "wf/matrix_expression.h"
 
-#include "wf_runtime/span.h"
-
 #include "wf/constants.h"
 #include "wf/derivative.h"
 #include "wf/distribute.h"
+#include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/functions.h"
 #include "wf/plain_formatter.h"
+#include "wf/tree_formatter.h"
 
 namespace wf {
 
@@ -21,6 +21,12 @@ matrix_expr matrix_expr::create(index_t rows, index_t cols, std::vector<scalar_e
 
 std::string matrix_expr::to_string() const {
   plain_formatter formatter{};
+  formatter(*this);
+  return formatter.take_output();
+}
+
+std::string matrix_expr::to_expression_tree_string() const {
+  tree_formatter_visitor formatter{};
   formatter(*this);
   return formatter.take_output();
 }

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -39,7 +39,7 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   // Convert to string.
   std::string to_string() const;
 
-  // Defined in tree_formatter.cc
+  // Format to graphical tree representation.
   std::string to_expression_tree_string() const;
 
   // Negation operator.

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -1,4 +1,6 @@
 // Copyright 2022 Gareth Cross
+#include "wf/tree_formatter.h"
+
 #include <vector>
 
 #include "wf/compound_expression.h"
@@ -8,7 +10,107 @@
 #include "wf/fmt_imports.h"
 #include "wf/matrix_expression.h"
 
+// TODO: We could optimize this to use caching of repeated expressions, but it is not
+//  particularly performance critical at the moment.
 namespace wf {
+
+void tree_formatter_visitor::operator()(const scalar_expr& x) { visit(x, *this); }
+void tree_formatter_visitor::operator()(const matrix_expr& m) { visit(m, *this); }
+void tree_formatter_visitor::operator()(const compound_expr& c) { visit(c, *this); }
+
+void tree_formatter_visitor::operator()(const addition& add) {
+  format_append("{}:", addition::name_str);
+  visit_all(add.sorted_terms());
+}
+
+void tree_formatter_visitor::operator()(const cast_bool& cast) {
+  format_append("{}:", cast_bool::name_str);
+  visit_right(cast.arg());
+}
+
+void tree_formatter_visitor::operator()(const complex_infinity&) {
+  format_append(complex_infinity::name_str);
+}
+
+void tree_formatter_visitor::operator()(const compound_expression_element& el) {
+  format_append("{} (index = {}):", compound_expression_element::name_str, el.index());
+  visit_right(el.provenance());
+}
+
+void tree_formatter_visitor::operator()(const conditional& conditional) {
+  format_append("{}:", conditional::name_str);
+  visit_all(conditional);
+}
+
+void tree_formatter_visitor::operator()(const custom_type_argument& arg) {
+  format_append("{} (type = {}, index = {})", custom_type_argument::name_str, arg.type().name(),
+                arg.arg_index());
+}
+
+void tree_formatter_visitor::operator()(const custom_type_construction& construct) {
+  format_append("{} (type = {}):", custom_type_construction::name_str, construct.type().name());
+  visit_all(construct.args());
+}
+
+void tree_formatter_visitor::operator()(const derivative& diff) {
+  format_append("{} (order = {}):", derivative::name_str, diff.order());
+  visit_all(diff);
+}
+
+void tree_formatter_visitor::operator()(const external_function_invocation& invocation) {
+  format_append("{} (function = `{}`):", external_function_invocation::name_str,
+                invocation.function().name());
+  visit_all(invocation.args());
+}
+
+void tree_formatter_visitor::operator()(const float_constant& f) {
+  format_append("{} ({})", float_constant::name_str, f.get_value());
+}
+
+void tree_formatter_visitor::operator()(const function& func) {
+  format_append("{} ({}):", function::name_str, func.function_name());
+  visit_all(func);
+}
+
+void tree_formatter_visitor::operator()(const integer_constant& i) {
+  format_append("{} ({})", integer_constant::name_str, i.get_value());
+}
+
+void tree_formatter_visitor::operator()(const matrix& mat) {
+  format_append("{} ({}, {}):", matrix::name_str, mat.rows(), mat.cols());
+  visit_all(mat);
+}
+
+void tree_formatter_visitor::operator()(const multiplication& op) {
+  format_append("{}:", multiplication::name_str);
+  visit_all(op.sorted_terms());
+}
+
+void tree_formatter_visitor::operator()(const power& pow) {
+  format_append("{}:", power::name_str);
+  visit_all(pow);
+}
+
+void tree_formatter_visitor::operator()(const rational_constant& r) {
+  format_append("{} ({} / {})", rational_constant::name_str, r.numerator(), r.denominator());
+}
+
+void tree_formatter_visitor::operator()(const relational& relational) {
+  format_append("{} ({})", relational::name_str, relational.operation_string());
+  visit_all(relational);
+}
+
+void tree_formatter_visitor::operator()(const symbolic_constant& constant) {
+  format_append("{} ({})", symbolic_constant::name_str,
+                string_from_symbolic_constant(constant.name()));
+}
+
+void tree_formatter_visitor::operator()(const undefined&) { format_append(undefined::name_str); }
+
+void tree_formatter_visitor::operator()(const variable& var) {
+  format_append("{} ({}, {})", variable::name_str, var.to_string(),
+                string_from_number_set(var.set()));
+}
 
 static void right_trim_in_place(std::string& str) {
   while (!str.empty() && std::isspace(str.back())) {
@@ -16,219 +118,63 @@ static void right_trim_in_place(std::string& str) {
   }
 }
 
-struct tree_formatter {
-  // Add indentation to the output string.
-  void apply_indentation() {
-    if (indentations_.empty()) {
-      return;
-    }
-    // For each left branch depth, we need to add a line.
-    // Right branches only need space.
-    for (std::size_t i = 0; i + 1 < indentations_.size(); ++i) {
-      if (indentations_[i]) {
-        output_ += "│  ";
-      } else {
-        output_ += "   ";
-      }
-    }
-    if (indentations_.back()) {
-      output_ += "├─ ";
+std::string tree_formatter_visitor::take_output() {
+  // Somewhat hacky. The formatter appends a superfluous newline on the last element. I think
+  // this is tricky to avoid w/o knowing the tree depth apriori. Instead, just trim it from the
+  // end.
+  right_trim_in_place(output_);
+  return std::move(output_);
+}
+
+void tree_formatter_visitor::apply_indentation() {
+  if (indentations_.empty()) {
+    return;
+  }
+  // For each left branch depth, we need to add a line.
+  // Right branches only need space.
+  for (std::size_t i = 0; i + 1 < indentations_.size(); ++i) {
+    if (indentations_[i]) {
+      output_ += "│  ";
     } else {
-      // Final right branch is the end of this tree.
-      output_ += "└─ ";
+      output_ += "   ";
     }
   }
-
-  template <typename... Args>
-  void append_name(const std::string_view fmt_str, Args&&... args) {
-    apply_indentation();
-    fmt::format_to(std::back_inserter(output_), fmt_str, std::forward<Args>(args)...);
-    output_ += "\n";
+  if (indentations_.back()) {
+    output_ += "├─ ";
+  } else {
+    // Final right branch is the end of this tree.
+    output_ += "└─ ";
   }
-
-  template <typename T>
-  void visit_left(const T& expr) {
-    indentations_.push_back(true);
-    visit(expr, *this);
-    indentations_.pop_back();
-  }
-
-  template <typename T>
-  void visit_right(const T& expr) {
-    indentations_.push_back(false);
-    visit(expr, *this);
-    indentations_.pop_back();
-  }
-
-  template <typename Container>
-  void visit_all(const Container& container) {
-    auto it = container.begin();
-    for (; std::next(it) != container.end(); ++it) {
-      visit_left(*it);
-    }
-    visit_right(*it);
-  }
-
-  void operator()(const scalar_expr& x) { visit(x, *this); }
-
-  void operator()(const matrix_expr& m) { operator()(m.as_matrix()); }
-
-  void operator()(const addition& op) {
-    absl::InlinedVector<scalar_expr, 16> terms;
-    terms.reserve(op.size());
-    std::copy(op.begin(), op.end(), std::back_inserter(terms));
-    std::sort(terms.begin(), terms.end(), [](const auto& a, const auto& b) {
-      auto acm = as_coeff_and_mul(a);
-      auto bcm = as_coeff_and_mul(b);
-      return determine_order(acm.second, bcm.second) == relative_order::less_than;
-    });
-
-    append_name("Addition:");
-    visit_all(terms);
-  }
-
-  void operator()(const compound_expression_element& el) {
-    append_name("{} (index = {}):", compound_expression_element::name_str, el.index());
-    visit_right(el.provenance());
-  }
-
-  void operator()(const external_function_invocation& invocation) {
-    append_name("{} (function = `{}`):", external_function_invocation::name_str,
-                invocation.function().name());
-    visit_all(invocation.args());
-  }
-
-  void operator()(const custom_type_argument& arg) {
-    append_name("{} (type = {}, index = {})", custom_type_argument::name_str, arg.type().name(),
-                arg.arg_index());
-  }
-
-  void operator()(const custom_type_construction& construct) {
-    append_name("{} (type = {}):", custom_type_construction::name_str, construct.type().name());
-    visit_all(construct.args());
-  }
-
-  void operator()(const derivative& diff) {
-    append_name("Derivative (order = {}):", diff.order());
-    visit_left(diff.differentiand());
-    visit_right(diff.argument());
-  }
-
-  void operator()(const multiplication& op) {
-    absl::InlinedVector<scalar_expr, 16> terms;
-    terms.reserve(op.size());
-    std::copy(op.begin(), op.end(), std::back_inserter(terms));
-    std::sort(terms.begin(), terms.end(), [](const auto& a, const auto& b) {
-      const auto abe = as_base_and_exp(a);
-      const auto bbe = as_base_and_exp(b);
-      return determine_order(abe.first, bbe.first) == relative_order::less_than;
-    });
-
-    append_name("Multiplication:");
-    auto it = terms.begin();
-    for (; std::next(it) != terms.end(); ++it) {
-      visit_left(*it);
-    }
-    visit_right(*it);
-  }
-
-  void operator()(const matrix& mat) {
-    // TODO: Print the (row, col) index for each element.
-    append_name("Matrix ({}, {}):", mat.rows(), mat.cols());
-    const auto& elements = mat.data();
-    for (std::size_t i = 0; i + 1 < elements.size(); ++i) {
-      visit_left(elements[i]);
-    }
-    visit_right(elements.back());
-  }
-
-  void operator()(const power& op) {
-    append_name("Power:");
-    visit_left(op.base());
-    visit_right(op.exponent());
-  }
-
-  void operator()(const complex_infinity&) { append_name("{}", complex_infinity::name_str); }
-
-  void operator()(const integer_constant& neg) { append_name("Integer ({})", neg.get_value()); }
-
-  void operator()(const float_constant& neg) { append_name("Float ({})", neg.get_value()); }
-
-  void operator()(const rational_constant& rational) {
-    append_name("Rational ({} / {})", rational.numerator(), rational.denominator());
-  }
-
-  void operator()(const relational& relational) {
-    append_name("Relational ({})", relational.operation_string());
-    visit_left(relational.left());
-    visit_right(relational.right());
-  }
-
-  void operator()(const function& func) {
-    append_name("Function ({}):", func.function_name());
-    auto it = func.begin();
-    for (; std::next(it) != func.end(); ++it) {
-      visit_left(*it);
-    }
-    visit_right(*it);
-  }
-
-  void operator()(const undefined&) { append_name(undefined::name_str); }
-
-  void operator()(const variable& var) {
-    append_name("{} ({}, {})", variable::name_str, var.to_string(),
-                string_from_number_set(var.set()));
-  }
-
-  void operator()(const cast_bool& cast) {
-    append_name("CastBool:");
-    visit_right(cast.arg());
-  }
-
-  void operator()(const conditional& conditional) {
-    append_name("Conditional:");
-    visit_left(conditional.condition());
-    visit_left(conditional.if_branch());
-    visit_right(conditional.else_branch());
-  }
-
-  void operator()(const symbolic_constant& constant) {
-    append_name("Constant ({})", string_from_symbolic_constant(constant.name()));
-  }
-
-  // Get the output string via move.
-  std::string take_output() {
-    // Somewhat hacky. The formatter appends a superfluous newline on the last element. I think
-    // this is tricky to avoid w/o knowing the tree depth apriori. Instead, just trim it from the
-    // end.
-    right_trim_in_place(output_);
-    return std::move(output_);
-  }
-
- private:
-  // The indentation pattern at our current tree depth.
-  // True indicates a left branch, false indicates a right branch.
-  std::vector<unsigned char> indentations_;
-  // The final output
-  std::string output_;
-};
-
-std::string scalar_expr::to_expression_tree_string() const {
-  tree_formatter formatter{};
-  visit(*this, formatter);
-  return formatter.take_output();
 }
 
-std::string matrix_expr::to_expression_tree_string() const {
-  tree_formatter formatter{};
-  formatter(as_matrix());
-  return formatter.take_output();
+template <typename... Args>
+void tree_formatter_visitor::format_append(const std::string_view fmt_str, Args&&... args) {
+  apply_indentation();
+  fmt::format_to(std::back_inserter(output_), fmt_str, std::forward<Args>(args)...);
+  output_ += "\n";
 }
 
-std::string compound_expr::to_expression_tree_string() const {
-  tree_formatter formatter{};
-  visit(*this, formatter);
-  return formatter.take_output();
+template <typename T>
+void tree_formatter_visitor::visit_left(const T& expr) {
+  indentations_.push_back(true);
+  visit(expr, *this);
+  indentations_.pop_back();
+}
+
+template <typename T>
+void tree_formatter_visitor::visit_right(const T& expr) {
+  indentations_.push_back(false);
+  visit(expr, *this);
+  indentations_.pop_back();
+}
+
+template <typename Container>
+void tree_formatter_visitor::visit_all(const Container& container) {
+  auto it = container.begin();
+  for (; std::next(it) != container.end(); ++it) {
+    visit_left(*it);
+  }
+  visit_right(*it);
 }
 
 }  // namespace wf

--- a/components/core/wf/tree_formatter.h
+++ b/components/core/wf/tree_formatter.h
@@ -1,0 +1,66 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include <vector>
+
+#include "wf/compound_expression.h"
+#include "wf/expression.h"
+#include "wf/matrix_expression.h"
+
+namespace wf {
+
+// Recursively print expressions as a graphical utf-8 tree (mostly for diffing/debugging).
+class tree_formatter_visitor {
+ public:
+  void operator()(const scalar_expr& x);
+  void operator()(const matrix_expr& m);
+  void operator()(const compound_expr& c);
+
+  void operator()(const addition& add);
+  void operator()(const cast_bool& cast);
+  void operator()(const complex_infinity&);
+  void operator()(const compound_expression_element& el);
+  void operator()(const conditional& conditional);
+  void operator()(const custom_type_argument& arg);
+  void operator()(const custom_type_construction& construct);
+  void operator()(const derivative& diff);
+  void operator()(const external_function_invocation& invocation);
+  void operator()(const float_constant& f);
+  void operator()(const function& func);
+  void operator()(const integer_constant& i);
+  void operator()(const matrix& mat);
+  void operator()(const multiplication& op);
+  void operator()(const power& pow);
+  void operator()(const rational_constant& r);
+  void operator()(const relational& relational);
+  void operator()(const symbolic_constant& constant);
+  void operator()(const undefined&);
+  void operator()(const variable& var);
+
+  // Get the output string. Result is returned via move.
+  std::string take_output();
+
+ private:
+  void apply_indentation();
+
+  template <typename... Args>
+  void format_append(std::string_view fmt_str, Args&&... args);
+
+  template <typename T>
+  void visit_left(const T& expr);
+
+  template <typename T>
+  void visit_right(const T& expr);
+
+  // Visit every element of `container`. All but the last element are left-visited, and the
+  // last element is right-visited.
+  template <typename Container>
+  void visit_all(const Container& container);
+
+  // The indentation pattern at our current tree depth.
+  // True indicates a left branch, false indicates a right branch.
+  std::vector<unsigned char> indentations_;
+  // The final output
+  std::string output_;
+};
+
+}  // namespace wf


### PR DESCRIPTION
- `tree_formatter_visitor` has a header file. Split declaration and implementation into header and cc.
- Simplify some tree_formatter implementation by using `visit_all(...)`
- Add `sorted_terms` methods to `addition` and `multiplication`.