### PR TITLE
Get rid of integer_constant operators, renamed `get_value --> value`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
 ---
-Checks: '-readability-convert-member-functions-to-static*,-modernize-avoid-bind,-modernize-use-nodiscard,-*-use-auto'
+Checks: '-readability-convert-member-functions-to-static*,-modernize-avoid-bind,-modernize-use-nodiscard,-*-use-auto,-*-no-recursion'

--- a/components/core/test_support/wf_test_support/eigen_test_macros.h
+++ b/components/core/test_support/wf_test_support/eigen_test_macros.h
@@ -67,14 +67,14 @@ inline Eigen::MatrixXd eigen_matrix_from_matrix_expr(const matrix_expr& m) {
     for (index_t j = 0; j < result.cols(); ++j) {
       if (const float_constant* as_flt = get_if<const float_constant>(m_eval(i, j));
           as_flt != nullptr) {
-        result(i, j) = as_flt->get_value();
+        result(i, j) = as_flt->value();
       } else if (const integer_constant* as_int = get_if<const integer_constant>(m_eval(i, j));
                  as_int != nullptr) {
-        result(i, j) = static_cast<float_constant>(*as_int).get_value();
+        result(i, j) = static_cast<float_constant>(*as_int).value();
       } else if (const rational_constant* as_rational =
                      get_if<const rational_constant>(m_eval(i, j));
                  as_rational != nullptr) {
-        result(i, j) = static_cast<float_constant>(*as_rational).get_value();
+        result(i, j) = static_cast<float_constant>(*as_rational).value();
       } else {
         throw type_error("Cannot coerce value to float: {}", m_eval(i, j));
       }

--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -77,7 +77,7 @@ struct compute_function_output_struct<scalar_expr> {
     const scalar_expr subs = evaluator.substitute(input);
     const scalar_expr evaluated = evaluator.evaluate(subs);
     if (const float_constant* f = get_if<const float_constant>(evaluated); f != nullptr) {
-      return f->get_value();
+      return f->value();
     } else {
       throw type_error("Expression should be a floating point value. Got type {}: {}",
                        subs.type_name(), subs);

--- a/components/core/tests/checked_int_test.cc
+++ b/components/core/tests/checked_int_test.cc
@@ -65,6 +65,14 @@ TEST(CheckedIntTest, TestCompare) {
   ASSERT_GE(32_chk, 31);
 }
 
+TEST(CheckedIntTest, TestIsEven) {
+  ASSERT_TRUE(checked_int(0).is_even());
+  ASSERT_TRUE(checked_int(2).is_even());
+  ASSERT_TRUE(checked_int(-4).is_even());
+  ASSERT_FALSE(checked_int(1).is_even());
+  ASSERT_FALSE(checked_int(-3).is_even());
+}
+
 TEST(CheckedIntTest, TestNegation) {
   ASSERT_EQ(0_chk, -0_chk);
   ASSERT_EQ(-1_chk, -checked_int(1));

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -303,8 +303,8 @@ struct custom_type_native_converter<symbolic::Point2d> {
   using native_type = numeric::Point2d;
 
   numeric::Point2d operator()(const symbolic::Point2d& p) const {
-    return numeric::Point2d{get<const float_constant>(p.x).get_value(),
-                            get<const float_constant>(p.y).get_value()};
+    return numeric::Point2d{get<const float_constant>(p.x).value(),
+                            get<const float_constant>(p.y).value()};
   }
 
   symbolic::Point2d operator()(const numeric::Point2d& p) const {
@@ -351,9 +351,9 @@ struct custom_type_native_converter<symbolic::Circle> {
   using native_type = numeric::Circle;
 
   numeric::Circle operator()(const symbolic::Circle& p) const {
-    return numeric::Circle{numeric::Point2d{get<const float_constant>(p.center.x).get_value(),
-                                            get<const float_constant>(p.center.y).get_value()},
-                           get<const float_constant>(p.radius).get_value()};
+    return numeric::Circle{numeric::Point2d{get<const float_constant>(p.center.x).value(),
+                                            get<const float_constant>(p.center.y).value()},
+                           get<const float_constant>(p.radius).value()};
   }
 
   symbolic::Circle operator()(const numeric::Circle& p) const {

--- a/components/core/tests/numeric_expressions_test.cc
+++ b/components/core/tests/numeric_expressions_test.cc
@@ -11,7 +11,7 @@ namespace wf {
 using namespace wf::custom_literals;
 
 std::ostream& operator<<(std::ostream& stream, const wf::integer_constant& i) {
-  stream << fmt::format("Integer({})", i.get_value());
+  stream << fmt::format("Integer({})", i.value());
   return stream;
 }
 
@@ -31,7 +31,7 @@ TEST(NumericExpressionsTest, TestRational) {
   ASSERT_FALSE(are_identical(a, {1, 3}));
   ASSERT_FALSE(a.try_convert_to_integer());
   ASSERT_EQ(a, rational_constant(16, 64));
-  ASSERT_EQ(0.25, static_cast<float_constant>(a).get_value());
+  ASSERT_EQ(0.25, static_cast<float_constant>(a).value());
 
   const rational_constant b{30, 10};
   ASSERT_TRUE(b.try_convert_to_integer());

--- a/components/core/tests/quaternion_test.cc
+++ b/components/core/tests/quaternion_test.cc
@@ -129,10 +129,10 @@ TEST(QuaternionTest, TestMultiply) {
                                 .subs(q2.y(), q2_num.y())
                                 .subs(q2.z(), q2_num.z());
   // Won't match exactly due to floating point order:
-  ASSERT_NEAR((q1_num * q2_num).w(), get<const float_constant>(result.w()).get_value(), 1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).x(), get<const float_constant>(result.x()).get_value(), 1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).y(), get<const float_constant>(result.y()).get_value(), 1.0e-15);
-  ASSERT_NEAR((q1_num * q2_num).z(), get<const float_constant>(result.z()).get_value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).w(), get<const float_constant>(result.w()).value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).x(), get<const float_constant>(result.x()).value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).y(), get<const float_constant>(result.y()).value(), 1.0e-15);
+  ASSERT_NEAR((q1_num * q2_num).z(), get<const float_constant>(result.z()).value(), 1.0e-15);
 }
 
 TEST(QuaternionTest, TestInverse) {
@@ -401,7 +401,7 @@ TEST(QuaternionTest, TestToAxisAngle) {
                                               .subs(y, axis_num.y())
                                               .subs(z, axis_num.z())
                                               .eval())
-                    .get_value(),
+                    .value(),
                 1.0e-15)
         << fmt::format("While testing axis = {}, angle = {}", axis_num.transpose(), angle_num);
 
@@ -527,9 +527,9 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
 
   auto cast_to_float = [](const scalar_expr& expr) -> double {
     if (expr.is_type<float_constant>()) {
-      return get<const float_constant>(expr).get_value();
+      return get<const float_constant>(expr).value();
     }
-    return static_cast<double>(get<const integer_constant>(expr).get_value());
+    return static_cast<double>(get<const integer_constant>(expr).value());
   };
 
   constexpr int num_vectors = 75;

--- a/components/core/wf/checked_int.h
+++ b/components/core/wf/checked_int.h
@@ -87,6 +87,8 @@ class checked_int final {
     return {static_cast<value_type>(arg)};
   }
 
+  constexpr bool is_even() const noexcept { return !static_cast<bool>(value_ & 1); }
+
  private:
   value_type value_;
 };

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -423,13 +423,13 @@ ast::ast_element ast_form_visitor::operator()(const ir::value&, const ir::load& 
           return ast::ast_element{std::in_place_type_t<ast::special_constant>{}, inner.name()};
         } else if constexpr (std::is_same_v<T, integer_constant>) {
           return ast::ast_element{std::in_place_type_t<ast::integer_literal>{},
-                                  static_cast<std::int64_t>(inner.get_value())};
+                                  static_cast<std::int64_t>(inner.value())};
         } else if constexpr (std::is_same_v<T, float_constant>) {
           return ast::ast_element{std::in_place_type_t<ast::float_literal>{},
-                                  static_cast<float_constant>(inner).get_value()};
+                                  static_cast<float_constant>(inner).value()};
         } else if constexpr (std::is_same_v<T, rational_constant>) {
           return ast::ast_element{std::in_place_type_t<ast::float_literal>{},
-                                  static_cast<float_constant>(inner).get_value()};
+                                  static_cast<float_constant>(inner).value()};
         } else if constexpr (std::is_same_v<T, boolean_constant>) {
           return ast::ast_element{std::in_place_type_t<ast::boolean_literal>{}, inner.value()};
         } else if constexpr (std::is_same_v<T, variable>) {

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -270,12 +270,12 @@ ir::value_ptr ir_form_visitor::operator()(const power& power) {
   constexpr int max_integer_mul_exponent = 16;
   if (const integer_constant* exp_int = get_if<const integer_constant>(power.exponent());
       exp_int != nullptr) {
-    WF_ASSERT_GREATER_OR_EQ(exp_int->get_value(), 0, "Negative exponents were handled above");
+    WF_ASSERT_GREATER_OR_EQ(exp_int->value(), 0, "Negative exponents were handled above");
     // Maximum exponent below which we rewrite `pow` as a series of multiplications.
     // Have not experimented with this cutoff much, but on GCC94 and Clang17, using a series of
     // multiplications is still faster even past x^32.
-    if (exp_int->get_value() <= max_integer_mul_exponent) {
-      return exponentiate_by_squaring(base, static_cast<std::uint64_t>(exp_int->get_value()));
+    if (exp_int->value() <= max_integer_mul_exponent) {
+      return exponentiate_by_squaring(base, static_cast<std::uint64_t>(exp_int->value()));
     } else {
       // Just call power variant with integer exponent:
       return push_operation(ir::call_std_function{std_math_function::powi},

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -74,7 +74,7 @@ scalar_expr distribute_visitor::operator()(const power& pow) {
   // If the base is an addition, we should expand the power.
   if (b.is_type<addition>()) {
     if (const integer_constant* exp_int = get_if<const integer_constant>(e); exp_int != nullptr) {
-      const checked_int abs_exp = abs(exp_int->get_value());
+      const checked_int abs_exp = abs(exp_int->value());
 
       scalar_expr distributed = distribute_power(std::move(b), static_cast<std::uint64_t>(abs_exp));
       if (exp_int->is_positive()) {

--- a/components/core/wf/evaluate.h
+++ b/components/core/wf/evaluate.h
@@ -1,7 +1,5 @@
 // Copyright 2023 Gareth Cross
 #pragma once
-#include <unordered_map>
-
 #include "wf/compound_expression.h"
 #include "wf/expression.h"
 #include "wf/expression_cache.h"

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -120,12 +120,12 @@ class scalar_expr final : public expression_base<scalar_expr, scalar_meta_type> 
   // Construct from integer.
   static scalar_expr from_int(checked_int x);
 
-  // TODO: Use checked casts here + safe numeric type.
   template <typename T>
   static scalar_expr construct_implicit(T v) {
+    static_assert(std::is_constructible_v<checked_int, T> || std::is_floating_point_v<T>);
     if constexpr (std::is_constructible_v<checked_int, T>) {
       return from_int(static_cast<checked_int>(v));
-    } else if constexpr (std::is_floating_point_v<T>) {
+    } else {
       return from_float(static_cast<double>(v));
     }
   }

--- a/components/core/wf/expression_variant.h
+++ b/components/core/wf/expression_variant.h
@@ -4,7 +4,6 @@
 
 #include "wf/error_types.h"
 #include "wf/hashing.h"
-#include "wf/traits.h"
 #include "wf/type_list.h"
 
 namespace wf {

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -99,7 +99,7 @@ struct multiply_visitor {
     } else if constexpr (std::is_same_v<T, integer_constant>) {
       if constexpr (FactorizeIntegers) {
         // Factorize integers into primes:
-        const auto factors = compute_prime_factors(arg.get_value());
+        const auto factors = compute_prime_factors(arg.value());
         insert_integer_factors(factors, true);
       } else {
         // Promote integers to rationals and multiply them onto `rational_coeff`.
@@ -161,14 +161,12 @@ void multiplication_parts::normalize_coefficients() {
     if (base && exponent) {
       const auto [integer_part, fractional_part] = factorize_rational_exponent(*exponent);
       // Update the rational coefficient:
-      if (integer_part.get_value() >= 0) {
+      if (integer_part >= 0) {
         rational_coeff =
-            rational_coeff *
-            rational_constant{integer_power(base->get_value(), integer_part.get_value()), 1};
+            rational_coeff * rational_constant{integer_power(base->value(), integer_part), 1};
       } else {
         rational_coeff =
-            rational_coeff *
-            rational_constant{1, integer_power(base->get_value(), -integer_part.get_value())};
+            rational_coeff * rational_constant{1, integer_power(base->value(), -integer_part)};
       }
 
       // We changed the exponent on this term, so update it.
@@ -211,7 +209,7 @@ scalar_expr multiplication_parts::create_multiplication() const {
     auto [coeff, mul] = as_coeff_and_mul(maybe_imaginary_coeff);
     if (is_negative_one(coeff)) {
       // If imaginary powers produced (-1), just multiply it onto the rational term.
-      rational_term = rational_term * integer_constant{-1};
+      rational_term = rational_term * -1;
     }
     if (!is_one(mul)) {
       // We still need the imaginary unit:
@@ -325,15 +323,15 @@ multiplication_format_parts get_formatting_info(const multiplication& mul) {
       }
     } else if (const integer_constant* const integer = get_if<const integer_constant>(expr);
                integer != nullptr) {
-      if (integer->get_value() != 1 && integer->get_value() != -1) {
+      if (integer->value() != 1 && integer->value() != -1) {
         result.numerator.emplace_back(integer->abs());
       }
-      if (integer->get_value() < 0) {
+      if (integer->value() < 0) {
         ++sign_count;
       }
     } else if (const float_constant* const f = get_if<const float_constant>(expr); f != nullptr) {
       result.numerator.emplace_back(f->abs());
-      if (f->get_value() < 0) {
+      if (f->value() < 0) {
         ++sign_count;
       }
     } else {

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "wf/algorithm_utils.h"
-#include "wf/constants.h"
+#include "wf/expression.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/special_constants.h"
 #include "wf/hashing.h"

--- a/components/core/wf/expressions/power.h
+++ b/components/core/wf/expressions/power.h
@@ -40,16 +40,15 @@ std::pair<scalar_expr, scalar_expr> as_base_and_exp(const scalar_expr& expr);
 // Convert a rational exponent to the whole integer part and the remainder.
 // If the exponent is negative, we add to the whole integer part so that the rational part
 // can be positive (i.e. we eliminate "absurd" rationals).
-constexpr std::pair<integer_constant, rational_constant> factorize_rational_exponent(
+constexpr std::pair<checked_int, rational_constant> factorize_rational_exponent(
     const rational_constant& r) {
-  const integer_constant integer_part{r.numerator() / r.denominator()};
+  const checked_int integer_part = r.numerator() / r.denominator();
   const rational_constant fractional_part_signed{r.numerator() % r.denominator(), r.denominator()};
   if (r.numerator() >= 0 || fractional_part_signed.is_zero()) {
     return std::make_pair(integer_part, fractional_part_signed);
   } else {
     // If negative, we subtract one from the integer part and make the rational part positive:
-    return std::make_pair(integer_constant{integer_part.get_value() - 1},
-                          fractional_part_signed + rational_constant{1, 1});
+    return std::make_pair(integer_part - 1, fractional_part_signed + rational_constant{1, 1});
   }
 }
 

--- a/components/core/wf/expressions/relational.cc
+++ b/components/core/wf/expressions/relational.cc
@@ -28,11 +28,11 @@ struct CompareNumerics {
 
   bool operator()(const integer_constant& a, const symbolic_constant& b) const {
     // This must have a value since float will not be nan.
-    return compare_int_float(a.get_value().value(), float_from_constant(b)).value() ==
+    return compare_int_float(a.value().value(), float_from_constant(b)).value() ==
            relative_order::less_than;
   }
   bool operator()(const symbolic_constant& a, const integer_constant& b) const {
-    return compare_int_float(b.get_value().value(), float_from_constant(a)).value() ==
+    return compare_int_float(b.value().value(), float_from_constant(a)).value() ==
            relative_order::greater_than;
   }
 
@@ -46,13 +46,13 @@ struct CompareNumerics {
 
   // Integer and float:
   bool operator()(const integer_constant& a, const float_constant& b) const {
-    const auto result = compare_int_float(a.get_value().value(), b.get_value());
+    const auto result = compare_int_float(a.value().value(), b.value());
     WF_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == relative_order::less_than;
   }
 
   bool operator()(const float_constant& a, const integer_constant& b) const {
-    const auto result = compare_int_float(b.get_value().value(), a.get_value());
+    const auto result = compare_int_float(b.value().value(), a.value());
     WF_ASSERT(result.has_value(), "Invalid float value: {}", b);
     return result.value() == relative_order::greater_than;
   }

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -398,7 +398,7 @@ scalar_expr atanh(const scalar_expr& arg) {
 // Support some very basic simplifications for numerical inputs.
 struct atan2_visitor {
   std::optional<scalar_expr> operator()(const float_constant& y, const float_constant& x) const {
-    return scalar_expr(std::atan2(y.get_value(), x.get_value()));
+    return scalar_expr(std::atan2(y.value(), x.value()));
   }
 
   std::optional<scalar_expr> operator()(const integer_constant& y,
@@ -406,22 +406,22 @@ struct atan2_visitor {
     static const scalar_expr pi_over_two = constants::pi / 2;
     static const scalar_expr neg_pi_over_two = -pi_over_two;
 
-    if (y.get_value() == 0 && x.get_value() == 1) {
+    if (y.value() == 0 && x.value() == 1) {
       return constants::zero;
-    } else if (y.get_value() == 1 && x.get_value() == 0) {
+    } else if (y.value() == 1 && x.value() == 0) {
       return pi_over_two;
-    } else if (y.get_value() == 0 && x.get_value() == -1) {
+    } else if (y.value() == 0 && x.value() == -1) {
       return constants::pi;
-    } else if (y.get_value() == -1 && x.get_value() == 0) {
+    } else if (y.value() == -1 && x.value() == 0) {
       return neg_pi_over_two;
-    } else if (y.abs() == x.abs() && x.get_value() != 0) {
+    } else if (y.abs() == x.abs() && x.value() != 0) {
       static const std::array<scalar_expr, 4> quadrant_solutions = {
           constants::pi / 4,
           3 * constants::pi / 4,
           -constants::pi / 4,
           -3 * constants::pi / 4,
       };
-      return quadrant_solutions[(y.get_value() < 0) * 2 + (x.get_value() < 0)];
+      return quadrant_solutions[(y.value() < 0) * 2 + (x.value() < 0)];
     }
     return std::nullopt;
   }
@@ -501,7 +501,7 @@ struct signum_visitor {
 
   // scalar_expr constructor will convert to `One` or `negative_one` constants for us
   std::optional<scalar_expr> operator()(const integer_constant& i) const {
-    return scalar_expr{sign(i.get_value())};
+    return scalar_expr{sign(i.value())};
   }
   std::optional<scalar_expr> operator()(const rational_constant& r) const {
     return scalar_expr{sign(r.numerator())};
@@ -510,7 +510,7 @@ struct signum_visitor {
     if (f.is_nan()) {
       return std::nullopt;
     }
-    return scalar_expr{sign(f.get_value())};
+    return scalar_expr{sign(f.value())};
   }
 
   std::optional<scalar_expr> operator()(const symbolic_constant& c) const {
@@ -555,16 +555,16 @@ struct floor_visitor {
     const auto [int_part, _] = r.normalized();
     if (r.is_negative()) {
       // Round down (away from zero) for negative values:
-      return scalar_expr{int_part.get_value() - 1};
+      return scalar_expr{int_part.value() - 1};
     }
-    return scalar_expr{int_part.get_value()};
+    return scalar_expr{int_part.value()};
   }
 
   std::optional<scalar_expr> operator()(const float_constant& f) const {
     if (f.is_nan()) {
       return std::nullopt;
     }
-    const auto floored = std::floor(f.get_value());
+    const auto floored = std::floor(f.value());
     return scalar_expr{static_cast<std::int64_t>(floored)};
   }
 

--- a/components/core/wf/numerical_casts.cc
+++ b/components/core/wf/numerical_casts.cc
@@ -32,7 +32,7 @@ struct convert_to_complex_visitor {
   }
 
   std::optional<complex_double> operator()(const float_constant f) const noexcept {
-    return complex_double{f.get_value(), 0.0};
+    return complex_double{f.value(), 0.0};
   }
 
   std::optional<complex_double> operator()(const imaginary_unit) const noexcept {
@@ -49,7 +49,7 @@ struct convert_to_complex_visitor {
     const auto [coeff, maybe_i] = as_coeff_and_mul(mul_abstract);
     if (const float_constant* f = get_if<const float_constant>(coeff);
         f != nullptr && is_i(maybe_i)) {
-      return complex_double{0.0, f->get_value()};
+      return complex_double{0.0, f->value()};
     }
     return std::nullopt;
   }
@@ -60,9 +60,9 @@ struct convert_to_complex_visitor {
 std::optional<std::variant<std::int64_t, double, std::complex<double>>> numerical_cast(
     const scalar_expr& expr) {
   if (const float_constant* f = get_if<const float_constant>(expr); f != nullptr) {
-    return f->get_value();
+    return f->value();
   } else if (const integer_constant* i = get_if<const integer_constant>(expr); i != nullptr) {
-    return static_cast<std::int64_t>(i->get_value());
+    return static_cast<std::int64_t>(i->value());
   } else if (const auto result = complex_cast(expr); result.has_value()) {
     return *result;
   }

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -172,7 +172,7 @@ void plain_formatter::operator()(const complex_infinity&) {
 void plain_formatter::operator()(const imaginary_unit&) { output_ += "I"; }
 
 void plain_formatter::operator()(const integer_constant& num) {
-  fmt::format_to(std::back_inserter(output_), "{}", num.get_value());
+  fmt::format_to(std::back_inserter(output_), "{}", num.value());
 }
 
 void plain_formatter::operator()(const iverson_bracket& bracket) {
@@ -182,7 +182,7 @@ void plain_formatter::operator()(const iverson_bracket& bracket) {
 }
 
 void plain_formatter::operator()(const float_constant& num) {
-  fmt::format_to(std::back_inserter(output_), "{}", num.get_value());
+  fmt::format_to(std::back_inserter(output_), "{}", num.value());
 }
 
 void plain_formatter::operator()(const matrix& mat) {

--- a/components/core/wf/substitute.cc
+++ b/components/core/wf/substitute.cc
@@ -198,7 +198,7 @@ struct substitute_mul_visitor : substitute_visitor_base<substitute_mul_visitor, 
     for (const auto& [base, exponent] : target_parts.terms) {
       auto it = input_parts.terms.find(base);
       WF_ASSERT(it != input_parts.terms.end());
-      it->second = it->second - (exponent * max_valid_exponent.get_value());
+      it->second = it->second - (exponent * max_valid_exponent.value());
     }
 
     // Insert the replacement
@@ -264,9 +264,9 @@ struct substitute_pow_visitor : substitute_visitor_base<substitute_pow_visitor, 
           // Subtract the integer part from the exponent.
           // For example, this would handle the replacement:
           // x**(4/3*y + z) replacing [x**y -> w] producing w * x**(1/3y + z)
-          it->second = it->second - target_exp_coeff * int_part.get_value();
+          it->second = it->second - target_exp_coeff * int_part.value();
           scalar_expr new_exponent = parts.create_addition();
-          return power::create(replacement, int_part.get_value()) *
+          return power::create(replacement, int_part.value()) *
                  power::create(candidate_base, new_exponent);
         }
       }
@@ -285,7 +285,7 @@ struct substitute_pow_visitor : substitute_visitor_base<substitute_pow_visitor, 
           // Can't do a full division
           return input_expression;
         }
-        return power::create(replacement, int_part.get_value()) *
+        return power::create(replacement, int_part.value()) *
                power::create(candidate_base, target_exponent * scalar_expr(frac_remainder));
       }
     }

--- a/components/core/wf/traits.h
+++ b/components/core/wf/traits.h
@@ -10,7 +10,7 @@ namespace wf {
 // Struct for getting argument types and return types from a function pointer or lambda.
 // This specialization is for lambdas.
 template <typename T>
-struct function_traits : public function_traits<decltype(&T::operator())> {};
+struct function_traits : function_traits<decltype(&T::operator())> {};
 
 // This specialization is for member functions (like operator() on a lambda).
 template <typename ClassType, typename Ret, typename... Args>
@@ -25,7 +25,7 @@ struct function_traits<Ret (ClassType::*)(Args...) const> {
 
   // Get the i'th argument type.
   template <std::size_t i>
-  using args_list_element_t = typename std::tuple_element<i, std::tuple<Args...>>::type;
+  using args_list_element_t = std::tuple_element_t<i, std::tuple<Args...>>;
 };
 
 // This specialization is for general function pointers.
@@ -41,7 +41,7 @@ struct function_traits<Ret (*)(Args...)> {
 
   // Get the i'th argument type.
   template <std::size_t i>
-  using args_list_element_t = typename std::tuple_element<i, std::tuple<Args...>>::type;
+  using args_list_element_t = std::tuple_element_t<i, std::tuple<Args...>>;
 };
 
 // Enable if to check that two types are the same.

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -69,7 +69,7 @@ void tree_formatter_visitor::operator()(const external_function_invocation& invo
 }
 
 void tree_formatter_visitor::operator()(const float_constant& f) {
-  format_append("{} ({})", float_constant::name_str, f.get_value());
+  format_append("{} ({})", float_constant::name_str, f.value());
 }
 
 void tree_formatter_visitor::operator()(const function& func) {
@@ -82,7 +82,7 @@ void tree_formatter_visitor::operator()(const imaginary_unit&) {
 }
 
 void tree_formatter_visitor::operator()(const integer_constant& i) {
-  format_append("{} ({})", integer_constant::name_str, i.get_value());
+  format_append("{} ({})", integer_constant::name_str, i.value());
 }
 
 void tree_formatter_visitor::operator()(const iverson_bracket& bracket) {


### PR DESCRIPTION
A couple of minor cleanup tasks for `integer_constant`:
- Get rid of operator overloads that were redundant with `checked_int`.
- Rename `get_value` to `value` (which is the accessor naming style used everywhere else).