### PR TITLE
Rename cast operations for stylistic compatibility with stl

### DIFF
--- a/components/core/test_support/wf_test_support/eigen_test_macros.h
+++ b/components/core/test_support/wf_test_support/eigen_test_macros.h
@@ -62,14 +62,14 @@ inline Eigen::MatrixXd eigen_matrix_from_matrix_expr(const matrix_expr& m) {
   Eigen::MatrixXd result{m_eval.rows(), m_eval.cols()};
   for (index_t i = 0; i < result.rows(); ++i) {
     for (index_t j = 0; j < result.cols(); ++j) {
-      if (const float_constant* as_flt = cast_ptr<const float_constant>(m_eval(i, j));
+      if (const float_constant* as_flt = get_if<const float_constant>(m_eval(i, j));
           as_flt != nullptr) {
         result(i, j) = as_flt->get_value();
-      } else if (const integer_constant* as_int = cast_ptr<const integer_constant>(m_eval(i, j));
+      } else if (const integer_constant* as_int = get_if<const integer_constant>(m_eval(i, j));
                  as_int != nullptr) {
         result(i, j) = static_cast<float_constant>(*as_int).get_value();
       } else if (const rational_constant* as_rational =
-                     cast_ptr<const rational_constant>(m_eval(i, j));
+                     get_if<const rational_constant>(m_eval(i, j));
                  as_rational != nullptr) {
         result(i, j) = static_cast<float_constant>(*as_rational).get_value();
       } else {

--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -76,7 +76,7 @@ struct compute_function_output_struct<scalar_expr> {
                     const scalar_type&) const {
     const scalar_expr subs = evaluator.substitute(input);
     const scalar_expr evaluated = evaluator.evaluate(subs);
-    if (const float_constant* f = cast_ptr<const float_constant>(evaluated); f != nullptr) {
+    if (const float_constant* f = get_if<const float_constant>(evaluated); f != nullptr) {
       return f->get_value();
     } else {
       throw type_error("Expression should be a floating point value. Got type {}: {}",

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -303,8 +303,8 @@ struct custom_type_native_converter<symbolic::Point2d> {
   using native_type = numeric::Point2d;
 
   numeric::Point2d operator()(const symbolic::Point2d& p) const {
-    return numeric::Point2d{cast_checked<const float_constant>(p.x).get_value(),
-                            cast_checked<const float_constant>(p.y).get_value()};
+    return numeric::Point2d{get<const float_constant>(p.x).get_value(),
+                            get<const float_constant>(p.y).get_value()};
   }
 
   symbolic::Point2d operator()(const numeric::Point2d& p) const {
@@ -351,10 +351,9 @@ struct custom_type_native_converter<symbolic::Circle> {
   using native_type = numeric::Circle;
 
   numeric::Circle operator()(const symbolic::Circle& p) const {
-    return numeric::Circle{
-        numeric::Point2d{cast_checked<const float_constant>(p.center.x).get_value(),
-                         cast_checked<const float_constant>(p.center.y).get_value()},
-        cast_checked<const float_constant>(p.radius).get_value()};
+    return numeric::Circle{numeric::Point2d{get<const float_constant>(p.center.x).get_value(),
+                                            get<const float_constant>(p.center.y).get_value()},
+                           get<const float_constant>(p.radius).get_value()};
   }
 
   symbolic::Circle operator()(const numeric::Circle& p) const {

--- a/components/core/tests/quaternion_test.cc
+++ b/components/core/tests/quaternion_test.cc
@@ -129,14 +129,10 @@ TEST(QuaternionTest, TestMultiply) {
                                 .subs(q2.y(), q2_num.y())
                                 .subs(q2.z(), q2_num.z());
   // Won't match exactly due to floating point order:
-  ASSERT_NEAR((q1_num * q2_num).w(), cast_checked<const float_constant>(result.w()).get_value(),
-              1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).x(), cast_checked<const float_constant>(result.x()).get_value(),
-              1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).y(), cast_checked<const float_constant>(result.y()).get_value(),
-              1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).z(), cast_checked<const float_constant>(result.z()).get_value(),
-              1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).w(), get<const float_constant>(result.w()).get_value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).x(), get<const float_constant>(result.x()).get_value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).y(), get<const float_constant>(result.y()).get_value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).z(), get<const float_constant>(result.z()).get_value(), 1.0e-15);
 }
 
 TEST(QuaternionTest, TestInverse) {
@@ -400,11 +396,11 @@ TEST(QuaternionTest, TestToAxisAngle) {
       axis_num *= -1.0;
     }
     EXPECT_NEAR(angle_num,
-                cast_checked<const float_constant>(angle_recovered.subs(angle, angle_num)
-                                                       .subs(x, axis_num.x())
-                                                       .subs(y, axis_num.y())
-                                                       .subs(z, axis_num.z())
-                                                       .eval())
+                get<const float_constant>(angle_recovered.subs(angle, angle_num)
+                                              .subs(x, axis_num.x())
+                                              .subs(y, axis_num.y())
+                                              .subs(z, axis_num.z())
+                                              .eval())
                     .get_value(),
                 1.0e-15)
         << fmt::format("While testing axis = {}, angle = {}", axis_num.transpose(), angle_num);
@@ -531,9 +527,9 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
 
   auto cast_to_float = [](const scalar_expr& expr) -> double {
     if (expr.is_type<float_constant>()) {
-      return cast_checked<const float_constant>(expr).get_value();
+      return get<const float_constant>(expr).get_value();
     }
-    return static_cast<double>(cast_checked<const integer_constant>(expr).get_value());
+    return static_cast<double>(get<const integer_constant>(expr).get_value());
   };
 
   constexpr int num_vectors = 75;

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -239,11 +239,6 @@ TEST(ScalarOperationsTest, TestDivision) {
   ASSERT_IDENTICAL(z / (y * z), 1_s / y);
 
   // Cancellation of powers:
-  ASSERT_TRUE(pow(x, 3).is_type<power>());
-  ASSERT_TRUE(pow(x, 2).is_type<power>());
-  ASSERT_IDENTICAL(cast_ptr<const power>(pow(x, 3))->base(),
-                   cast_ptr<const power>(pow(x, 2))->base());
-
   ASSERT_IDENTICAL(x, pow(x, 3) / pow(x, 2));
   ASSERT_IDENTICAL(constants::one, pow(x, 3) / (x * x * x));
   ASSERT_IDENTICAL(x * y * pow(z, 1_s / 2_s),
@@ -735,9 +730,8 @@ TEST(ScalarOperationsTest, TestConditional) {
 
   // Nested conditionals don't simplify:
   const scalar_expr nested = where(x < 0, where(x < 0, cos(x), sin(x)), log(z));
-  ASSERT_IDENTICAL(cast_checked<const conditional>(nested).if_branch(),
-                   where(x < 0, cos(x), sin(x)));
-  ASSERT_IDENTICAL(cast_checked<const conditional>(nested).else_branch(), log(z));
+  ASSERT_IDENTICAL(get<const conditional>(nested).if_branch(), where(x < 0, cos(x), sin(x)));
+  ASSERT_IDENTICAL(get<const conditional>(nested).else_branch(), log(z));
 }
 
 TEST(ScalarOperationsTest, TestDistribute) {

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -40,7 +40,7 @@ ir::value_ptr ir_form_visitor::operator()(const compound_expression_element& el)
   return overloaded_visit(
       compound_val->type(),
       [&](ir::void_type) -> ir::value_ptr {
-        WF_ASSERT_ALWAYS("Compount expression cannot have void type. name = {}, index = {}",
+        WF_ASSERT_ALWAYS("Compound expression cannot have void type. name = {}, index = {}",
                          compound_val->name(), el.index());
       },
       [&](scalar_type) { return compound_val; },
@@ -268,7 +268,7 @@ ir::value_ptr ir_form_visitor::operator()(const power& power) {
   }
 
   constexpr int max_integer_mul_exponent = 16;
-  if (const integer_constant* exp_int = cast_ptr<const integer_constant>(power.exponent());
+  if (const integer_constant* exp_int = get_if<const integer_constant>(power.exponent());
       exp_int != nullptr) {
     WF_ASSERT_GREATER_OR_EQ(exp_int->get_value(), 0, "Negative exponents were handled above");
     // Maximum exponent below which we rewrite `pow` as a series of multiplications.
@@ -282,7 +282,7 @@ ir::value_ptr ir_form_visitor::operator()(const power& power) {
                             code_numeric_type::floating_point, base, operator()(power.exponent()));
     }
   } else if (const rational_constant* exp_rational =
-                 cast_ptr<const rational_constant>(power.exponent());
+                 get_if<const rational_constant>(power.exponent());
              exp_rational != nullptr) {
     WF_ASSERT_GREATER_OR_EQ(exp_rational->numerator(), 0, "rational = {}", *exp_rational);
 

--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -36,7 +36,7 @@ struct collect_visitor {
 
     const auto new_end =
         std::remove_if(container.begin(), container.end(), [&](const scalar_expr& child) {
-          if (const multiplication* mul = cast_ptr<const multiplication>(child); mul != nullptr) {
+          if (const multiplication* mul = get_if<const multiplication>(child); mul != nullptr) {
             // Look for relevant terms:
             std::optional<scalar_expr> exponent;
             const auto it =

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -71,8 +71,7 @@ scalar_expr derivative_visitor::operator()(const addition& add) {
 
 scalar_expr derivative_visitor::operator()(const compound_expression_element& el,
                                            const scalar_expr& expr) const {
-  if (const compound_expression_element* arg =
-          cast_ptr<const compound_expression_element>(argument_);
+  if (const compound_expression_element* arg = get_if<const compound_expression_element>(argument_);
       arg != nullptr && are_identical(*arg, el)) {
     return constants::one;
   }
@@ -281,7 +280,7 @@ scalar_expr derivative_visitor::operator()(const relational&, const scalar_expr&
 scalar_expr derivative_visitor::operator()(const undefined&) const { return constants::undefined; }
 
 scalar_expr derivative_visitor::operator()(const variable& var) const {
-  if (const variable* arg = cast_ptr<const variable>(argument_);
+  if (const variable* arg = get_if<const variable>(argument_);
       arg != nullptr && are_identical(*arg, var)) {
     return constants::one;
   }

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -73,7 +73,7 @@ scalar_expr distribute_visitor::operator()(const power& pow) {
 
   // If the base is an addition, we should expand the power.
   if (b.is_type<addition>()) {
-    if (const integer_constant* exp_int = cast_ptr<const integer_constant>(e); exp_int != nullptr) {
+    if (const integer_constant* exp_int = get_if<const integer_constant>(e); exp_int != nullptr) {
       const checked_int abs_exp = abs(exp_int->get_value());
 
       scalar_expr distributed = distribute_power(std::move(b), static_cast<std::uint64_t>(abs_exp));
@@ -82,7 +82,7 @@ scalar_expr distribute_visitor::operator()(const power& pow) {
       } else if (exp_int->is_negative()) {
         return power::create(std::move(distributed), constants::negative_one);
       }
-    } else if (const rational_constant* exp_rational = cast_ptr<const rational_constant>(e);
+    } else if (const rational_constant* exp_rational = get_if<const rational_constant>(e);
                exp_rational != nullptr && exp_rational->denominator() == 2 &&
                abs(exp_rational->numerator()) > 1) {
       // This can be interpreted as integer power of sqrt(...).
@@ -135,7 +135,7 @@ scalar_expr distribute_visitor::distribute_power(scalar_expr base, std::size_t p
 // Create a span from input expression `x`. If `x` is an addition, the span will be over the terms
 // of the addition. Otherwise it will be a single length span containing just `x`.
 static absl::Span<const scalar_expr> expression_as_span(const scalar_expr& x) noexcept {
-  if (const addition* add = cast_ptr<const addition>(x); add != nullptr) {
+  if (const addition* add = get_if<const addition>(x); add != nullptr) {
     return add->as_span();
   } else {
     return {&x, 1};

--- a/components/core/wf/expression_variant.h
+++ b/components/core/wf/expression_variant.h
@@ -149,9 +149,9 @@ class expression_variant {
     return model->contents();
   }
 
-  // Allow access to `cast_to_type` in cast_unchecked.
+  // Allow access to `cast_to_type` in get_unchecked.
   template <typename T, typename D, typename M>
-  friend const auto& cast_unchecked(const expression_base<D, M>& x) noexcept;
+  friend const auto& get_unchecked(const expression_base<D, M>& x) noexcept;
   template <std::size_t I, typename M>
   friend const auto& detail::cast_to_index(const expression_variant<M>& v) noexcept;
 
@@ -236,10 +236,10 @@ class expression_base {
   constexpr storage_type& impl() noexcept { return impl_; }
 
   template <typename T, typename D, typename M>
-  friend const auto& cast_unchecked(const expression_base<D, M>& x) noexcept;
+  friend const auto& get_unchecked(const expression_base<D, M>& x) noexcept;
 
   template <typename T, typename D, typename M>
-  friend decltype(auto) cast_unchecked(expression_base<D, M>& x) noexcept;
+  friend decltype(auto) get_unchecked(expression_base<D, M>& x) noexcept;
 
   storage_type impl_;
 };
@@ -277,7 +277,7 @@ struct is_identical_struct<T, enable_if_inherits_expression_base_t<T>> {
 
 // Cast expression with no checking. UB will occur if the wrong type is accessed.
 template <typename T, typename D, typename M>
-const auto& cast_unchecked(const expression_base<D, M>& x) noexcept {
+const auto& get_unchecked(const expression_base<D, M>& x) noexcept {
   static_assert(type_list_contains_v<std::remove_const_t<T>, typename expression_base<D, M>::types>,
                 "Not a valid type to cast to.");
   return x.impl().template cast_to_type<std::remove_const_t<T>>();
@@ -286,20 +286,20 @@ const auto& cast_unchecked(const expression_base<D, M>& x) noexcept {
 // Cast expression to const pointer of the specified type.
 // Returned pointer is valid in scope only as long as the argument `x` survives.
 template <typename T, typename D, typename M>
-const T* cast_ptr(const expression_base<D, M>& x) noexcept {
+const T* get_if(const expression_base<D, M>& x) noexcept {
   if (x.template is_type<T>()) {
-    return &cast_unchecked<T>(x);
+    return &get_unchecked<T>(x);
   } else {
     return nullptr;
   }
 }
 
-// Cast expression to const reference of the specified type. TypeError is thrown if the cast is
+// Cast expression to const reference of the specified type. type_error is thrown if the cast is
 // invalid.
 template <typename T, typename D, typename M>
-const T& cast_checked(const expression_base<D, M>& x) {
+const T& get(const expression_base<D, M>& x) {
   if (x.template is_type<T>()) {
-    return cast_unchecked<T>(x);
+    return get_unchecked<T>(x);
   } else {
     throw type_error("Cannot cast expression of type `{}` to `{}`", x.type_name(), T::name_str);
   }

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -71,7 +71,7 @@ struct addition_visitor {
     if (mul.is_type<addition>()) {
       // This is probably not great for performance, but shouldn't be _that_ common.
       const scalar_expr distributed = input_expression.distribute();
-      operator()(cast_checked<const addition>(distributed));
+      operator()(get<const addition>(distributed));
       return;
     }
 

--- a/components/core/wf/expressions/compound_expression_element.cc
+++ b/components/core/wf/expressions/compound_expression_element.cc
@@ -8,7 +8,7 @@ namespace wf {
 
 scalar_expr compound_expression_element::create(compound_expr provenance, const std::size_t index) {
   if (const custom_type_construction* construct =
-          cast_ptr<const custom_type_construction>(provenance);
+          get_if<const custom_type_construction>(provenance);
       construct != nullptr) {
     return construct->at(index);
   }

--- a/components/core/wf/expressions/custom_type_expressions.cc
+++ b/components/core/wf/expressions/custom_type_expressions.cc
@@ -38,7 +38,7 @@ static std::optional<compound_expr> maybe_get_existing_compound_expr(
 
   // Get the first element, which we use to get the inner compound expression type.
   const compound_expression_element* first_element =
-      cast_ptr<const compound_expression_element>(args[0]);
+      get_if<const compound_expression_element>(args[0]);
   if (!first_element || first_element->index() != 0) {
     return std::nullopt;
   }
@@ -52,7 +52,7 @@ static std::optional<compound_expr> maybe_get_existing_compound_expr(
 
   // Now check if (in aggregate) the vector of expressions is just a copy of `provenance`.
   for (std::size_t i = 1; i < args.size(); ++i) {
-    if (const auto* element = cast_ptr<const compound_expression_element>(args[i]);
+    if (const auto* element = get_if<const compound_expression_element>(args[i]);
         element == nullptr || element->index() != i ||
         element->provenance().hash() != provenance.hash() ||
         !are_identical(element->provenance(), provenance)) {

--- a/components/core/wf/expressions/derivative_expression.cc
+++ b/components/core/wf/expressions/derivative_expression.cc
@@ -13,7 +13,7 @@ scalar_expr derivative::create(scalar_expr function, scalar_expr arg, int order)
                      arg.to_string());
   }
 
-  if (const derivative* d = cast_ptr<const derivative>(function);
+  if (const derivative* d = get_if<const derivative>(function);
       d != nullptr && d->argument().is_identical_to(arg)) {
     // We are just increasing the order of a derivative taken with respect to the same variable.
     // dD(f(x), x, n)/dx = D(f(x), x, n + 1)

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -49,10 +49,10 @@ scalar_expr multiplication::from_operands(const absl::Span<const scalar_expr> ar
   // TODO: this simplification doesn't always work because there might be multiple
   // integer/rational/float terms.
   if (args.size() == 2) {
-    if (const addition* add = cast_ptr<const addition>(args[0]);
+    if (const addition* add = get_if<const addition>(args[0]);
         add && args[1].is_type<integer_constant, rational_constant, float_constant>()) {
       return multiply_into_addition(*add, args[1]);
-    } else if (add = cast_ptr<const addition>(args[1]);
+    } else if (add = get_if<const addition>(args[1]);
                add && args[0].is_type<integer_constant, float_constant, rational_constant>()) {
       return multiply_into_addition(*add, args[0]);
     }
@@ -154,8 +154,8 @@ void multiplication_parts::multiply_term(const scalar_expr& arg, bool factorize_
 
 void multiplication_parts::normalize_coefficients() {
   for (auto it = terms.begin(); it != terms.end(); ++it) {
-    const integer_constant* base = cast_ptr<const integer_constant>(it->first);
-    const rational_constant* exponent = cast_ptr<const rational_constant>(it->second);
+    const integer_constant* base = get_if<const integer_constant>(it->first);
+    const rational_constant* exponent = get_if<const rational_constant>(it->second);
     // Check if the exponent is now greater than 1, in which case we factorize it into an integer
     // part and a fractional part. The integer part is multiplied onto the rational coefficient.
     if (base && exponent) {
@@ -311,7 +311,7 @@ multiplication_format_parts get_formatting_info(const multiplication& mul) {
   std::size_t sign_count = 0;
   for (const scalar_expr& expr : terms) {
     // Extract rationals:
-    if (const rational_constant* const rational = cast_ptr<const rational_constant>(expr);
+    if (const rational_constant* const rational = get_if<const rational_constant>(expr);
         rational != nullptr) {
       if (const auto abs_num = abs(rational->numerator()); abs_num != 1) {
         // Don't put redundant ones into the numerator for rationals of the form 1/n.
@@ -323,7 +323,7 @@ multiplication_format_parts get_formatting_info(const multiplication& mul) {
         // If negative, increase the sign count.
         ++sign_count;
       }
-    } else if (const integer_constant* const integer = cast_ptr<const integer_constant>(expr);
+    } else if (const integer_constant* const integer = get_if<const integer_constant>(expr);
                integer != nullptr) {
       if (integer->get_value() != 1 && integer->get_value() != -1) {
         result.numerator.emplace_back(integer->abs());
@@ -331,7 +331,7 @@ multiplication_format_parts get_formatting_info(const multiplication& mul) {
       if (integer->get_value() < 0) {
         ++sign_count;
       }
-    } else if (const float_constant* const f = cast_ptr<const float_constant>(expr); f != nullptr) {
+    } else if (const float_constant* const f = get_if<const float_constant>(expr); f != nullptr) {
       result.numerator.emplace_back(f->abs());
       if (f->get_value() < 0) {
         ++sign_count;

--- a/components/core/wf/expressions/power.cc
+++ b/components/core/wf/expressions/power.cc
@@ -333,10 +333,10 @@ struct power_imaginary_visitor {
 };
 
 static bool magnitude_less_than_one(const scalar_expr& value) {
-  if (const rational_constant* r = cast_ptr<const rational_constant>(value);
+  if (const rational_constant* r = get_if<const rational_constant>(value);
       r != nullptr && r->is_proper()) {
     return true;
-  } else if (const float_constant* f = cast_ptr<const float_constant>(value);
+  } else if (const float_constant* f = get_if<const float_constant>(value);
              f != nullptr && std::abs(f->get_value()) < 1.0) {
     return true;
   }
@@ -418,7 +418,7 @@ scalar_expr power::create(scalar_expr base, scalar_expr exp) {
   }
 
   // Check if the base is itself a power:
-  if (const power* a_pow = cast_ptr<const power>(base); a_pow != nullptr) {
+  if (const power* a_pow = get_if<const power>(base); a_pow != nullptr) {
     if (can_multiply_exponents(*a_pow, exp)) {
       return power::create(a_pow->base(), a_pow->exponent() * exp);
     }
@@ -440,7 +440,7 @@ scalar_expr power::create(scalar_expr base, scalar_expr exp) {
 
   // Check if the base is a multiplication and the exponent is an integer.
   // In this case, we convert to a multiplication of powers.
-  if (const multiplication* const mul = cast_ptr<const multiplication>(base); mul != nullptr) {
+  if (const multiplication* const mul = get_if<const multiplication>(base); mul != nullptr) {
     if (exp.is_type<integer_constant>()) {
       const auto args = transform_map<std::vector>(
           *mul, [&exp](const scalar_expr& arg) { return power::create(arg, exp); });
@@ -459,7 +459,7 @@ scalar_expr pow(scalar_expr base, scalar_expr exp) {
 }
 
 std::pair<scalar_expr, scalar_expr> as_base_and_exp(const scalar_expr& expr) {
-  if (const power* pow = cast_ptr<const power>(expr); pow != nullptr) {
+  if (const power* pow = get_if<const power>(expr); pow != nullptr) {
     // Return as base/exponent pair.
     return std::make_pair(pow->base(), pow->exponent());
   }

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -56,7 +56,7 @@ static std::optional<scalar_expr> maybe_swap_hyberbolic_trig(const scalar_expr& 
                                                              Replacement replacement) {
   if (is_i(arg)) {
     return replacement(constants::one);
-  } else if (const multiplication* mul = cast_ptr<const multiplication>(arg);
+  } else if (const multiplication* mul = get_if<const multiplication>(arg);
              mul != nullptr && any_of(*mul, &is_i)) {
     // The `any_of` check assumes we've placed multiplications into canonical form, which currently
     // is always true.
@@ -67,10 +67,9 @@ static std::optional<scalar_expr> maybe_swap_hyberbolic_trig(const scalar_expr& 
 }
 
 static std::optional<rational_constant> try_cast_to_rational(const scalar_expr& expr) {
-  if (const rational_constant* const r = cast_ptr<const rational_constant>(expr); r != nullptr) {
+  if (const rational_constant* const r = get_if<const rational_constant>(expr); r != nullptr) {
     return *r;
-  } else if (const integer_constant* const i = cast_ptr<const integer_constant>(expr);
-             i != nullptr) {
+  } else if (const integer_constant* const i = get_if<const integer_constant>(expr); i != nullptr) {
     return static_cast<rational_constant>(*i);
   }
   return {};
@@ -287,7 +286,7 @@ scalar_expr cosh(const scalar_expr& arg) {
   if (is_complex_infinity(arg) || is_undefined(arg)) {
     return constants::undefined;
   }
-  if (const function* func = cast_ptr<const function>(arg);
+  if (const function* func = get_if<const function>(arg);
       func != nullptr && func->enum_value() == built_in_function::arccosh) {
     // cosh(acosh(x)) --> x
     return func->args().front();
@@ -316,7 +315,7 @@ scalar_expr sinh(const scalar_expr& arg) {
   if (is_complex_infinity(arg) || is_undefined(arg)) {
     return constants::undefined;
   }
-  if (const function* func = cast_ptr<const function>(arg);
+  if (const function* func = get_if<const function>(arg);
       func != nullptr && func->enum_value() == built_in_function::arcsinh) {
     // sinh(asinh(x)) --> x
     return func->args().front();
@@ -344,7 +343,7 @@ scalar_expr tanh(const scalar_expr& arg) {
   if (is_complex_infinity(arg) || is_undefined(arg)) {
     return constants::undefined;
   }
-  if (const function* func = cast_ptr<const function>(arg);
+  if (const function* func = get_if<const function>(arg);
       func != nullptr && func->enum_value() == built_in_function::arctanh) {
     // tanh(atanh(x)) --> x
     return func->args().front();
@@ -451,7 +450,7 @@ scalar_expr sqrt(const scalar_expr& arg) {
 }
 
 scalar_expr abs(const scalar_expr& arg) {
-  if (const function* func = cast_ptr<const function>(arg);
+  if (const function* func = get_if<const function>(arg);
       func != nullptr && func->enum_value() == built_in_function::abs) {
     // abs(abs(x)) --> abs(x)
     return arg;
@@ -474,7 +473,7 @@ scalar_expr abs(const scalar_expr& arg) {
       result.has_value()) {
     return *std::move(result);
   }
-  if (const symbolic_constant* constant = cast_ptr<const symbolic_constant>(arg);
+  if (const symbolic_constant* constant = get_if<const symbolic_constant>(arg);
       constant != nullptr) {
     if (const auto as_double = double_from_symbolic_constant(constant->name());
         compare_int_float(0, as_double).value() != relative_order::greater_than) {
@@ -637,7 +636,7 @@ matrix_expr where(const boolean_expr& condition, const matrix_expr& if_true,
 }
 
 scalar_expr iverson(const boolean_expr& bool_expression) {
-  if (const boolean_constant* constant = cast_ptr<const boolean_constant>(bool_expression);
+  if (const boolean_constant* constant = get_if<const boolean_constant>(bool_expression);
       constant != nullptr) {
     if (constant->value()) {
       return constants::one;

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -73,7 +73,7 @@ scalar_expr matrix_expr::squared_norm() const {
 
 scalar_expr matrix_expr::norm() const { return sqrt(squared_norm()); }
 
-const matrix& matrix_expr::as_matrix() const { return cast_unchecked<const matrix>(*this); }
+const matrix& matrix_expr::as_matrix() const { return get_unchecked<const matrix>(*this); }
 
 std::vector<scalar_expr> matrix_expr::to_vector() const { return as_matrix().data(); }
 

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -210,7 +210,7 @@ class determine_set_visitor {
     }
 
     if (is_real_set(base)) {
-      if (const integer_constant* exp_int = cast_ptr<const integer_constant>(pow.exponent());
+      if (const integer_constant* exp_int = get_if<const integer_constant>(pow.exponent());
           exp_int != nullptr && exp_int->is_even()) {
         return contains_zero(base) ? number_set::real_non_negative : number_set::real_positive;
       }

--- a/components/core/wf/numerical_casts.cc
+++ b/components/core/wf/numerical_casts.cc
@@ -47,7 +47,7 @@ struct convert_to_complex_visitor {
     }
     // TODO: Should not need the abstract value to do this.
     const auto [coeff, maybe_i] = as_coeff_and_mul(mul_abstract);
-    if (const float_constant* f = cast_ptr<const float_constant>(coeff);
+    if (const float_constant* f = get_if<const float_constant>(coeff);
         f != nullptr && is_i(maybe_i)) {
       return complex_double{0.0, f->get_value()};
     }
@@ -59,9 +59,9 @@ struct convert_to_complex_visitor {
 // TODO: optional of variant is perhaps not as performant, but it is ergonomic for my use case.
 std::optional<std::variant<std::int64_t, double, std::complex<double>>> numerical_cast(
     const scalar_expr& expr) {
-  if (const float_constant* f = cast_ptr<const float_constant>(expr); f != nullptr) {
+  if (const float_constant* f = get_if<const float_constant>(expr); f != nullptr) {
     return f->get_value();
-  } else if (const integer_constant* i = cast_ptr<const integer_constant>(expr); i != nullptr) {
+  } else if (const integer_constant* i = get_if<const integer_constant>(expr); i != nullptr) {
     return static_cast<std::int64_t>(i->get_value());
   } else if (const auto result = complex_cast(expr); result.has_value()) {
     return *result;

--- a/components/core/wf/ordering.cc
+++ b/components/core/wf/ordering.cc
@@ -48,7 +48,7 @@ relative_order order_struct<scalar_expr>::operator()(const scalar_expr& a,
     using Ta = std::decay_t<decltype(a_typed)>;
     static_assert(is_orderable_v<Ta>, "Type does not implement order_struct.");
 
-    const auto& b_typed = cast_unchecked<const Ta>(b);
+    const auto& b_typed = get_unchecked<const Ta>(b);
     return order_struct<Ta>{}(a_typed, b_typed);
   });
 }
@@ -63,7 +63,7 @@ relative_order order_struct<compound_expr>::operator()(const compound_expr& a,
   return visit(a, [&b](const auto& a_typed) -> relative_order {
     using Ta = std::decay_t<decltype(a_typed)>;
     static_assert(is_orderable_v<Ta>, "Type does not implement order_struct.");
-    return order_struct<Ta>{}(a_typed, cast_unchecked<const Ta>(b));
+    return order_struct<Ta>{}(a_typed, get_unchecked<const Ta>(b));
   });
 }
 
@@ -77,7 +77,7 @@ relative_order order_struct<boolean_expr>::operator()(const boolean_expr& a,
   return visit(a, [&b](const auto& a_typed) -> relative_order {
     using Ta = std::decay_t<decltype(a_typed)>;
     static_assert(is_orderable_v<Ta>, "Type does not implement order_struct.");
-    return order_struct<Ta>{}(a_typed, cast_unchecked<const Ta>(b));
+    return order_struct<Ta>{}(a_typed, get_unchecked<const Ta>(b));
   });
 }
 

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -2,7 +2,7 @@
 #pragma once
 #include "wf/compound_expression.h"
 #include "wf/expression.h"
-#include "wf/expressions/special_constants.h"
+#include "wf/matrix_expression.h"
 
 namespace wf {
 
@@ -27,7 +27,7 @@ class plain_formatter {
   void operator()(const imaginary_unit&);
   void operator()(const integer_constant& num);
   void operator()(const iverson_bracket& bracket);
-  void operator()(const class matrix& mat);
+  void operator()(const matrix& mat);
   void operator()(const multiplication& mul);
   void operator()(const power& pow);
   void operator()(const rational_constant& rational);

--- a/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
@@ -16,7 +16,7 @@ using namespace py::literals;
 namespace wf {
 
 static bool coerce_to_bool(const boolean_expr& self) {
-  if (const boolean_constant* constant = cast_ptr<const boolean_constant>(self);
+  if (const boolean_constant* constant = get_if<const boolean_constant>(self);
       constant != nullptr) {
     return constant->value();
   } else {


### PR DESCRIPTION
To improve stylistic compatibility with the STL, I rename the `expression_variant` casters:
- `cast_ptr` --> `get_if` (non throwing)
- `cast_checked` --> `get` (throwing)
- `cast_unchecked` --> `get_unchecked`

This should make their function a bit more obvious.