### PR TITLE
Clean up string utilities

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -7,13 +7,12 @@ add_library(
   wf/boolean_expression.h
   wf/checked_int.h
   wf/checked_pointers.h
+  wf/code_generation/ast.cc
+  wf/code_generation/ast.h
   wf/code_generation/ast_conversion.cc
   wf/code_generation/ast_conversion.h
   wf/code_generation/ast_element.h
   wf/code_generation/ast_formatters.h
-  wf/code_generation/ast.cc
-  wf/code_generation/ast.h
-  wf/code_generation/code_formatter.h
   wf/code_generation/control_flow_graph.cc
   wf/code_generation/control_flow_graph.h
   wf/code_generation/cpp_code_generator.cc
@@ -53,11 +52,11 @@ add_library(
   wf/enumerations.h
   wf/error_types.h
   wf/evaluate.cc
+  wf/expression.cc
+  wf/expression.h
   wf/expression_cache.h
   wf/expression_variant.h
   wf/expression_visitor.h
-  wf/expression.cc
-  wf/expression.h
   wf/expressions/addition.cc
   wf/expressions/addition.h
   wf/expressions/all_expressions.h
@@ -106,6 +105,7 @@ add_library(
   wf/output_annotations.h
   wf/plain_formatter.cc
   wf/plain_formatter.h
+  wf/string_utils.h
   wf/substitute.cc
   wf/template_utils.h
   wf/third_party_imports.h

--- a/components/core/tests/CMakeLists.txt
+++ b/components/core/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_single_file_test(plain_formatter_test.cc)
 add_single_file_test(quaternion_test.cc)
 add_single_file_test(checked_int_test.cc)
 add_single_file_test(scalar_operations_test.cc)
+add_single_file_test(string_utils_test.cc)
 add_single_file_test(substitute_test.cc)
 add_single_file_test(type_list_test.cc)
 

--- a/components/core/tests/cpp_generation_gen.cc
+++ b/components/core/tests/cpp_generation_gen.cc
@@ -15,7 +15,7 @@ class custom_cpp_code_generator final : public cpp_code_generator {
   using cpp_code_generator::operator();
 
   std::string operator()(const ast::call_external_function& func) const override {
-    return fmt::format("test::{}({})", func.function.name(), join(*this, ", ", func.args));
+    return fmt::format("test::{}({})", func.function.name(), join(", ", func.args, *this));
   }
 
   std::string operator()(const custom_type& custom) const override {
@@ -41,7 +41,7 @@ class custom_cpp_code_generator final : public cpp_code_generator {
 
   // ... And how they are constructed:
   std::string operator()(const ast::construct_matrix& construct) const override {
-    const std::string args = join(*this, ", ", construct.args);
+    const std::string args = join(", ", construct.args, *this);
     return fmt::format("(Eigen::Matrix<Scalar, {}, {}>() << {}).finished()", construct.type.rows(),
                        construct.type.cols(), args);
   }

--- a/components/core/tests/rust_generation_gen.cc
+++ b/components/core/tests/rust_generation_gen.cc
@@ -56,7 +56,7 @@ class custom_rust_code_generator final : public rust_code_generator {
   }
 
   std::string operator()(const ast::construct_matrix& construct) const override {
-    const std::string args = join(*this, ", ", construct.args);
+    const std::string args = join(", ", construct.args, *this);
     return fmt::format("nalgebra::SMatrix::<f64, {}, {}>::new({})", construct.type.rows(),
                        construct.type.cols(), args);
   }

--- a/components/core/tests/string_utils_test.cc
+++ b/components/core/tests/string_utils_test.cc
@@ -1,0 +1,50 @@
+// Copyright 2024 Gareth Cross
+#include <gtest/gtest.h>
+
+#include "wf/string_utils.h"
+
+// Tests for functions in `string_utils`.
+namespace wf {
+
+TEST(StringUtilsTest, TestFmtView) {
+  // Formatters that transform values:
+  EXPECT_EQ(
+      "6, 12, 13_x",
+      fmt::format("{}, {}, {}", make_fmt_view([](auto x) { return std::to_string(x * 3); }, 2),
+                  make_fmt_view([](auto x) { return std::to_string(x + 5); }, 7),
+                  make_fmt_view([](auto x) { return std::to_string(x) + "_x"; }, 13)));
+
+  struct type_printer {
+    std::string operator()(int x) const { return fmt::format("int: {}", x); }
+    std::string operator()(double x) const { return fmt::format("double: {}", x); }
+  };
+  EXPECT_EQ("int: 5, double: 22", fmt::format("{}, {}", make_fmt_view(type_printer{}, 5),
+                                              make_fmt_view(type_printer{}, 22.0)));
+
+  // Test that we can store vector in the view.
+  struct vector_printer {
+    std::string operator()(const std::vector<int>& data) const {
+      return fmt::format("vector of size {}, first = {}", data.size(), data.front());
+    }
+  };
+  EXPECT_EQ("vector of size 3, first = 89",
+            fmt::format("{}", make_fmt_view(vector_printer{}, std::vector{89, 64, 123})));
+}
+
+TEST(StringUtilsTest, TestJoin) {
+  EXPECT_EQ("", join(", ", std::vector<int>{}, [](auto x) { return std::to_string(x); }));
+  EXPECT_EQ("alone", join(", ", std::vector<std::string_view>{"alone"}, [](auto x) { return x; }));
+  EXPECT_EQ("1, 2, 3", join(", ", std::vector{1, 2, 3}, [](auto x) { return std::to_string(x); }));
+  EXPECT_EQ("llo; rld; iend", join("; ", std::vector<std::string_view>{"hello", "world", "friend"},
+                                   [](auto x) { return x.substr(2); }));
+}
+
+TEST(StringUtilsTest, TestJoinEnumerate) {
+  const std::vector<std::string_view> elements{"alea", "iacta", "est"};
+  EXPECT_EQ("0: alea, 1: iacta, 2: est",
+            join_enumerate(", ", elements, [](std::size_t index, auto element) {
+              return fmt::format("{}: {}", index, element);
+            }));
+}
+
+}  // namespace wf

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Gareth Cross
 #pragma once
 #include "wf/code_generation/ast.h"
-#include "wf/code_generation/code_formatter.h"
+#include "wf/string_utils.h"
 
 namespace wf {
 

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Gareth Cross
 #pragma once
 #include "wf/code_generation/ast.h"
-#include "wf/code_generation/code_formatter.h"
+#include "wf/string_utils.h"
 
 namespace wf {
 

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -3,6 +3,7 @@
 #include "wf/assertions.h"
 #include "wf/common_visitors.h"
 #include "wf/expression_visitor.h"
+#include "wf/string_utils.h"
 #include "wf/third_party_imports.h"
 
 WF_BEGIN_THIRD_PARTY_INCLUDES


### PR DESCRIPTION
- Move `code_formatter.h` to `string_utils.h`
- Add some test coverage to `string_utils.h`
- Delete a couple of redundant methods
- Fix a bug where make_fmt_view did not handle string literals correctly in the captured args. (It stored `const char*&` instead of `const char*`)