### PR TITLE
Disallow mutable expressions

### DIFF
--- a/components/core/wf/boolean_expression.h
+++ b/components/core/wf/boolean_expression.h
@@ -12,8 +12,8 @@ struct type_list_trait<boolean_meta_type> {
   // All the boolean-valued expressions.
   // clang-format off
   using types = type_list<
-    const class boolean_constant,
-    const class relational
+    class boolean_constant,
+    class relational
     >;
   // clang-format on
 };

--- a/components/core/wf/compound_expression.h
+++ b/components/core/wf/compound_expression.h
@@ -11,9 +11,9 @@ template <>
 struct type_list_trait<compound_meta_type> {
   // clang-format off
   using types = type_list<
-    const class external_function_invocation,
-    const class custom_type_argument,
-    const class custom_type_construction
+    class external_function_invocation,
+    class custom_type_argument,
+    class custom_type_construction
   >;
   // clang-format on
 };

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -21,22 +21,22 @@ struct type_list_trait<scalar_meta_type> {
   // All the scalar-valued expressions.
   // clang-format off
   using types = type_list<
-    const class addition,
-    const class compound_expression_element,
-    const class conditional,
-    const class symbolic_constant,
-    const class derivative,
-    const class float_constant,
-    const class function,
-    const class complex_infinity,
-    const class imaginary_unit,
-    const class integer_constant,
-    const class iverson_bracket,
-    const class multiplication,
-    const class power,
-    const class rational_constant,
-    const class undefined,
-    const class variable
+    class addition,
+    class compound_expression_element,
+    class conditional,
+    class symbolic_constant,
+    class derivative,
+    class float_constant,
+    class function,
+    class complex_infinity,
+    class imaginary_unit,
+    class integer_constant,
+    class iverson_bracket,
+    class multiplication,
+    class power,
+    class rational_constant,
+    class undefined,
+    class variable
     >;
   // clang-format on
 };

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -35,22 +35,16 @@ index_t matrix_expr::rows() const { return as_matrix().rows(); }
 
 index_t matrix_expr::cols() const { return as_matrix().cols(); }
 
-const scalar_expr& matrix_expr::operator[](index_t i) const { return as_matrix()[i]; }
+const scalar_expr& matrix_expr::operator[](const index_t i) const { return as_matrix()[i]; }
 
