### PR TITLE
Cleanup some uses of matrix visitors

### DIFF
--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -14,6 +14,7 @@ struct collect_visitor {
   scalar_expr operator()(const scalar_expr& x) { return visit(x, *this); }
   compound_expr operator()(const compound_expr& x) { return map_compound_expressions(x, *this); }
   boolean_expr operator()(const boolean_expr& x) { return visit(x, *this); }
+  matrix_expr operator()(const matrix_expr& x) { return map_matrix_expression(x, *this); }
 
   template <typename T>
   auto recurse(const T& op) {
@@ -40,8 +41,8 @@ struct collect_visitor {
             std::optional<scalar_expr> exponent;
             const auto it =
                 std::find_if(mul->begin(), mul->end(), [&](const scalar_expr& mul_term) {
-                  auto [base, exp] = as_base_and_exp(mul_term);
-                  if (base.is_identical_to(collected_term)) {
+                  if (auto [base, exp] = as_base_and_exp(mul_term);
+                      base.is_identical_to(collected_term)) {
                     // found the base we want
                     exponent = std::move(exp);
                     return true;
@@ -118,7 +119,7 @@ struct collect_visitor {
     return collect_addition_terms(std::move(children));
   }
 
-  boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) { return arg; }
+  boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) const { return arg; }
   scalar_expr operator()(const compound_expression_element& el) { return el.map_children(*this); }
   scalar_expr operator()(const multiplication& mul, const scalar_expr&) { return recurse(mul); }
   scalar_expr operator()(const function& f) { return recurse(f); }

--- a/components/core/wf/distribute.h
+++ b/components/core/wf/distribute.h
@@ -1,9 +1,6 @@
 // Copyright 2024 Gareth Cross
 #pragma once
-#include <unordered_map>
-
-#include "wf/compound_expression.h"
-#include "wf/expression.h"
+#include "wf/expression_cache.h"
 
 namespace wf {
 
@@ -12,9 +9,10 @@ namespace wf {
 // (a + b)^2 = a^2 + 2*a*b + b^2
 class distribute_visitor {
  public:
-  scalar_expr operator()(const scalar_expr& x);
-  compound_expr operator()(const compound_expr& x);
-  boolean_expr operator()(const boolean_expr& x);
+  scalar_expr operator()(const scalar_expr& input);
+  compound_expr operator()(const compound_expr& input);
+  boolean_expr operator()(const boolean_expr& input);
+  matrix_expr operator()(const matrix_expr& input);
 
   scalar_expr operator()(const addition& add);
   boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) const;
@@ -44,9 +42,7 @@ class distribute_visitor {
   template <typename Container>
   scalar_expr distribute_multiplied_terms(const Container& multiplied_terms);
 
-  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
-                     is_identical_struct<scalar_expr>>
-      cache_;
+  wf::expression_cache<> cache_;
 };
 
 }  // namespace wf

--- a/components/core/wf/evaluate.h
+++ b/components/core/wf/evaluate.h
@@ -1,11 +1,11 @@
 // Copyright 2023 Gareth Cross
 #pragma once
-
 #include <unordered_map>
 
-#include "compound_expression.h"
+#include "wf/compound_expression.h"
 #include "wf/expression.h"
-#include "wf/hashing.h"
+#include "wf/expression_cache.h"
+#include "wf/matrix_expression.h"
 
 namespace wf {
 
@@ -25,16 +25,10 @@ class evaluate_visitor {
   scalar_expr operator()(const scalar_expr& input);
   compound_expr operator()(const compound_expr& input);
   boolean_expr operator()(const boolean_expr& input);
+  matrix_expr operator()(const matrix_expr& input);
 
  private:
-  // Cached evaluated values:
-  // TODO: Introduce a cache type that can accept any expression type.
-  std::unordered_map<scalar_expr, scalar_expr, hash_struct<scalar_expr>,
-                     is_identical_struct<scalar_expr>>
-      cache_;
-  std::unordered_map<compound_expr, compound_expr, hash_struct<compound_expr>,
-                     is_identical_struct<compound_expr>>
-      compound_cache_;
+  wf::expression_cache<> cache_;
 };
 
 }  // namespace wf

--- a/components/core/wf/expression_cache.h
+++ b/components/core/wf/expression_cache.h
@@ -3,6 +3,8 @@
 #include <tuple>
 #include <unordered_map>
 
+#include "wf/boolean_expression.h"
+#include "wf/compound_expression.h"
 #include "wf/expression.h"
 #include "wf/matrix_expression.h"
 
@@ -37,9 +39,7 @@ class expression_cache {
   using tuple_type = tuple_from_type_list_t<type_list_map_t<map_type_t, expression_type_list>>;
 
  public:
-  expression_cache() {
-    std::apply([](auto&... map) { (map.reserve(50), ...); }, storage_);
-  }
+  expression_cache() { std::get<0>(storage_).reserve(50); }
 
   // Look-up `expression` in the cache. Return it if it exists, otherwise compute and insert a value
   // by calling lambda `f`.

--- a/components/core/wf/expressions/matrix.cc
+++ b/components/core/wf/expressions/matrix.cc
@@ -1,11 +1,21 @@
 // Copyright 2023 Gareth Cross
 #include "wf/expressions/matrix.h"
 
+#include "wf/assertions.h"
 #include "wf/expression_visitor.h"
 #include "wf/expressions/addition.h"
-#include "wf/matrix_functions.h"
 
 namespace wf {
+
+matrix::matrix(const index_t rows, const index_t cols, container_type data)
+    : rows_(rows), cols_(cols), data_(std::move(data)) {
+  if (data_.size() != static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_)) {
+    throw dimension_error("Mismatch between shape and # of elements. size = {}, shape = [{}, {}]",
+                          data_.size(), rows_, cols_);
+  }
+  WF_ASSERT_GREATER_OR_EQ(rows_, 0);
+  WF_ASSERT_GREATER_OR_EQ(cols_, 0);
+}
 
 matrix matrix::get_block(const index_t row, const index_t col, const index_t nrows,
                          const index_t ncols) const {

--- a/components/core/wf/expressions/matrix.h
+++ b/components/core/wf/expressions/matrix.h
@@ -3,9 +3,8 @@
 #include <vector>
 
 #include "wf/algorithm_utils.h"
-#include "wf/assertions.h"
 #include "wf/error_types.h"
-#include "wf/expression.h"
+#include "wf/matrix_expression.h"
 
 namespace wf {
 
@@ -18,21 +17,13 @@ class matrix {
   using container_type = std::vector<scalar_expr>;
 
   // Construct from data vector.
-  matrix(index_t rows, index_t cols, container_type data)
-      : rows_(rows), cols_(cols), data_(std::move(data)) {
-    if (data_.size() != static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_)) {
-      throw dimension_error("Mismatch between shape and # of elements. size = {}, shape = [{}, {}]",
-                            data_.size(), rows_, cols_);
-    }
-    WF_ASSERT_GREATER_OR_EQ(rows_, 0);
-    WF_ASSERT_GREATER_OR_EQ(cols_, 0);
-  }
+  matrix(index_t rows, index_t cols, container_type data);
 
   // Implement ExpressionImpl::Map
   template <typename Operation>
-  matrix map_children(Operation&& operation) const {
-    return {rows(), cols(),
-            transform_map<container_type>(data_, std::forward<Operation>(operation))};
+  matrix_expr map_children(Operation&& operation) const {
+    return matrix_expr{std::in_place_type_t<matrix>{}, rows(), cols(),
+                       transform_map<container_type>(data_, std::forward<Operation>(operation))};
   }
 
   // Access element in a vector. Only valid if `cols` or `rows` is 1.

--- a/components/core/wf/geometry/quaternion.cc
+++ b/components/core/wf/geometry/quaternion.cc
@@ -177,7 +177,7 @@ quaternion quaternion::from_rotation_matrix(const matrix_expr& R_in) {
 }
 
 matrix_expr quaternion::jacobian(const wf::matrix_expr& vars,
-                                 non_differentiable_behavior behavior) const {
+                                 const non_differentiable_behavior behavior) const {
   if (vars.rows() != 1 && vars.cols() != 1) {
     throw dimension_error("Variables must be a row or column vector. Received dimensions: [{}, {}]",
                           vars.rows(), vars.cols());


### PR DESCRIPTION
- Cleanup some usages of `as_matrix()` and replace them with `map_matrix_expression`.
- Use `expression_cache` in a few more places.