### PR TITLE
Fix issue with improperly formatted negatives in power operations

### DIFF
--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -176,9 +176,15 @@ inline testing::AssertionResult expect_complex_near(const std::string_view name_
   }
 }
 
-// ostream operator for `NumericSet`.
+// ostream operator for `number_set`.
 inline std::ostream& operator<<(std::ostream& s, const number_set set) {
   s << string_from_number_set(set);
+  return s;
+}
+
+// ostream operator for `precedence`
+inline std::ostream& operator<<(std::ostream& s, const precedence p) {
+  s << string_from_precedence(p);
   return s;
 }
 

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -73,9 +73,8 @@ TEST(PlainFormatterTest, TestMultiplication) {
 }
 
 TEST(PlainFormatterTest, TestPower) {
-  const scalar_expr x{"x"};
-  const scalar_expr y{"y"};
-  const scalar_expr z{"z"};
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+
   ASSERT_STR_EQ("x ** y", pow(x, y));
   ASSERT_STR_EQ("8", pow(2, 3));
   ASSERT_STR_EQ("(x + y) ** z", pow(x + y, z));
@@ -88,6 +87,11 @@ TEST(PlainFormatterTest, TestPower) {
   ASSERT_STR_EQ("-5 ** (2 / 3) * 7 ** (2 / 3) + x - y * z",
                 pow(5 * 7, 2 / 3_s) * constants::negative_one + x - y * z);
   ASSERT_STR_EQ("-I ** (3 / 2)", pow(constants::imaginary_unit, 7_s / 2));
+
+  // Make sure we add brackets when the base is a negative number:
+  ASSERT_STR_EQ("(-3) ** x", pow(-3, x));
+  ASSERT_STR_EQ("(-3.12) ** x", pow(-3.12, x));
+  ASSERT_STR_EQ("(-4 / 5) ** x", pow(-4_s / 5, x));
 }
 
 TEST(PlainFormatterTest, TestRelationals) {

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -35,11 +35,14 @@ TEST(ScalarOperationsTest, TestAddition) {
   const scalar_expr y{"y"};
   const scalar_expr z{"z"};
   ASSERT_TRUE((x + y).is_type<addition>());
+  ASSERT_TRUE((x - y).is_type<addition>());
   ASSERT_IDENTICAL(x + y, x + y);
   ASSERT_IDENTICAL(x + y, y + x);
   ASSERT_NOT_IDENTICAL(x + w, x + y);
   ASSERT_NOT_IDENTICAL(x - w, z + y);
   ASSERT_EQ("Addition", (x + y).type_name());
+  ASSERT_EQ(precedence::addition, get_precedence(x + y));
+  ASSERT_EQ(precedence::addition, get_precedence(x - y));
 
   // Canonicalization of order:
   ASSERT_IDENTICAL(w + x + y, y + x + w);
@@ -95,6 +98,7 @@ TEST(ScalarOperationsTest, TestMultiplication) {
   ASSERT_TRUE((x * y).is_type<multiplication>());
   ASSERT_IDENTICAL(x * y, x * y);
   ASSERT_EQ("Multiplication", (x * y).type_name());
+  ASSERT_EQ(precedence::multiplication, get_precedence(x * y));
 
   // Canonicalization of order for a simple case:
   ASSERT_IDENTICAL(y * x, x * y);
@@ -212,6 +216,7 @@ TEST(ScalarOperationsTest, TestDivision) {
   const scalar_expr z{"z"};
   ASSERT_IDENTICAL(x / y, x / y);
   ASSERT_TRUE((x / y).is_type<multiplication>());
+  ASSERT_EQ(precedence::multiplication, get_precedence(x / y));
   ASSERT_NOT_IDENTICAL(y / x, x / y);
   ASSERT_IDENTICAL(x / y / z, (x / y) / z);
   ASSERT_IDENTICAL(constants::zero, 0 / x);

--- a/components/core/wf/enumerations.h
+++ b/components/core/wf/enumerations.h
@@ -152,6 +152,23 @@ constexpr std::string_view string_from_relative_order(const relative_order order
   return "<NOT A VALID ENUM VALUE>";
 }
 
+// Convert `precedence` to string view.
+constexpr std::string_view string_from_precedence(const precedence p) noexcept {
+  switch (p) {
+    case precedence::relational:
+      return "relational";
+    case precedence::addition:
+      return "addition";
+    case precedence::multiplication:
+      return "multiplication";
+    case precedence::power:
+      return "power";
+    case precedence::none:
+      return "none";
+  }
+  return "<NOT A VALID ENUM VALUE>";
+}
+
 // Convert unary function enum to string.
 constexpr std::string_view string_from_built_in_function(const built_in_function name) noexcept {
   switch (name) {

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -108,7 +108,7 @@ boolean_expr operator==(const scalar_expr& a, const scalar_expr& b) {
 // Visitor to determine mathematical precedence.
 struct precedence_visitor {
   template <typename T>
-  constexpr precedence operator()(const T&) const noexcept {
+  constexpr precedence operator()(const T& value) const noexcept {
     if constexpr (std::is_same_v<multiplication, T>) {
       return precedence::multiplication;
     } else if constexpr (std::is_same_v<addition, T>) {
@@ -119,6 +119,9 @@ struct precedence_visitor {
       return precedence::multiplication;
     } else if constexpr (std::is_same_v<relational, T>) {
       return precedence::relational;
+    } else if constexpr (type_list_contains_v<T, integer_constant, rational_constant,
+                                              float_constant>) {
+      return value.is_negative() ? precedence::multiplication : precedence::none;
     } else {
       return precedence::none;
     }

--- a/components/core/wf/expressions/variable.h
+++ b/components/core/wf/expressions/variable.h
@@ -95,7 +95,8 @@ class variable {
   std::string to_string() const;
 
   // Create a function argument expression.
-  static scalar_expr create_function_argument(std::size_t arg_index, std::size_t element_index) {
+  static scalar_expr create_function_argument(const std::size_t arg_index,
+                                              const std::size_t element_index) {
     // TODO: Support creating function arguments that are not real.
     return make_expr<variable>(function_argument_variable(arg_index, element_index),
                                number_set::real);

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -44,7 +44,7 @@ class plain_formatter {
   void format_precedence(precedence parent, const scalar_expr& expr);
 
   // Format power operation with the appropriate operator.
-  void format_power(const scalar_expr& Base, const scalar_expr& Exponent);
+  void format_power(const scalar_expr& base, const scalar_expr& exponent);
 
   std::string output_{};
 };

--- a/components/wrapper/python_test/expression_wrapper_test.py
+++ b/components/wrapper/python_test/expression_wrapper_test.py
@@ -85,7 +85,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertReprEqual('cosh(x) * sinh(z)', sym.cosh(x) * sym.sinh(z))
         self.assertReprEqual('2 + tanh(z)', 2 + sym.tanh(z))
         self.assertReprEqual('x ** (1 / 2)', sym.sqrt(x))
-        self.assertReprEqual('3 ** (1 / 2) * 7 ** (1 / 2) * x ** (1 / 2) * (z ** -1) ** (1 / 2)',
+        self.assertReprEqual('3 ** (1 / 2) * 7 ** (1 / 2) * x ** (1 / 2) * (z ** (-1)) ** (1 / 2)',
                              sym.sqrt(21 * x / z))
         self.assertReprEqual('atan2(y, x)', sym.atan2(y, x))
         self.assertReprEqual('abs(x)', sym.abs(x))

--- a/components/wrapper/python_test/external_function_wrapper_test.py
+++ b/components/wrapper/python_test/external_function_wrapper_test.py
@@ -123,7 +123,7 @@ class ExternalFunctionWrapperTest(MathTestBase):
         g = func_2(w=y * x, q=f)
         self.assertIsInstance(g, sym.Expr)
         self.assertEqual("CompoundExpressionElement", g.type_name)
-        self.assertEqual("func_2(func_1(x + 2 * y ** -1), x * y)", repr(g))
+        self.assertEqual("func_2(func_1(x + 2 * y ** (-1)), x * y)", repr(g))
 
     def test_comparisons(self):
         """Check that we can test external functions for equality."""


### PR DESCRIPTION
There was a bug were negative constant values received the wrong precedence when formatting powers, so `pow(-1, x)` became `-1 ** x` instead of `(-1) ** x`, which can lead to ambiguity in reading the printed expressions. This change fixes this.