-const scalar_expr& matrix_expr::operator()(index_t i, index_t j) const { return as_matrix()(i, j); }
-
-void matrix_expr::set(index_t i, index_t j, const scalar_expr& value) {
-  as_matrix_mut().set_unchecked(i, j, value);
+const scalar_expr& matrix_expr::operator()(const index_t i, const index_t j) const {
+  return as_matrix()(i, j);
 }
 
-matrix_expr matrix_expr::get_block(index_t row, index_t col, index_t nrows, index_t ncols) const {
+matrix_expr matrix_expr::get_block(const index_t row, const index_t col, const index_t nrows,
+                                   const index_t ncols) const {
   matrix result = as_matrix().get_block(row, col, nrows, ncols);
   return matrix_expr{std::move(result)};
-}
-
-void matrix_expr::set_block(index_t row, index_t col, index_t nrows, index_t ncols,
-                            const matrix_expr& block) {
-  as_matrix_mut().set_block(row, col, nrows, ncols, block.as_matrix());
 }
 
 matrix_expr matrix_expr::transposed() const { return matrix_expr{as_matrix().transposed()}; }
@@ -59,12 +53,12 @@ matrix_expr matrix_expr::reshape(index_t nrows, index_t ncols) const {
   if (nrows < 0 || ncols < 0) {
     throw dimension_error("Dimensions must be non-negative. Received [{}, {}]", nrows, ncols);
   }
-  if (static_cast<std::size_t>(nrows * ncols) != size()) {
+  if (static_cast<std::size_t>(nrows) * static_cast<std::size_t>(ncols) != size()) {
     throw dimension_error(
         "Reshaped dimensions [{} x {} = {}] does not match number of input elements [{} x {} = {}]",
         nrows, ncols, nrows * ncols, rows(), cols(), size());
   }
-  return matrix_expr::create(nrows, ncols, to_vector());
+  return create(nrows, ncols, to_vector());
 }
 
 scalar_expr matrix_expr::squared_norm() const {
@@ -80,8 +74,6 @@ scalar_expr matrix_expr::squared_norm() const {
 scalar_expr matrix_expr::norm() const { return sqrt(squared_norm()); }
 
 const matrix& matrix_expr::as_matrix() const { return cast_unchecked<const matrix>(*this); }
-
-matrix& matrix_expr::as_matrix_mut() { return cast_unchecked<matrix>(*this); }
 
 std::vector<scalar_expr> matrix_expr::to_vector() const { return as_matrix().data(); }
 

--- a/components/core/wf/matrix_expression.h
+++ b/components/core/wf/matrix_expression.h
@@ -89,14 +89,8 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
   // Access row `i` and column `j`.
   const scalar_expr& operator()(index_t i, index_t j) const;
 
-  // Set row `i` and column `j` (only valid on dense matrix expression).
-  void set(index_t i, index_t j, const scalar_expr& value);
-
   // Get a block of rows [start, start + length).
   matrix_expr get_block(index_t row, index_t col, index_t nrows, index_t ncols) const;
-
-  // Set a block of rows [start, start + length).
-  void set_block(index_t row, index_t col, index_t nrows, index_t ncols, const matrix_expr& block);
 
   // Transpose the matrix.
   [[nodiscard]] matrix_expr transposed() const;
@@ -112,9 +106,6 @@ class matrix_expr final : public expression_base<matrix_expr, matrix_meta_type> 
 
   // Cast to underlying matrix type.
   const matrix& as_matrix() const;
-
-  // Cast to mutable underlying matrix type.
-  matrix& as_matrix_mut();
 
   // Convert to vector of expressions, in row-major order.
   std::vector<scalar_expr> to_vector() const;

--- a/components/wrapper/python_test/matrix_wrapper_test.py
+++ b/components/wrapper/python_test/matrix_wrapper_test.py
@@ -246,65 +246,6 @@ class MatrixWrapperTest(MathTestBase):
         for index, row in enumerate(m):
             self.assertIdentical(m[index], row)
 
-    def test_matrix_setting(self):
-        # Create 4x5 symbol grid:
-        symbols = []
-        for i in range(4):
-            symbols.append(sym.symbols(f"x_{i}{j}" for j in range(5)))
-
-        symbol_array = np.array(symbols, dtype=object)
-
-        m = sym.zeros(4, 5)
-
-        # set individual elements
-        for i in range(m.shape[0]):
-            for j in range(m.shape[1]):
-                m[i, j] = symbols[i][j]
-                self.assertIdentical(symbols[i][j], m[i, j])
-
-        m = sym.zeros(4, 5)
-
-        # set rows
-        for i in range(m.shape[0]):
-            m[i] = sym.row_vector(*symbols[i])
-            self.assertIdentical(sym.row_vector(*symbols[i]), m[i])
-
-        m = sym.zeros(4, 5)
-
-        # set cols
-        for j in range(m.shape[1]):
-            m[:, j] = sym.vector(*[symbols[i][j] for i in range(m.shape[0])])
-            self.assertIdentical(sym.vector(*[symbols[i][j] for i in range(m.shape[0])]), m[:, j])
-
-        m = sym.zeros(4, 5)
-
-        # set slice on cols
-        for i in range(m.shape[0]):
-            for col_slice in self.generate_slices(m.shape[1]):
-                sliced_symbols = symbol_array[i, col_slice].reshape((1, -1))
-                if sliced_symbols.size != 0:
-                    m[i, col_slice] = sym.matrix(sliced_symbols)
-                    self.assertIdentical(sym.matrix(sliced_symbols), m[i, col_slice])
-
-        m = sym.zeros(4, 5)
-
-        # set slice on rows
-        for j in range(m.shape[1]):
-            for row_slice in self.generate_slices(m.shape[0]):
-                sliced_symbols = symbol_array[row_slice, j].reshape((-1, 1))
-                if sliced_symbols.size != 0:
-                    m[row_slice, j] = sym.matrix(sliced_symbols)
-                    self.assertIdentical(sym.matrix(sliced_symbols), m[row_slice, j])
-
-        m = sym.zeros(4, 5)
-
-        # set slice on both dimensions
-        for row_slice, col_slice in self.generate_row_and_col_slices(m.shape):
-            sliced_symbols = symbol_array[row_slice, col_slice]
-            if sliced_symbols.size != 0:
-                m[row_slice, col_slice] = sym.matrix(sliced_symbols)
-                self.assertIdentical(sym.matrix(sliced_symbols), m[row_slice, col_slice])
-
     def test_unary_map(self):
         """Test unary map w/ a lambda."""
         q = sym.symbols("q")


### PR DESCRIPTION
Allowing mutable expressions introduced a bug where a matrix could be updated, but its hash would remain unchanged. This only applied to the `matrix` type since it was the only mutable expression. In hindsight, allowing mutability might be more trouble than it is worth.

It also introduces an issue where expression caches can be invalid (because the cached expression has been changed since it was inserted into the cache).

In the interest of simplicity, I have opted to restore the invariant that expressions are immutable after construction. 