### PR TITLE
Fix handling of add+mul when the result is floating point zero

### DIFF
--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -26,8 +26,13 @@ struct multiply_numeric_constants {
   // Promote int and rational to float:
   template <typename B, typename = enable_if_contains_type_t<B, float_constant, integer_constant,
                                                              rational_constant>>
-  constexpr float_constant operator()(const float_constant a, const B b) const {
-    return a * static_cast<float_constant>(b);
+  constexpr multiplication_parts::constant_coeff operator()(const float_constant a,
+                                                            const B b) const {
+    if (const float_constant prod = a * static_cast<float_constant>(b); !prod.is_zero()) {
+      return prod;
+    }
+    // Float multiplications that work out to zero should be converted to integer zero.
+    return integer_constant{0};
   }
 
   // Anything times undefined is undefined.


### PR DESCRIPTION
In https://github.com/gareth-cross/wrenfold/pull/131 I cleaned up some logic in addition+multiplication and fixed some edge cases. Unfortunately I introduced one new bug: 

When the total of an addition or multiplication was _floating point_ zero (ie. `0.0` not `0`), it would not get simplified to integer zero. This didn't cause any results to be wrong, but prevented some simplifications. As a result, the `motion_planning` example generation time got much higher (from ~2 seconds to 16 seconds).

This change fixes the behavior, and adds more test coverage so it does not occur again.