### PR TITLE
Separate out `boolean_expr` from `scalar_expr`

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(
   wf/absl_imports.h
   wf/algorithm_utils.h
   wf/assertions.h
+  wf/boolean_expression.cc
+  wf/boolean_expression.h
   wf/checked_int.h
   wf/checked_pointers.h
   wf/code_generation/ast.cc
@@ -54,6 +56,7 @@ add_library(
   wf/evaluate.cc
   wf/expression.cc
   wf/expression.h
+  wf/expression_cache.h
   wf/expression_variant.h
   wf/expression_visitor.h
   wf/expressions/addition.cc

--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -43,6 +43,10 @@ struct convert_assertion_argument<T, std::enable_if_t<std::is_convertible_v<T, s
   // This overload will get selected for numeric literals.
   scalar_expr operator()(const T& arg) const { return static_cast<scalar_expr>(arg); }
 };
+template <typename T>
+struct convert_assertion_argument<T, std::enable_if_t<std::is_convertible_v<T, boolean_expr>>> {
+  boolean_expr operator()(const T& arg) const { return static_cast<boolean_expr>(arg); }
+};
 template <>
 struct convert_assertion_argument<matrix_expr> {
   matrix_expr operator()(const matrix_expr& arg) const { return arg; }

--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -184,25 +184,25 @@ TEST(DerivativesTest, TestMatrix) {
 TEST(DerivativesTest, TestRelational) {
   // Cannot diff a relational:
   const auto [x, y] = make_symbols("x", "y");
-  ASSERT_IDENTICAL(0, (x < y).diff(x));
-  ASSERT_IDENTICAL(0, (x == y).diff(x));
-  ASSERT_IDENTICAL(derivative::create(x < y, x, 1),
-                   (x < y).diff(x, 1, non_differentiable_behavior::abstract));
-  ASSERT_IDENTICAL(derivative::create(x == y, x, 1),
-                   (x == y).diff(x, 1, non_differentiable_behavior::abstract));
+  ASSERT_IDENTICAL(0, iverson(x < y).diff(x));
+  ASSERT_IDENTICAL(0, iverson(x == y).diff(x));
+  ASSERT_IDENTICAL(derivative::create(iverson(x < y), x, 1),
+                   iverson(x < y).diff(x, 1, non_differentiable_behavior::abstract));
+  ASSERT_IDENTICAL(derivative::create(iverson(x == y), x, 1),
+                   iverson(x == y).diff(x, 1, non_differentiable_behavior::abstract));
 }
 
-TEST(DerivativesTest, TestCastBool) {
+TEST(DerivativesTest, TestIversonBracket) {
   const auto [x, y] = make_symbols("x", "y");
 
-  ASSERT_IDENTICAL(0, cast_int_from_bool(x < y).diff(x));
-  ASSERT_IDENTICAL(0, cast_int_from_bool(x < y).diff(x).diff(y));
+  ASSERT_IDENTICAL(0, iverson(x < y).diff(x));
+  ASSERT_IDENTICAL(0, iverson(x < y).diff(x).diff(y));
 
   // Check that this produces a `derivative` expression:
-  ASSERT_IDENTICAL(derivative::create(cast_int_from_bool(x < y), x, 1),
-                   cast_int_from_bool(x < y).diff(x, 1, non_differentiable_behavior::abstract));
-  ASSERT_IDENTICAL(derivative::create(derivative::create(cast_int_from_bool(x < y), x, 1), y, 1),
-                   cast_int_from_bool(x < y)
+  ASSERT_IDENTICAL(derivative::create(iverson(x < y), x, 1),
+                   iverson(x < y).diff(x, 1, non_differentiable_behavior::abstract));
+  ASSERT_IDENTICAL(derivative::create(derivative::create(iverson(x < y), x, 1), y, 1),
+                   iverson(x < y)
                        .diff(x, 1, non_differentiable_behavior::abstract)
                        .diff(y, 1, non_differentiable_behavior::abstract));
 }

--- a/components/core/tests/functions_test.cc
+++ b/components/core/tests/functions_test.cc
@@ -299,8 +299,6 @@ TEST(FunctionTest, TestMinMax) {
 
   ASSERT_IDENTICAL(0, min(1, 0));
   ASSERT_IDENTICAL(1.4123, min(1.4123, 10));
-  ASSERT_IDENTICAL(constants::boolean_false,
-                   min(constants::boolean_false, constants::boolean_true));
   ASSERT_IDENTICAL(-10, min(-10, constants::euler));
 
   ASSERT_IDENTICAL(x, max(x, x));

--- a/components/core/tests/ir_conversion_test.cc
+++ b/components/core/tests/ir_conversion_test.cc
@@ -296,8 +296,8 @@ TEST(IrTest, TestConditionals2) {
   auto [expected_expressions, ir] = create_ir(
       [](scalar_expr x, scalar_expr y) {
         // use the condition in one of the branches:
-        scalar_expr condition = x > y;
-        return where(condition, condition * 2, cos(y - 2));
+        boolean_expr condition = x > y;
+        return where(condition, iverson(condition) * 2, cos(y - 2));
       },
       "func", arg("x"), arg("y"));
 
@@ -364,12 +364,12 @@ TEST(IrTest, TestConditionals5) {
       },
       "func", arg("x"), arg("y"), arg("z"));
 
-  ASSERT_EQ(55, ir.num_operations()) << ir;
+  ASSERT_EQ(54, ir.num_operations()) << ir;
   ASSERT_EQ(6, ir.num_conditionals()) << ir;
   check_expressions(expected_expressions, ir);
 
   const control_flow_graph output_ir = std::move(ir).convert_conditionals_to_control_flow();
-  ASSERT_EQ(57, output_ir.num_operations()) << output_ir;
+  ASSERT_EQ(56, output_ir.num_operations()) << output_ir;
   ASSERT_EQ(7, output_ir.num_conditionals()) << output_ir;
   check_expressions_with_output_permutations(expected_expressions, output_ir);
 }

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -1,5 +1,4 @@
 #include "wf/constants.h"
-#include "wf/fmt_imports.h"
 #include "wf/functions.h"
 #include "wf/matrix_functions.h"
 
@@ -100,8 +99,8 @@ TEST(PlainFormatterTest, TestRelationals) {
   // Test precedence:
   ASSERT_STR_EQ("x * y < 5", x * y < 5);
   ASSERT_STR_EQ("sin(y) < 2 * x + z", z + 2 * x > sin(y));
-  ASSERT_STR_EQ("x < (z < y)", x < (z < y));
-  ASSERT_STR_EQ("x < (y <= z)", x < (z >= y));
+  ASSERT_STR_EQ("x < iverson(z < y)", x < iverson(z < y));
+  ASSERT_STR_EQ("x < iverson(y <= z)", x < iverson(z >= y));
 }
 
 TEST(PlainFormatterTest, TestConditionals) {
@@ -155,5 +154,15 @@ TEST(PlainFormatterTest, TestDerivativeExpression) {
 TEST(PlainFormatterTest, TestComplexInfinity) { ASSERT_STR_EQ("zoo", constants::complex_infinity); }
 
 TEST(PlainFormatterTest, TestUndefined) { ASSERT_STR_EQ("nan", constants::undefined); }
+
+TEST(PlainFormatterTest, TestScalarConstants) {
+  ASSERT_STR_EQ("pi", constants::pi);
+  ASSERT_STR_EQ("e", constants::euler);
+}
+
+TEST(PlainFormatterTest, TestBooleanConstants) {
+  ASSERT_STR_EQ("True", constants::boolean_true);
+  ASSERT_STR_EQ("False", constants::boolean_false);
+}
 
 }  // namespace wf

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -41,8 +41,8 @@ inline scalar_expr heaviside(scalar_expr x) { return where(x >= 0, 1, 0); }
 
 // Exclusive or on the conditions x > 0 and y > 0 (a simple nested conditional).
 inline scalar_expr exclusive_or(scalar_expr x, scalar_expr y) {
-  scalar_expr cond_x = x > 0;
-  scalar_expr cond_y = y > 0;
+  boolean_expr cond_x = x > 0;
+  boolean_expr cond_y = y > 0;
   return where(cond_x, where(cond_y, 0, 1), where(cond_y, 1, 0));
 }
 

--- a/components/core/wf/boolean_expression.cc
+++ b/components/core/wf/boolean_expression.cc
@@ -1,0 +1,31 @@
+// Copyright 2024 Gareth Cross
+#include "wf/boolean_expression.h"
+
+#include "wf/constants.h"
+#include "wf/plain_formatter.h"
+#include "wf/tree_formatter.h"
+
+namespace wf {
+
+std::string boolean_expr::to_string() const {
+  plain_formatter formatter{};
+  formatter(*this);
+  return formatter.take_output();
+}
+
+std::string boolean_expr::to_expression_tree_string() const {
+  tree_formatter_visitor formatter{};
+  formatter(*this);
+  return formatter.take_output();
+}
+
+boolean_expr boolean_expr::construct_implicit(const bool value) {
+  // Return an existing constant instead of allocating a new one:
+  if (value) {
+    return constants::boolean_true;
+  } else {
+    return constants::boolean_false;
+  }
+}
+
+}  // namespace wf

--- a/components/core/wf/boolean_expression.h
+++ b/components/core/wf/boolean_expression.h
@@ -1,0 +1,71 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include "wf/expression_variant.h"
+#include "wf/operations.h"
+#include "wf/ordering.h"
+
+namespace wf {
+
+struct boolean_meta_type {};
+template <>
+struct type_list_trait<boolean_meta_type> {
+  // All the boolean-valued expressions.
+  // clang-format off
+  using types = type_list<
+    const class boolean_constant,
+    const class relational
+    >;
+  // clang-format on
+};
+
+// An abstract boolean-valued expression.
+class boolean_expr final : public expression_base<boolean_expr, boolean_meta_type> {
+ public:
+  using expression_base::expression_base;
+
+  // Support implicit construction from bool (and only bool).
+  template <typename T, typename = std::enable_if_t<std::is_same_v<bool, T>>>
+  boolean_expr(const T value) : boolean_expr(construct_implicit(value)) {}
+
+  // Convert to string.
+  std::string to_string() const;
+
+  // Convert to graphical expression tree.
+  std::string to_expression_tree_string() const;
+
+  // Create a new expression by recursively substituting `replacement` for `target`.
+  template <typename A, typename B>
+  boolean_expr subs(const A& target, const B& replacement) const {
+    return wf::substitute(*this, target, replacement);
+  }
+
+ private:
+  static boolean_expr construct_implicit(bool value);
+};
+
+// ostream support
+inline std::ostream& operator<<(std::ostream& stream, const boolean_expr& x) {
+  stream << x.to_string();
+  return stream;
+}
+
+// Determine relative order of two boolean expressions.
+// This is not a mathematical ordering - rather it is a canonical ordering we impose on expressions.
+template <>
+struct order_struct<boolean_expr> {
+  // Implemented in ordering.cc
+  relative_order operator()(const boolean_expr& a, const boolean_expr& b) const;
+};
+
+}  // namespace wf
+
+// libfmt support for boolean_expr.
+template <>
+struct fmt::formatter<wf::boolean_expr> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const wf::boolean_expr& x, FormatContext& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", x.to_string());
+  }
+};

--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -38,6 +38,12 @@ struct assign_output_scalar {
   ast_element value;
 };
 
+// A boolean litera: 'true' or 'false'.
+struct boolean_literal {
+  static constexpr std::string_view snake_case_name_str = "boolean_literal";
+  bool value;
+};
+
 // An if/else statement.
 struct branch {
   static constexpr std::string_view snake_case_name_str = "branch";

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -430,6 +430,8 @@ ast::ast_element ast_form_visitor::operator()(const ir::value&, const ir::load& 
         } else if constexpr (std::is_same_v<T, rational_constant>) {
           return ast::ast_element{std::in_place_type_t<ast::float_literal>{},
                                   static_cast<float_constant>(inner).get_value()};
+        } else if constexpr (std::is_same_v<T, boolean_constant>) {
+          return ast::ast_element{std::in_place_type_t<ast::boolean_literal>{}, inner.value()};
         } else if constexpr (std::is_same_v<T, variable>) {
           // inspect inner type of the variable
           return std::visit([this](const auto& var_type) { return this->operator()(var_type); },

--- a/components/core/wf/code_generation/ast_element.h
+++ b/components/core/wf/code_generation/ast_element.h
@@ -21,6 +21,7 @@ using ast_element_types = type_list<
     struct assign_output_matrix,
     struct assign_output_scalar,
     struct assign_output_struct,
+    struct boolean_literal,
     struct branch,
     struct call_external_function,
     struct call_std_function,

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -51,6 +51,11 @@ auto format_ast(Iterator it, const wf::ast::assign_temporary& v) {
 }
 
 template <typename Iterator>
+auto format_ast(Iterator it, const wf::ast::boolean_literal& b) {
+  return fmt::format_to(it, "({})", b.value ? "true" : "false");
+}
+
+template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::branch& d) {
   return fmt::format_to(it, "(if {} {{ {} statements }} else {{ {} statements }})", d.condition,
                         d.if_branch.size(), d.else_branch.size());

--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -177,6 +177,10 @@ std::string cpp_code_generator::operator()(const ast::assign_temporary& x) const
   return fmt::format("{} = {};", x.left, make_view(x.right));
 }
 
+std::string cpp_code_generator::operator()(const ast::boolean_literal& x) const {
+  return x.value ? "true" : "false";
+}
+
 std::string cpp_code_generator::operator()(const ast::branch& x) const {
   std::string result{};
   fmt::format_to(std::back_inserter(result), "if ({}) ", make_view(x.condition));
@@ -337,10 +341,6 @@ static constexpr std::string_view cpp_string_for_symbolic_constant(
       return "M_E";
     case symbolic_constant_enum::pi:
       return "M_PI";
-    case symbolic_constant_enum::boolean_true:
-      return "true";
-    case symbolic_constant_enum::boolean_false:
-      return "false";
   }
   return "<INVALID ENUM VALUE>";
 }

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -32,6 +32,8 @@ class cpp_code_generator {
 
   virtual std::string operator()(const ast::assign_temporary& x) const;
 
+  virtual std::string operator()(const ast::boolean_literal& x) const;
+
   virtual std::string operator()(const ast::branch& x) const;
 
   virtual std::string operator()(const ast::call_external_function& x) const;

--- a/components/core/wf/code_generation/ir_types.h
+++ b/components/core/wf/code_generation/ir_types.h
@@ -214,8 +214,9 @@ class jump_condition {
 // value arguments, but has an expression.
 class load {
  public:
-  using storage_type = std::variant<symbolic_constant, integer_constant, float_constant,
-                                    rational_constant, variable, custom_type_argument>;
+  using storage_type =
+      std::variant<symbolic_constant, integer_constant, float_constant, rational_constant,
+                   boolean_constant, variable, custom_type_argument>;
 
   constexpr static bool is_commutative() noexcept { return false; }
   constexpr static int num_value_operands() noexcept { return 0; }

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -173,6 +173,10 @@ std::string rust_code_generator::operator()(const ast::assign_temporary& x) cons
   return fmt::format("{} = {};", x.left, make_view(x.right));
 }
 
+std::string rust_code_generator::operator()(const ast::boolean_literal& x) const {
+  return x.value ? "true" : "false";
+}
+
 std::string rust_code_generator::operator()(const ast::branch& x) const {
   std::string result{};
   fmt::format_to(std::back_inserter(result), "if {} ", make_view(x.condition));
@@ -347,10 +351,6 @@ static constexpr std::string_view rust_string_for_symbolic_constant(
       return "std::f64::consts::E";
     case symbolic_constant_enum::pi:
       return "std::f64::consts::PI";
-    case symbolic_constant_enum::boolean_true:
-      return "true";
-    case symbolic_constant_enum::boolean_false:
-      return "false";
   }
   return "<INVALID ENUM VALUE>";
 }

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -32,6 +32,8 @@ class rust_code_generator {
 
   virtual std::string operator()(const ast::assign_temporary& x) const;
 
+  virtual std::string operator()(const ast::boolean_literal& x) const;
+
   virtual std::string operator()(const ast::branch& x) const;
 
   virtual std::string operator()(const ast::call_external_function& x) const;

--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -13,6 +13,7 @@ struct collect_visitor {
 
   scalar_expr operator()(const scalar_expr& x) { return visit(x, *this); }
   compound_expr operator()(const compound_expr& x) { return map_compound_expressions(x, *this); }
+  boolean_expr operator()(const boolean_expr& x) { return visit(x, *this); }
 
   template <typename T>
   auto recurse(const T& op) {
@@ -117,12 +118,12 @@ struct collect_visitor {
     return collect_addition_terms(std::move(children));
   }
 
+  boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) { return arg; }
   scalar_expr operator()(const compound_expression_element& el) { return el.map_children(*this); }
-
   scalar_expr operator()(const multiplication& mul, const scalar_expr&) { return recurse(mul); }
   scalar_expr operator()(const function& f) { return recurse(f); }
   scalar_expr operator()(const power& pow) { return recurse(pow); }
-  scalar_expr operator()(const cast_bool& cast) { return recurse(cast); }
+  scalar_expr operator()(const iverson_bracket& cast) { return recurse(cast); }
   scalar_expr operator()(const conditional& conditional) { return recurse(conditional); }
   scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const { return arg; }
   scalar_expr operator()(const derivative& diff, const scalar_expr&) { return recurse(diff); }
@@ -130,7 +131,7 @@ struct collect_visitor {
   scalar_expr operator()(const integer_constant&, const scalar_expr& arg) const { return arg; }
   scalar_expr operator()(const float_constant&, const scalar_expr& arg) const { return arg; }
   scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const { return arg; }
-  scalar_expr operator()(const relational& relation) { return recurse(relation); }
+  boolean_expr operator()(const relational& relation) { return recurse(relation); }
   scalar_expr operator()(const undefined&) const { return constants::undefined; }
   scalar_expr operator()(const variable&, const scalar_expr& arg) const { return arg; }
 

--- a/components/core/wf/constants.cc
+++ b/components/core/wf/constants.cc
@@ -12,10 +12,9 @@ const scalar_expr constants::pi = make_expr<symbolic_constant>(symbolic_constant
 const scalar_expr constants::euler = make_expr<symbolic_constant>(symbolic_constant_enum::euler);
 const scalar_expr constants::negative_one = make_expr<integer_constant>(-1);
 const scalar_expr constants::complex_infinity = make_expr<wf::complex_infinity>();
-const scalar_expr constants::boolean_true =
-    make_expr<symbolic_constant>(symbolic_constant_enum::boolean_true);
-const scalar_expr constants::boolean_false =
-    make_expr<symbolic_constant>(symbolic_constant_enum::boolean_false);
 const scalar_expr constants::undefined = make_expr<wf::undefined>();
+
+const boolean_expr constants::boolean_true{std::in_place_type_t<boolean_constant>{}, true};
+const boolean_expr constants::boolean_false{std::in_place_type_t<boolean_constant>{}, false};
 
 }  // namespace wf

--- a/components/core/wf/constants.h
+++ b/components/core/wf/constants.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "wf/boolean_expression.h"
 #include "wf/expression.h"
 
 namespace wf {
@@ -10,9 +11,10 @@ class constants {
   static const scalar_expr euler;
   static const scalar_expr negative_one;
   static const scalar_expr complex_infinity;
-  static const scalar_expr boolean_true;
-  static const scalar_expr boolean_false;
   static const scalar_expr undefined;
+
+  static const boolean_expr boolean_true;
+  static const boolean_expr boolean_false;
 };
 
 inline bool is_zero(const scalar_expr& expr) { return expr.is_identical_to(constants::zero); }

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -18,7 +18,6 @@ class derivative_visitor {
   scalar_expr apply(const scalar_expr& expression);
 
   scalar_expr operator()(const addition& add);
-  scalar_expr operator()(const cast_bool&, const scalar_expr& expr) const;
   scalar_expr operator()(const compound_expression_element&, const scalar_expr& expr) const;
   scalar_expr operator()(const conditional& cond);
   scalar_expr operator()(const symbolic_constant&) const;
@@ -28,6 +27,7 @@ class derivative_visitor {
   scalar_expr operator()(const function& func);
   scalar_expr operator()(const complex_infinity&) const;
   scalar_expr operator()(const integer_constant&) const;
+  scalar_expr operator()(const iverson_bracket&, const scalar_expr& arg) const;
   scalar_expr operator()(const float_constant&) const;
   scalar_expr operator()(const power& pow);
   scalar_expr operator()(const rational_constant&) const;

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -23,8 +23,16 @@ compound_expr distribute_visitor::operator()(const compound_expr& x) {
   return map_compound_expressions(x, *this);
 }
 
+boolean_expr distribute_visitor::operator()(const boolean_expr& x) { return visit(x, *this); }
+
 scalar_expr distribute_visitor::operator()(const addition& add) { return add.map_children(*this); }
-scalar_expr distribute_visitor::operator()(const cast_bool& cast) {
+
+boolean_expr distribute_visitor::operator()(const boolean_constant&,
+                                            const boolean_expr& arg) const {
+  return arg;
+}
+
+scalar_expr distribute_visitor::operator()(const iverson_bracket& cast) {
   return cast.map_children(*this);
 }
 scalar_expr distribute_visitor::operator()(const compound_expression_element& el) {
@@ -87,9 +95,11 @@ scalar_expr distribute_visitor::operator()(const power& pow) {
 scalar_expr distribute_visitor::operator()(const rational_constant&, const scalar_expr& arg) const {
   return arg;
 }
-scalar_expr distribute_visitor::operator()(const relational& relation) {
+
+boolean_expr distribute_visitor::operator()(const relational& relation) {
   return relation.map_children(*this);
 }
+
 scalar_expr distribute_visitor::operator()(const symbolic_constant&, const scalar_expr& arg) const {
   return arg;
 }

--- a/components/core/wf/distribute.h
+++ b/components/core/wf/distribute.h
@@ -14,9 +14,11 @@ class distribute_visitor {
  public:
   scalar_expr operator()(const scalar_expr& x);
   compound_expr operator()(const compound_expr& x);
+  boolean_expr operator()(const boolean_expr& x);
 
   scalar_expr operator()(const addition& add);
-  scalar_expr operator()(const cast_bool& cast);
+  boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) const;
+  scalar_expr operator()(const iverson_bracket& cast);
   scalar_expr operator()(const compound_expression_element& el);
   scalar_expr operator()(const complex_infinity&, const scalar_expr& arg) const;
   scalar_expr operator()(const conditional& conditional);
@@ -27,7 +29,7 @@ class distribute_visitor {
   scalar_expr operator()(const multiplication& mul);
   scalar_expr operator()(const power& pow);
   scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const;
-  scalar_expr operator()(const relational& relation);
+  boolean_expr operator()(const relational& relation);
   scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const;
   scalar_expr operator()(const undefined&) const;
   scalar_expr operator()(const variable&, const scalar_expr& arg) const;

--- a/components/core/wf/enumerations.h
+++ b/components/core/wf/enumerations.h
@@ -62,8 +62,6 @@ enum class relational_operation {
 enum class symbolic_constant_enum {
   euler,
   pi,
-  boolean_true,
-  boolean_false,
 };
 
 // Types of numeric values (at code-generation time).
@@ -195,10 +193,6 @@ constexpr std::string_view string_from_symbolic_constant(
       return "e";
     case symbolic_constant_enum::pi:
       return "pi";
-    case symbolic_constant_enum::boolean_true:
-      return "true";
-    case symbolic_constant_enum::boolean_false:
-      return "false";
   }
   return "<INVALID ENUM VALUE>";
 }

--- a/components/core/wf/evaluate.cc
+++ b/components/core/wf/evaluate.cc
@@ -5,8 +5,8 @@
 
 namespace wf {
 
-template <typename T, typename>
-scalar_expr evaluate_visitor::operator()(const T& input_typed, const scalar_expr& input) {
+template <typename T, typename X, typename>
+X evaluate_visitor::operator()(const T& input_typed, const X& input) {
   if constexpr (type_list_contains_v<T, derivative, complex_infinity>) {
     throw type_error("Cannot call eval on expression of type: {}", T::name_str);
   } else if constexpr (T::is_leaf_node) {
@@ -49,6 +49,8 @@ compound_expr evaluate_visitor::operator()(const compound_expr& input) {
   compound_cache_.emplace(input, result);
   return result;
 }
+
+boolean_expr evaluate_visitor::operator()(const boolean_expr& input) { return visit(input, *this); }
 
 scalar_expr evaluate(const scalar_expr& arg) { return evaluate_visitor{}(arg); }
 

--- a/components/core/wf/evaluate.h
+++ b/components/core/wf/evaluate.h
@@ -12,17 +12,19 @@ namespace wf {
 // Convert expressions to `float_constant` values.
 class evaluate_visitor {
  public:
-  template <typename T, typename = enable_if_does_not_contain_type_t<
-                            T, integer_constant, rational_constant, symbolic_constant>>
-  scalar_expr operator()(const T& input_typed, const scalar_expr& input);
+  template <typename T, typename X,
+            typename = enable_if_does_not_contain_type_t<T, integer_constant, rational_constant,
+                                                         symbolic_constant>>
+  X operator()(const T& input_typed, const X& input);
 
   scalar_expr operator()(const integer_constant& x) const;
   scalar_expr operator()(const rational_constant& x) const;
-  scalar_expr operator()(const symbolic_constant& x) const;
+  scalar_expr operator()(const symbolic_constant& c) const;
 
   // Visit and cache the result.
   scalar_expr operator()(const scalar_expr& input);
-  compound_expr operator()(const compound_expr& expr);
+  compound_expr operator()(const compound_expr& input);
+  boolean_expr operator()(const boolean_expr& input);
 
  private:
   // Cached evaluated values:

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -75,23 +75,23 @@ scalar_expr operator/(const scalar_expr& a, const scalar_expr& b) {
   return multiplication::from_operands({a, one_over_b});
 }
 
-scalar_expr operator<(const scalar_expr& a, const scalar_expr& b) {
+boolean_expr operator<(const scalar_expr& a, const scalar_expr& b) {
   return relational::create(relational_operation::less_than, a, b);
 }
 
-scalar_expr operator>(const scalar_expr& a, const scalar_expr& b) {
+boolean_expr operator>(const scalar_expr& a, const scalar_expr& b) {
   return relational::create(relational_operation::less_than, b, a);
 }
 
-scalar_expr operator<=(const scalar_expr& a, const scalar_expr& b) {
+boolean_expr operator<=(const scalar_expr& a, const scalar_expr& b) {
   return relational::create(relational_operation::less_than_or_equal, a, b);
 }
 
-scalar_expr operator>=(const scalar_expr& a, const scalar_expr& b) {
+boolean_expr operator>=(const scalar_expr& a, const scalar_expr& b) {
   return relational::create(relational_operation::less_than_or_equal, b, a);
 }
 
-scalar_expr operator==(const scalar_expr& a, const scalar_expr& b) {
+boolean_expr operator==(const scalar_expr& a, const scalar_expr& b) {
   return relational::create(relational_operation::equal, a, b);
 }
 

--- a/components/core/wf/expression_cache.h
+++ b/components/core/wf/expression_cache.h
@@ -1,0 +1,73 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include <tuple>
+#include <unordered_map>
+
+#include "wf/expression.h"
+#include "wf/matrix_expression.h"
+
+namespace wf {
+
+// When specified as the `OutputType` of the cache, the value type of each map in the cache will
+// match its key. This is so we can map `scalar_expr --> scalar_expr`, `boolean_expr -->
+// boolean_expr`, etc.
+struct output_is_input_t {};
+
+namespace detail {
+template <typename Key, typename Value>
+struct cache_map_type {
+  using type =
+      std::unordered_map<Key,
+                         std::conditional_t<std::is_same_v<Value, output_is_input_t>, Key, Value>,
+                         hash_struct<Key>, is_identical_struct<Key>>;
+};
+template <typename Key, typename Value>
+using cache_map_type_t = typename cache_map_type<Key, Value>::type;
+
+}  // namespace detail
+
+// Store a tuple of maps. There is one element in the tuple for every expression type.
+template <typename OutputType = output_is_input_t>
+class expression_cache {
+ private:
+  // Determine the value types we keep in the cache.
+  using expression_type_list = type_list<scalar_expr, boolean_expr, matrix_expr, compound_expr>;
+  template <typename Key>
+  using map_type_t = detail::cache_map_type_t<Key, OutputType>;
+  using tuple_type = tuple_from_type_list_t<type_list_map_t<map_type_t, expression_type_list>>;
+
+ public:
+  expression_cache() {
+    std::apply([](auto&... map) { (map.reserve(50), ...); }, storage_);
+  }
+
+  // Look-up `expression` in the cache. Return it if it exists, otherwise compute and insert a value
+  // by calling lambda `f`.
+  template <typename T, typename F>
+  const auto& get_or_insert(const T& expression, F&& f) {
+    // Figure out which map type `T` is stored in:
+    auto& map = std::get<type_list_index_v<T, expression_type_list>>(storage_);
+    if (auto it = map.find(expression); it != map.end()) {
+      return it->second;
+    }
+    const auto [insertion_it, _] = map.emplace(expression, f(expression));
+    return insertion_it->second;
+  }
+
+  // Find an element if an exists in the cache, otherwise return nullopt.
+  template <typename T>
+  auto find(const T& expression) const {
+    auto& map = std::get<type_list_index_v<T, expression_type_list>>(storage_);
+    using value_type = typename std::remove_reference_t<decltype(map)>::mapped_type;
+    if (auto it = map.find(expression); it != map.end()) {
+      // TODO: Add a version that does not copy into an optional?
+      return std::optional<value_type>{it->second};
+    }
+    return std::optional<value_type>{std::nullopt};
+  }
+
+ private:
+  tuple_type storage_;
+};
+
+}  // namespace wf

--- a/components/core/wf/expression_visitor.h
+++ b/components/core/wf/expression_visitor.h
@@ -82,6 +82,7 @@ compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
                              //  visit(...) here.
                              return overloaded_visit(
                                  arg, [&](const scalar_expr& x) -> any_expression { return f(x); },
+                                 [&](const boolean_expr& x) -> any_expression { return f(x); },
                                  [&](const matrix_expr& x) -> any_expression {
                                    matrix m = x.as_matrix().map_children(std::forward<F>(f));
                                    return matrix_expr(std::move(m));

--- a/components/core/wf/expressions/casts.h
+++ b/components/core/wf/expressions/casts.h
@@ -1,21 +1,19 @@
 // Copyright 2023 Gareth Cross
 #pragma once
-
 #include "wf/functions.h"
 #include "wf/hashing.h"
 
 namespace wf {
 
 // Cast a boolean value to an integer numerical value.
-class cast_bool {
+class iverson_bracket {
  public:
-  static constexpr std::string_view name_str = "CastBool";
+  static constexpr std::string_view name_str = "IversonBracket";
   static constexpr bool is_leaf_node = false;
 
-  explicit cast_bool(scalar_expr arg) noexcept(std::is_nothrow_move_constructible_v<scalar_expr>)
-      : arg_{std::move(arg)} {}
+  explicit iverson_bracket(boolean_expr arg) noexcept : arg_{std::move(arg)} {}
 
-  constexpr const scalar_expr& arg() const noexcept { return arg_[0]; }
+  constexpr const boolean_expr& arg() const noexcept { return arg_[0]; }
 
   // Iterators
   constexpr auto begin() const noexcept { return arg_.begin(); }
@@ -24,28 +22,28 @@ class cast_bool {
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {
-    return cast_int_from_bool(operation(arg_.front()));
+    return iverson(operation(arg_.front()));
   }
 
  private:
-  std::array<scalar_expr, 1> arg_;
+  std::array<boolean_expr, 1> arg_;
 };
 
 template <>
-struct hash_struct<cast_bool> {
-  std::size_t operator()(const cast_bool& cast) const { return hash(cast.arg()); }
+struct hash_struct<iverson_bracket> {
+  std::size_t operator()(const iverson_bracket& cast) const { return hash(cast.arg()); }
 };
 
 template <>
-struct is_identical_struct<cast_bool> {
-  bool operator()(const cast_bool& a, const cast_bool& b) const {
+struct is_identical_struct<iverson_bracket> {
+  bool operator()(const iverson_bracket& a, const iverson_bracket& b) const {
     return are_identical(a.arg(), b.arg());
   }
 };
 
 template <>
-struct order_struct<cast_bool> {
-  relative_order operator()(const cast_bool& a, const cast_bool& b) const {
+struct order_struct<iverson_bracket> {
+  relative_order operator()(const iverson_bracket& a, const iverson_bracket& b) const {
     return order_by(a.arg(), b.arg());
   }
 };

--- a/components/core/wf/expressions/conditional.cc
+++ b/components/core/wf/expressions/conditional.cc
@@ -5,8 +5,8 @@
 
 namespace wf {
 
-scalar_expr conditional::create(wf::scalar_expr condition, wf::scalar_expr if_branch,
-                                wf::scalar_expr else_branch) {
+scalar_expr conditional::create(boolean_expr condition, scalar_expr if_branch,
+                                scalar_expr else_branch) {
   if (condition.is_identical_to(constants::boolean_true)) {
     return if_branch;
   } else if (condition.is_identical_to(constants::boolean_false)) {
@@ -15,7 +15,8 @@ scalar_expr conditional::create(wf::scalar_expr condition, wf::scalar_expr if_br
     // If and else are the same anyway, so ignore the condition.
     return if_branch;
   }
-  return make_expr<conditional>(std::move(condition), std::move(if_branch), std::move(else_branch));
+  return scalar_expr(std::in_place_type_t<conditional>{}, std::move(condition),
+                     std::move(if_branch), std::move(else_branch));
 }
 
 }  // namespace wf

--- a/components/core/wf/expressions/conditional.h
+++ b/components/core/wf/expressions/conditional.h
@@ -10,13 +10,13 @@ class conditional {
   static constexpr std::string_view name_str = "Conditional";
   static constexpr bool is_leaf_node = false;
 
-  conditional(scalar_expr condition, scalar_expr if_branch, scalar_expr else_branch)
+  conditional(boolean_expr condition, scalar_expr if_branch, scalar_expr else_branch)
       : children_{std::move(condition), std::move(if_branch), std::move(else_branch)} {}
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
   scalar_expr map_children(Operation&& operation) const {
-    scalar_expr cond = operation(condition());
+    boolean_expr cond = operation(condition());
     if (cond.is_identical_to(constants::boolean_true)) {
       return operation(if_branch());
     } else if (cond.is_identical_to(constants::boolean_false)) {
@@ -26,22 +26,19 @@ class conditional {
   }
 
   // Create a new conditional.
-  static scalar_expr create(scalar_expr condition, scalar_expr if_branch, scalar_expr else_branch);
+  static scalar_expr create(boolean_expr condition, scalar_expr if_branch, scalar_expr else_branch);
 
-  constexpr const scalar_expr& condition() const noexcept { return children_[0]; }
-  constexpr const scalar_expr& if_branch() const noexcept { return children_[1]; }
-  constexpr const scalar_expr& else_branch() const noexcept { return children_[2]; }
-
-  constexpr auto begin() const noexcept { return children_.begin(); }
-  constexpr auto end() const noexcept { return children_.end(); }
+  constexpr const boolean_expr& condition() const noexcept { return std::get<0>(children_); }
+  constexpr const scalar_expr& if_branch() const noexcept { return std::get<1>(children_); }
+  constexpr const scalar_expr& else_branch() const noexcept { return std::get<2>(children_); }
 
  protected:
-  std::array<scalar_expr, 3> children_;
+  std::tuple<boolean_expr, scalar_expr, scalar_expr> children_;
 };
 
 template <>
 struct hash_struct<conditional> {
-  std::size_t operator()(const conditional& c) const {
+  std::size_t operator()(const conditional& c) const noexcept {
     return hash_args(0, c.condition(), c.if_branch(), c.else_branch());
   }
 };
@@ -49,14 +46,18 @@ struct hash_struct<conditional> {
 template <>
 struct is_identical_struct<conditional> {
   bool operator()(const conditional& a, const conditional& b) const {
-    return std::equal(a.begin(), a.end(), b.begin(), b.end(), is_identical_struct<scalar_expr>{});
+    return are_identical(a.condition(), b.condition()) &&
+           are_identical(a.if_branch(), b.if_branch()) &&
+           are_identical(a.else_branch(), b.else_branch());
   }
 };
 
 template <>
 struct order_struct<conditional> {
   relative_order operator()(const conditional& a, const conditional& b) const {
-    return wf::lexicographical_order(a, b, order_struct<scalar_expr>{});
+    return wf::order_by(a.condition(), b.condition())
+        .and_then_by(a.if_branch(), b.if_branch())
+        .and_then_by(a.else_branch(), b.else_branch());
   }
 };
 

--- a/components/core/wf/expressions/relational.cc
+++ b/components/core/wf/expressions/relational.cc
@@ -95,16 +95,17 @@ struct RelationalSimplification {
   relational_operation operation_;
 };
 
-scalar_expr relational::create(relational_operation operation, scalar_expr left,
-                               scalar_expr right) {
+boolean_expr relational::create(relational_operation operation, scalar_expr left,
+                                scalar_expr right) {
   if (is_complex_infinity(left) || is_complex_infinity(right) || is_undefined(left) ||
       is_undefined(right)) {
     throw type_error("Cannot construct relational with types: {} {} {}", left.type_name(),
                      string_from_relational_operation(operation), right.type_name());
   }
+
   // See if this relational automatically simplifies to a boolean constant:
-  const tri_state simplified = visit_binary(left, right, RelationalSimplification{operation});
-  if (simplified == tri_state::True) {
+  if (const tri_state simplified = visit_binary(left, right, RelationalSimplification{operation});
+      simplified == tri_state::True) {
     return constants::boolean_true;
   } else if (simplified == tri_state::False) {
     return constants::boolean_false;
@@ -115,7 +116,8 @@ scalar_expr relational::create(relational_operation operation, scalar_expr left,
       std::swap(left, right);
     }
   }
-  return make_expr<relational>(operation, std::move(left), std::move(right));
+  return boolean_expr(std::in_place_type_t<relational>{}, operation, std::move(left),
+                      std::move(right));
 }
 
 }  // namespace wf

--- a/components/core/wf/expressions/relational.h
+++ b/components/core/wf/expressions/relational.h
@@ -1,5 +1,6 @@
 // Copyright 2023 Gareth Cross
 #pragma once
+#include "wf/boolean_expression.h"
 #include "wf/expression.h"
 
 namespace wf {
@@ -15,12 +16,12 @@ class relational {
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  scalar_expr map_children(Operation&& operation) const {
+  boolean_expr map_children(Operation&& operation) const {
     return relational::create(operation_, operation(left()), operation(right()));
   }
 
   // Create a relational operation.
-  static scalar_expr create(relational_operation operation, scalar_expr left, scalar_expr right);
+  static boolean_expr create(relational_operation operation, scalar_expr left, scalar_expr right);
 
   constexpr relational_operation operation() const noexcept { return operation_; }
   constexpr const scalar_expr& left() const noexcept { return children_[0]; }

--- a/components/core/wf/external_function.cc
+++ b/components/core/wf/external_function.cc
@@ -77,6 +77,9 @@ any_expression external_function::create_invocation(std::vector<any_expression> 
           // TODO: Check numeric type here.
           return scalar_type(code_numeric_type::floating_point);
         },
+        [&](const boolean_expr&) -> type_variant {
+          return scalar_type(code_numeric_type::boolean);
+        },
         [&](const matrix_expr& matrix) -> type_variant {
           return matrix_type(matrix.rows(), matrix.cols());
         },

--- a/components/core/wf/external_function.h
+++ b/components/core/wf/external_function.h
@@ -10,7 +10,7 @@ namespace wf {
 
 // Variant of possible expression types.
 // TODO: This should be declared somewhere more general.
-using any_expression = std::variant<scalar_expr, matrix_expr, compound_expr>;
+using any_expression = std::variant<scalar_expr, matrix_expr, compound_expr, boolean_expr>;
 
 template <>
 struct hash_struct<any_expression> : hash_variant<any_expression> {};

--- a/components/core/wf/functions.h
+++ b/components/core/wf/functions.h
@@ -51,14 +51,15 @@ scalar_expr max(const scalar_expr& a, const scalar_expr& b);
 scalar_expr min(const scalar_expr& a, const scalar_expr& b);
 
 // Conditional/ternary expression.
-scalar_expr where(const scalar_expr& condition, const scalar_expr& if_true,
+scalar_expr where(const boolean_expr& condition, const scalar_expr& if_true,
                   const scalar_expr& if_false);
 
 // Conditional over a matrix w/ scalar condition.
-matrix_expr where(const scalar_expr& condition, const matrix_expr& if_true,
+matrix_expr where(const boolean_expr& condition, const matrix_expr& if_true,
                   const matrix_expr& if_false);
 
-// Cast the provided expression from a boolean to an integer.
-scalar_expr cast_int_from_bool(const scalar_expr& bool_expression);
+// Iverson bracket: Cast the provided expression from a boolean to an integer.
+// Evaluates to 1 if bool_expression is true, and 0 if bool_expression is false.
+scalar_expr iverson(const boolean_expr& bool_expression);
 
 }  // namespace wf

--- a/components/core/wf/limits.cc
+++ b/components/core/wf/limits.cc
@@ -96,12 +96,8 @@ class limit_visitor {
     return std::nullopt;
   }
 
-  std::optional<scalar_expr> operator()(const cast_bool& cast) {
-    std::optional<scalar_expr> arg = visit(cast.arg());
-    if (!arg) {
-      return std::nullopt;
-    }
-    return cast_int_from_bool(*arg);
+  std::optional<scalar_expr> operator()(const iverson_bracket&) const {
+    throw type_error("Not handled.");
   }
 
   std::optional<scalar_expr> operator()(const conditional&) const {
@@ -376,8 +372,6 @@ class limit_visitor {
       return std::nullopt;
     }
 
-    WF_ASSERT(!exp_sub.is_identical_to(constants::boolean_false));
-
     if (is_zero(exp_sub) && (is_inf(base_sub) || is_zero(base_sub))) {
       // 0 ^ 0 is an indeterminate form, and ∞ ^ 0
       // lim[x->c] f(x)^g(x) = e ^ (lim[x->c] g(x) * log(f(x)))
@@ -492,17 +486,8 @@ class limit_visitor {
     return process_power(pow.base(), pow.exponent());
   }
 
-  std::optional<scalar_expr> operator()(const relational& rel, const scalar_expr&) {
-    // For relationals, we do a substitution:
-    std::optional<scalar_expr> left = visit(rel.left());
-    if (!left) {
-      return std::nullopt;
-    }
-    std::optional<scalar_expr> right = visit(rel.right());
-    if (!right) {
-      return std::nullopt;
-    }
-    return relational::create(rel.operation(), std::move(*left), std::move(*right));
+  std::optional<scalar_expr> operator()(const relational&, const scalar_expr&) {
+    throw type_error("Unhandled!");
   }
 
   std::optional<scalar_expr> operator()(const undefined&) const { return constants::undefined; }

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -51,7 +51,7 @@ class determine_set_visitor {
     return handle_add_or_mul(add, &combine_sets_add);
   }
 
-  constexpr number_set operator()(const cast_bool&) const noexcept {
+  constexpr number_set operator()(const iverson_bracket&) const noexcept {
     return number_set::real_non_negative;
   }
 
@@ -83,10 +83,7 @@ class determine_set_visitor {
     return std::max(left, right);
   }
 
-  constexpr number_set operator()(const symbolic_constant& c) const noexcept {
-    if (c.name() == symbolic_constant_enum::boolean_false) {
-      return number_set::real_non_negative;
-    }
+  constexpr number_set operator()(const symbolic_constant&) const noexcept {
     return number_set::real_positive;
   }
 

--- a/components/core/wf/operations.h
+++ b/components/core/wf/operations.h
@@ -8,11 +8,14 @@
 namespace wf {
 class scalar_expr;
 class matrix_expr;
+class boolean_expr;
 
 // Replace instances of `target` w/ `replacement` in the input expression tree `input`.
 // Implemented in substitute.cc
 scalar_expr substitute(const scalar_expr& input, const scalar_expr& target,
                        const scalar_expr& replacement);
+boolean_expr substitute(const boolean_expr& input, const scalar_expr& target,
+                        const scalar_expr& replacement);
 
 // Replace all the [target, replacement] pairs in the input expression tree `input`.
 // Every `target` must be a variable.

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -9,8 +9,9 @@
 
 namespace wf {
 
-void plain_formatter::operator()(const scalar_expr& x) { return visit(x, *this); }
-void plain_formatter::operator()(const matrix_expr& x) { operator()(x.as_matrix()); }
+void plain_formatter::operator()(const scalar_expr& x) { visit(x, *this); }
+void plain_formatter::operator()(const matrix_expr& x) { visit(x, *this); }
+void plain_formatter::operator()(const boolean_expr& x) { visit(x, *this); }
 
 void plain_formatter::operator()(const addition& expr) {
   WF_ASSERT_GREATER_OR_EQ(expr.size(), 2);
@@ -62,10 +63,13 @@ void plain_formatter::operator()(const addition& expr) {
   }
 }
 
-void plain_formatter::operator()(const cast_bool& cast) {
-  output_ += "cast(";
-  visit(cast.arg(), *this);
-  output_ += ")";
+void plain_formatter::operator()(const boolean_constant& b) {
+  if (b) {
+    // Capitalized for consistency with python.
+    output_ += "True";
+  } else {
+    output_ += "False";
+  }
 }
 
 void plain_formatter::operator()(const compound_expression_element& el) {
@@ -162,6 +166,12 @@ void plain_formatter::operator()(const complex_infinity&) {
 
 void plain_formatter::operator()(const integer_constant& expr) {
   fmt::format_to(std::back_inserter(output_), "{}", expr.get_value());
+}
+
+void plain_formatter::operator()(const iverson_bracket& bracket) {
+  output_ += "iverson(";
+  visit(bracket.arg(), *this);
+  output_ += ")";
 }
 
 void plain_formatter::operator()(const float_constant& expr) {

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -10,9 +10,10 @@ class plain_formatter {
  public:
   void operator()(const scalar_expr& x);
   void operator()(const matrix_expr& x);
+  void operator()(const boolean_expr& x);
 
   void operator()(const addition& add);
-  void operator()(const cast_bool& cast);
+  void operator()(const boolean_constant& b);
   void operator()(const compound_expression_element& el);
   void operator()(const external_function_invocation& invocation);
   void operator()(const custom_type_argument& arg);
@@ -23,6 +24,7 @@ class plain_formatter {
   void operator()(const float_constant& num);
   void operator()(const complex_infinity&);
   void operator()(const integer_constant& num);
+  void operator()(const iverson_bracket& bracket);
   void operator()(const class matrix& mat);
   void operator()(const multiplication& mul);
   void operator()(const power& pow);

--- a/components/core/wf/substitute.h
+++ b/components/core/wf/substitute.h
@@ -29,9 +29,10 @@ class substitute_variables_visitor {
   scalar_expr operator()(const scalar_expr& expression);
   matrix_expr operator()(const matrix_expr& expression);
   compound_expr operator()(const compound_expr& expression);
+  boolean_expr operator()(const boolean_expr& expression);
 
-  template <typename T>
-  scalar_expr operator()(const T& concrete, const scalar_expr& abstract);
+  template <typename T, typename X>
+  X operator()(const T& concrete, const X& abstract);
 
  private:
   std::unordered_map<variable, scalar_expr, hash_struct<variable>, is_identical_struct<variable>>

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -17,15 +17,15 @@ namespace wf {
 void tree_formatter_visitor::operator()(const scalar_expr& x) { visit(x, *this); }
 void tree_formatter_visitor::operator()(const matrix_expr& m) { visit(m, *this); }
 void tree_formatter_visitor::operator()(const compound_expr& c) { visit(c, *this); }
+void tree_formatter_visitor::operator()(const boolean_expr& b) { visit(b, *this); }
 
 void tree_formatter_visitor::operator()(const addition& add) {
   format_append("{}:", addition::name_str);
   visit_all(add.sorted_terms());
 }
 
-void tree_formatter_visitor::operator()(const cast_bool& cast) {
-  format_append("{}:", cast_bool::name_str);
-  visit_right(cast.arg());
+void tree_formatter_visitor::operator()(const boolean_constant& b) {
+  format_append("{} ({})", boolean_constant::name_str, b.value() ? "true" : "false");
 }
 
 void tree_formatter_visitor::operator()(const complex_infinity&) {
@@ -39,7 +39,9 @@ void tree_formatter_visitor::operator()(const compound_expression_element& el) {
 
 void tree_formatter_visitor::operator()(const conditional& conditional) {
   format_append("{}:", conditional::name_str);
-  visit_all(conditional);
+  visit_left(conditional.condition());
+  visit_left(conditional.if_branch());
+  visit_right(conditional.else_branch());
 }
 
 void tree_formatter_visitor::operator()(const custom_type_argument& arg) {
@@ -74,6 +76,11 @@ void tree_formatter_visitor::operator()(const function& func) {
 
 void tree_formatter_visitor::operator()(const integer_constant& i) {
   format_append("{} ({})", integer_constant::name_str, i.get_value());
+}
+
+void tree_formatter_visitor::operator()(const iverson_bracket& bracket) {
+  format_append("{}:", iverson_bracket::name_str);
+  visit_all(bracket);
 }
 
 void tree_formatter_visitor::operator()(const matrix& mat) {

--- a/components/core/wf/tree_formatter.h
+++ b/components/core/wf/tree_formatter.h
@@ -1,5 +1,7 @@
 // Copyright 2024 Gareth Cross
 #pragma once
+#include "expressions/special_constants.h"
+
 #include <vector>
 
 #include "wf/compound_expression.h"
@@ -14,9 +16,10 @@ class tree_formatter_visitor {
   void operator()(const scalar_expr& x);
   void operator()(const matrix_expr& m);
   void operator()(const compound_expr& c);
+  void operator()(const boolean_expr& b);
 
   void operator()(const addition& add);
-  void operator()(const cast_bool& cast);
+  void operator()(const boolean_constant& b);
   void operator()(const complex_infinity&);
   void operator()(const compound_expression_element& el);
   void operator()(const conditional& conditional);
@@ -27,6 +30,7 @@ class tree_formatter_visitor {
   void operator()(const float_constant& f);
   void operator()(const function& func);
   void operator()(const integer_constant& i);
+  void operator()(const iverson_bracket& bracket);
   void operator()(const matrix& mat);
   void operator()(const multiplication& op);
   void operator()(const power& pow);

--- a/components/core/wf/type_list.h
+++ b/components/core/wf/type_list.h
@@ -127,6 +127,16 @@ struct type_list_from_tuple<std::tuple<Ts...>> {
   using type = type_list<Ts...>;
 };
 
+// Create a tuple from a type list.
+template <typename T>
+struct tuple_from_type_list;
+template <typename T>
+using tuple_from_type_list_t = typename tuple_from_type_list<T>::type;
+template <typename... Ts>
+struct tuple_from_type_list<type_list<Ts...>> {
+  using type = std::tuple<Ts...>;
+};
+
 // Perform a map on a type list, and produce a new type list.
 template <template <typename...> typename Map, typename T>
 struct type_list_map;

--- a/components/wrapper/pywrenfold/CMakeLists.txt
+++ b/components/wrapper/pywrenfold/CMakeLists.txt
@@ -103,12 +103,13 @@ add_wrapper_module(
   NAME
   "wf_wrapper"
   SOURCES
-  expression_wrapper.cc
-  matrix_wrapper.cc
-  codegen_wrapper.cc
+  boolean_expression_wrapper.cc
   code_formatting_wrapper.cc
+  codegen_wrapper.cc
   compound_expression_wrapper.cc
+  expression_wrapper.cc
   geometry_wrapper.cc
+  matrix_wrapper.cc
   wrapper_utils.h
   SUB_MODULE_NAMES
   codegen

--- a/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
@@ -1,0 +1,43 @@
+// Copyright 2024 Gareth Cross
+
+#define PYBIND11_DETAILED_ERROR_MESSAGES
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "wf/boolean_expression.h"
+#include "wf/constants.h"
+#include "wf/expressions/special_constants.h"
+
+#include "wrapper_utils.h"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace wf {
+
+static bool coerce_to_bool(const boolean_expr& self) {
+  if (const boolean_constant* constant = cast_ptr<const boolean_constant>(self);
+      constant != nullptr) {
+    return constant->value();
+  } else {
+    throw type_error(
+        "Expression of type `{}` cannot be coerced to boolean. Only expressions sym.true "
+        "and sym.false can be evaluated for truthiness.",
+        self.type_name());
+  }
+}
+
+void wrap_boolean_expression(py::module_& m) {
+  wrap_class<boolean_expr>(m, "BooleanExpr")
+      .def("__repr__", &boolean_expr::to_string)
+      .def("expression_tree_str", &boolean_expr::to_expression_tree_string,
+           py::doc("Retrieve the expression tree as a pretty-printed string."))
+      .def_property_readonly("type_name", [](const boolean_expr& self) { return self.type_name(); })
+      .def("__bool__", &coerce_to_bool, py::doc("Coerce expression to boolean."));
+
+  // We need to declare these here so that boolean_expr is available in `m`.
+  m.attr("true") = constants::boolean_true;
+  m.attr("false") = constants::boolean_false;
+}
+
+}  // namespace wf

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -403,6 +403,9 @@ void wrap_codegen_operations(py::module_& m) {
           "value", [](const ast::assign_output_struct& x) -> const auto& { return x.value; },
           py::return_value_policy::reference_internal);
 
+  wrap_ast_type<ast::boolean_literal>(m).def_property_readonly(
+      "value", [](const ast::boolean_literal& b) { return b.value; });
+
   wrap_ast_type<ast::branch>(m)
       .def_property_readonly("condition", to_inner_accessor(&ast::branch::condition),
                              py::keep_alive<0, 1>())

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -522,7 +522,7 @@ void wrap_matrix_operations(py::module_& m) {
 
   // Version of where() for matrices
   m.def("where",
-        static_cast<matrix_expr (*)(const scalar_expr&, const matrix_expr&, const matrix_expr&)>(
+        static_cast<matrix_expr (*)(const boolean_expr&, const matrix_expr&, const matrix_expr&)>(
             &wf::where),
         "condition"_a, "if_true"_a, "if_false"_a, "If-else statement with matrix operands.");
 


### PR DESCRIPTION
This change separates out boolean expressions into a new expression type, `boolean_expr`. Previously they were just treated as `scalar_expr`, but this introduces some issues:
- Lack of type safety. Previously you can just implicitly add/mul/divide together boolean values, which is confusing and increases the surface area for bugs 
- It meant any future "logical" operations (like and/or) would need to type-check their arguments to make sure you weren't doing logical operations on float values. This entails adding hand-written logic, when instead we can just use the type system to avoid this.

In general, boolean values and their usages are sufficiently "special" compared to scalars that they deserve their own type.

Supporting changes:
- Rename `cast_bool_to_int` to [iverson bracket](https://en.wikipedia.org/wiki/Iverson_bracket).
- Add `expression_cache` which can store cached results for any of the four expression types: `scalar_expr`, `boolean_expr`, `matrix_expr`, and `compound_expr`.
- Add `ast::boolean_literal` to represent true/false in generated code.

This change does not add any of the missing logical operations yet (that will be a follow up PR). I just introduced the new type, and got every test passing with existing code.