### PR TITLE
Disable motion_planning test on windows

### DIFF
--- a/examples/motion_planning/motion_planning_test/src/lib.rs
+++ b/examples/motion_planning/motion_planning_test/src/lib.rs
@@ -1,9 +1,14 @@
+//! This module continues to cause issues on Windows CI (OOM).
+//! Until I have time to make the generated functions shorter, I am disabling it.
+#![cfg(not(target_os = "windows"))]
+
 pub mod generated;
 pub mod problem;
 
 pub use problem::{ProblemInfo, Weights};
 
 #[cfg(test)]
+#[cfg(not(target_os = "windows"))]
 mod tests {
     use crate::problem;
     use argmin::core::{Executor, State};

--- a/examples/motion_planning/motion_planning_test/src/problem.rs
+++ b/examples/motion_planning/motion_planning_test/src/problem.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "windows"))]
+
 use argmin::core::{CostFunction, Error, Gradient, Hessian};
 use nalgebra as na;
 use ndarray::{Array1, Array2};


### PR DESCRIPTION
Disabling this on windows again, since it is causing OOM problems on CI during rust compilation. Not sure why this came back (possible the CI runner rust version was raised). Still need to take a look at making the compiled output shorter for this function.

CC @hi-mel 