### PR TITLE
Fix `tan()` handling of multiples of pi

### DIFF
--- a/components/core/tests/functions_test.cc
+++ b/components/core/tests/functions_test.cc
@@ -53,6 +53,13 @@ TEST(FunctionsTest, TestCosine) {
                      cos(constants::pi * -2_s / 7_s + scalar_expr(2 * i) * constants::pi));
   }
 
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::cos, constants::pi / 4),
+                   cos(constants::pi / 4));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::cos, constants::pi / 6),
+                   cos(constants::pi / 6));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::cos, -constants::pi / 12),
+                   cos(-constants::pi / 12));
+
   // Sign adjustment
   ASSERT_IDENTICAL(cos(x), cos(-x));
   ASSERT_IDENTICAL(cos(5_s * x * y), cos(-y * 5_s * x));
@@ -98,6 +105,13 @@ TEST(FunctionsTest, TestSine) {
                      sin(constants::pi * -6_s / 13_s + scalar_expr(2 * i) * constants::pi));
   }
 
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::sin, constants::pi / 4),
+                   sin(constants::pi / 4));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::sin, constants::pi / 6),
+                   sin(constants::pi / 6));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::sin, -constants::pi / 12),
+                   sin(-constants::pi / 12));
+
   ASSERT_IDENTICAL(-sin(x), sin(-x));
   ASSERT_IDENTICAL(-sin(y / x), sin(y / -x));
   ASSERT_IDENTICAL(-sin(3_s / 5_s), sin(-3_s / 5_s));
@@ -137,6 +151,13 @@ TEST(FunctionsTest, TestTan) {
     ASSERT_IDENTICAL(tan(constants::pi * -3_s / 13_s),
                      tan(constants::pi * -3_s / 13_s + scalar_expr(i) * constants::pi));
   }
+
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::tan, constants::pi / 4),
+                   tan(constants::pi / 4));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::tan, constants::pi / 6),
+                   tan(constants::pi / 6));
+  ASSERT_IDENTICAL(make_expr<function>(built_in_function::tan, -constants::pi / 12),
+                   tan(-constants::pi / 12));
 
   ASSERT_IDENTICAL(-tan(x), tan(-x));
   ASSERT_IDENTICAL(-tan(x * y), tan(-x * y));

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -189,7 +189,7 @@ scalar_expr tan(const scalar_expr& arg) {
         return constants::complex_infinity;
       }
       return make_expr<function>(built_in_function::tan,
-                                 scalar_expr(r_mod_half_pi) * pi_over_two());
+                                 scalar_expr(r_mod_half_pi) * constants::pi);
     }
   } else if (is_zero(arg)) {
     return constants::zero;


### PR DESCRIPTION
There is a pretty silly bug in the handling of expressions like `tan(pi / 4)` (multiples of pi), where the argument value would get divided by an additional two (if the other simplification cases did not apply). This change resolves this bug.