### PR TITLE
Raise bspline test threshold (for mac aarch64)

### DIFF
--- a/examples/bspline/bspline_test.cc
+++ b/examples/bspline/bspline_test.cc
@@ -243,7 +243,7 @@ TEST(BSplineTest, TestBSplineCoeffsOrder6) {
           });
 
       // High tolerance here, the higher order derivatives have very large values.
-      ASSERT_EIGEN_NEAR(D_numerical, evaluated.col(d).eval(), 1.0e-6)
+      ASSERT_EIGEN_NEAR(D_numerical, evaluated.col(d).eval(), 2.0e-6)
           << fmt::format("d = {}, x = {}", d, x);
     }
   }


### PR DESCRIPTION
This test fails when run on M2/aarch64 mac. It looks like the github runners use `osx-64`, which explains why it passes on CI. I'm raising the threshold a bit here so it passes on aarch64.