### PR TITLE
Speed up rust CI tasks

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -79,9 +79,17 @@ jobs:
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: ctest --output-on-failure
 
+      - name: Install rust
+        run: rustup toolchain install stable --profile minimal
+
       - name: Dump rustc version
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: rustc --version
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> ${{runner.workspace}}/build-${{matrix.build_type}}/cargo
 
       - name: Cargo test
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -77,9 +77,17 @@ jobs:
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: ctest --output-on-failure
 
+      - name: Install rust
+        run: rustup toolchain install stable --profile minimal
+
       - name: Dump rustc version
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: rustc --version
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> ${{runner.workspace}}/build-${{matrix.build_type}}/cargo
 
       - name: Cargo test
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -87,9 +87,17 @@ jobs:
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: ctest --output-on-failure
 
+      - name: Install rust
+        run: rustup toolchain install stable --profile minimal
+
       - name: Dump rustc version
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}
         run: rustc --version
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> ${{runner.workspace}}/build-${{matrix.build_type}}/cargo
 
       - name: Cargo test
         working-directory: ${{runner.workspace}}/build-${{matrix.build_type}}


### PR DESCRIPTION
- Add caching via the [rust-cache](https://github.com/marketplace/actions/rust-cache) action.
- Run clippy with `--no-deps` to skip third party dependencies.