### PR TITLE
Fix incorrect definition of quaternion::inverse

### DIFF
--- a/components/core/wf/geometry/quaternion.cc
+++ b/components/core/wf/geometry/quaternion.cc
@@ -28,6 +28,11 @@ scalar_expr quaternion::squared_norm() const {
 
 scalar_expr quaternion::norm() const { return sqrt(squared_norm()); }
 
+quaternion quaternion::inverse() const {
+  const scalar_expr n2 = squared_norm();
+  return {w() / n2, x() / -n2, y() / -n2, z() / -n2};
+}
+
 matrix_expr quaternion::to_rotation_matrix() const {
   const scalar_expr x2 = x() * 2;
   const scalar_expr y2 = y() * 2;

--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -82,12 +82,8 @@ class quaternion {
   // [w, x, y, z] --> [w, -x, -y, -z].
   [[nodiscard]] quaternion conjugate() const { return {w(), -x(), -y(), -z()}; }
 
-  // Invert the quaternion by conjugating and normalizing.
-  [[nodiscard]] quaternion inverse() const {
-    const scalar_expr n = norm();
-    const scalar_expr negative_norm = -n;
-    return {w() / n, x() / negative_norm, y() / negative_norm, z() / negative_norm};
-  }
+  // Invert the quaternion by conjugating and dividing by squared norm.
+  [[nodiscard]] quaternion inverse() const;
 
   // Convert a unit-norm to a rotation matrix. If the input does not have unit norm, the
   // result will not be a valid member of SO(3).

--- a/components/wrapper/tests/geometry_wrapper_test.py
+++ b/components/wrapper/tests/geometry_wrapper_test.py
@@ -72,8 +72,12 @@ class GeometryWrapperTest(MathTestBase):
         self.assertIdentical(0, q_ident.y)
         self.assertIdentical(0, q_ident.z)
 
+        q = Quaternion(4, -3, 1, -2)
         q_ident = q * q.inverse()
-        self.assertIdentical(1, q_ident.w.collect(squared_norm).subs(squared_norm, 1))
+        self.assertIdentical(1, q_ident.w)
+        self.assertIdentical(0, q_ident.x)
+        self.assertIdentical(0, q_ident.y)
+        self.assertIdentical(0, q_ident.z)
 
     def test_to_rotation_matrix(self):
         """Test calling to_rotation_matrix."""


### PR DESCRIPTION
Quaternion `inverse()` had not been adequately tested, and was defined as dividing by `norm` instead of `squared_norm` (this is incorrect). This change fixes the issue and improves the test to catch this.