### PR TITLE
Euler constant is printed as `E`

### DIFF
--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -170,7 +170,7 @@ TEST(PlainFormatterTest, TestUndefined) { ASSERT_STR_EQ("nan", constants::undefi
 
 TEST(PlainFormatterTest, TestScalarConstants) {
   ASSERT_STR_EQ("pi", constants::pi);
-  ASSERT_STR_EQ("e", constants::euler);
+  ASSERT_STR_EQ("E", constants::euler);
   ASSERT_STR_EQ("I", constants::imaginary_unit);
 }
 

--- a/components/core/wf/enumerations.h
+++ b/components/core/wf/enumerations.h
@@ -231,7 +231,7 @@ constexpr std::string_view string_from_symbolic_constant(
     const symbolic_constant_enum value) noexcept {
   switch (value) {
     case symbolic_constant_enum::euler:
-      return "e";
+      return "E";
     case symbolic_constant_enum::pi:
       return "pi";
   }

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -114,6 +114,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertReprEqual('x == z', sym.eq(x, z))
         self.assertReprEqual('iverson(z < x)', sym.iverson(x > z))
         self.assertReprEqual('I', sym.I)
+        self.assertReprEqual('E', sym.E)
         self.assertReprEqual('2 + 5*I', 2 + 5 * sym.I)
 
     def test_bool_conversion(self):

--- a/docs/source/tutorial/symbolic_manipulation.rst
+++ b/docs/source/tutorial/symbolic_manipulation.rst
@@ -80,7 +80,7 @@ Or substitute numerical constants and evaluate into a floating point value:
 
     >>> val = df.subs(x, sym.E).subs(y, sym.integer(1) / 3)
     >>> val
-    e**2 - sin(e/3)/3
+    E**2 - sin(E/3)/3
     >>> val.eval()
     7.126689299943595
 


### PR DESCRIPTION
Improve consistency with sympy and print euler's constant as capital `E`