### PR TITLE
ExternalFunction inherits from PyExternalFunction

### DIFF
--- a/components/core/tests/generation_test_2.py
+++ b/components/core/tests/generation_test_2.py
@@ -19,12 +19,15 @@ class StructType:
 
 
 class VectorOfStructs(Opaque):
-    """This is a placeholder that will be generated as std::vector<StructType> or std::vec::Vec<StructType>."""
+    """
+    This is a placeholder that will be generated as std::vector<StructType> or
+    std::vec::Vec<StructType>.
+    """
 
-    def interpolate_access(self, x: sym.Expr) -> sym.Expr:
+    def interpolate_access(self, x: sym.Expr) -> StructType:
         """
-        We assume a user-defined external function that accepts a value `x` and uses it to linearly interpolate
-        between values in our `VectorOfStructs`.
+        We assume a user-defined external function that accepts a value `x` and uses it to linearly
+        interpolate between values in our `VectorOfStructs`.
         """
         return vector_interpolate_access(vec=self, x=x)
 
@@ -52,7 +55,7 @@ class CustomCppGenerator(CppGenerator):
 
     def format_call_external_function(self, element: ast.CallExternalFunction) -> str:
         """
-        Place our custom functions in the `external` namespace.
+        Place our external functions in the `external` namespace.
         """
         args = ', '.join(self.format(x) for x in element.args)
         return f'external::{element.function.name}({args})'
@@ -61,9 +64,9 @@ class CustomCppGenerator(CppGenerator):
         """
         Place `StructType` in `types` namespace. Format vector name.
         """
-        if element.python_type is StructType:
+        if element.python_type == StructType:
             return f'types::{element.name}'
-        elif element.python_type is VectorOfStructs:
+        elif element.python_type == VectorOfStructs:
             return f'std::vector<types::StructType>'
         return self.super_format(element)
 
@@ -73,7 +76,7 @@ class CustomCppGenerator(CppGenerator):
         TODO: Unify this with `format_custom_type`.
         """
         if isinstance(element.type,
-                      type_info.CustomType) and element.type.python_type is StructType:
+                      type_info.CustomType) and element.type.python_type == StructType:
             return f'types::{element.type.name}'
         return self.super_format(element)
 
@@ -88,9 +91,9 @@ class CustomRustGenerator(RustGenerator):
         return f'crate::external::{element.function.name}({args})'
 
     def format_custom_type(self, element: type_info.CustomType) -> str:
-        if element.python_type is StructType:
+        if element.python_type == StructType:
             return f'crate::types::{element.name}'
-        elif element.python_type is VectorOfStructs:
+        elif element.python_type == VectorOfStructs:
             return f'std::vec::Vec<crate::types::StructType>'
         return self.super_format(element)
 

--- a/components/wrapper/pywrenfold/codegen_wrapper.cc
+++ b/components/wrapper/pywrenfold/codegen_wrapper.cc
@@ -72,18 +72,22 @@ void wrap_argument(py::module_& m) {
 }
 
 void wrap_codegen_operations(py::module_& m) {
-  // We give this a Py prefix since we wrap it in python with another object.
+  // We give this a Py prefix since we subclass it in python with another object.
   wrap_class<external_function>(m, "PyExternalFunction")
       .def(py::init(&init_external_function), py::arg("name"), py::arg("arguments"),
-           py::arg("return_type"))
-      .def_property_readonly("name", &external_function::name)
-      .def_property_readonly("arguments", &external_function::arguments)
-      .def_property_readonly("num_arguments", &external_function::num_arguments)
+           py::arg("return_type"), "Construct with name, arguments, and return type.")
+      .def(py::init<external_function>(), "Copy constructor.")
+      .def_property_readonly("name", &external_function::name, "Name of the function.")
+      .def_property_readonly("arguments", &external_function::arguments, "List of arguments.")
+      .def_property_readonly("num_arguments", &external_function::num_arguments,
+                             "Number of arguments the function expects to receive.")
       .def("arg_position", &external_function::arg_position, py::arg("arg"),
-           py::doc("Find the position of the argument with the specified name."))
-      .def_property_readonly("return_type", &external_function::return_type)
-      .def("__call__", &call_external_function, py::arg("args"),
-           py::doc("Call external function and create return expression."))
+           "Find the position of the argument with the specified name.")
+      .def_property_readonly("return_type", &external_function::return_type,
+                             "Return type of the function. This will determine the type of "
+                             "variable we must declare in code-generated functions.")
+      .def("call", &call_external_function, py::arg("args"),
+           "Call external function and create return expression. OMIT_FROM_SPHINX")
       .def("__repr__", [](const external_function& self) {
         const auto args = transform_map<std::vector<std::string>>(
             self.arguments(),

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -195,7 +195,7 @@ class CustomCppGenerator(CppGenerator):
         """Place our custom types into the `geo` namespace."""
         if element.python_type in [Point3d, Pose3d]:
             return f'geo::{element.name}'
-        elif element.python_type is EigenQuaternion:
+        elif element.python_type == EigenQuaternion:
             return f'Eigen::Quaternion<double>'
         return self.super_format(element)
 
@@ -210,7 +210,7 @@ class CustomCppGenerator(CppGenerator):
         return f'Eigen::Matrix<double, {element.type.num_rows}, {element.type.num_cols}>({formatted_args})'
 
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
-        if element.type.python_type is EigenQuaternion:
+        if element.type.python_type == EigenQuaternion:
             # Eigen quaternion expects constructor args in order (w, x, y, z)
             arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ', '.join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
@@ -226,9 +226,9 @@ class CustomRustGenerator(RustGenerator):
         """
         Use member accessors for the Pose3 type.
         """
-        if element.struct_type.python_type is Pose3d:
+        if element.struct_type.python_type == Pose3d:
             return f"{self.format(element.arg)}.{element.field_name}()"
-        elif element.struct_type.python_type is EigenQuaternion:
+        elif element.struct_type.python_type == EigenQuaternion:
             # Customize accessors for UnitQuaternion in rust:
             if element.field_name in ("x", "y", "z"):
                 return f'{self.format(element.arg)}.imag().{element.field_name}'
@@ -241,7 +241,7 @@ class CustomRustGenerator(RustGenerator):
         """Place our custom types into the `geo` namespace."""
         if element.python_type in [Point3d, Pose3d]:
             return f'crate::geo::{element.name}'
-        elif element.python_type is EigenQuaternion:
+        elif element.python_type == EigenQuaternion:
             return f'nalgebra::UnitQuaternion::<f64>'
         return self.super_format(element)
 
@@ -252,11 +252,11 @@ class CustomRustGenerator(RustGenerator):
 
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
         """Use a `new()` method for our Pose3 type, and the UnitQuaternion constructor for rotations."""
-        if element.type.python_type is Pose3d:
+        if element.type.python_type == Pose3d:
             r = self.format(element.get_field_value("rotation"))
             t = self.format(element.get_field_value("translation"))
             return f'crate::geo::Pose3d::new(\n  {r},\n  {t}\n)'
-        elif element.type.python_type is EigenQuaternion:
+        elif element.type.python_type == EigenQuaternion:
             # Order for nalgebra is [w, x, y, z]
             arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ', '.join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))


### PR DESCRIPTION
Previously, `ExternalFunction` wrapped a `PyExternalFunction`. This caused issues though because when `__eq__` was called with the arguments in the wrong order, it would call the base function instead (and fail to match).

This change switches their relationship to inheritance, which causes the base version to always be called (and returns True/False in the correct situations). It also eliminates some duplicated code on the python side.