### PR TITLE
Add tracing

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(
   wf/output_annotations.h
   wf/plain_formatter.cc
   wf/plain_formatter.h
+  wf/scoped_trace.cc
+  wf/scoped_trace.h
   wf/string_utils.h
   wf/substitute.cc
   wf/template_utils.h
@@ -141,6 +143,12 @@ target_link_libraries(wf_core wf_runtime fmt::fmt-header-only
                       absl::inlined_vector absl::span)
 if(WIN32)
   target_compile_definitions(wf_core PUBLIC -D_USE_MATH_DEFINES)
+endif()
+
+option(WF_BUILD_WITH_TRACING "Enable traces for profiling." OFF)
+if(WF_BUILD_WITH_TRACING)
+  message(STATUS "Building with tracing enabled.")
+  target_compile_definitions(wf_core PUBLIC -DWF_ENABLE_TRACING)
 endif()
 
 target_include_directories(

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -7,6 +7,7 @@
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/special_constants.h"
 #include "wf/expressions/variable.h"
+#include "wf/scoped_trace.h"
 #include "wf/template_utils.h"
 
 namespace wf::ast {
@@ -550,6 +551,7 @@ ast::ast_element ast_form_visitor::format_operation_count_comment() const {
 
 function_definition create_ast(const wf::control_flow_graph& ir,
                                const function_description& description) {
+  WF_FUNCTION_TRACE();
   ast_form_visitor converter{ir.value_print_width(), description};
   return converter.convert_function(ir.first_block());
 }

--- a/components/core/wf/code_generation/control_flow_graph.cc
+++ b/components/core/wf/code_generation/control_flow_graph.cc
@@ -12,6 +12,7 @@
 #include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/hashing.h"
+#include "wf/scoped_trace.h"
 
 namespace wf {
 namespace ir {
@@ -129,6 +130,7 @@ using value_table =
 
 // Eliminate duplicates in `block`, using existing values stored in `table`.
 inline void local_value_numbering(const ir::block_ptr block, value_table& table) {
+  WF_FUNCTION_TRACE();
   for (const ir::value_ptr val : block->operations()) {
     // Then see if this operation already exists in the map:
     if (auto [it, was_inserted] = table.insert(val); !was_inserted) {
@@ -176,6 +178,7 @@ class sort_expression_order_visitor {
 
 // We pass `groups` by copy so we can replace the expressions with sorted versions below:
 control_flow_graph::control_flow_graph(std::vector<expression_group> groups) {
+  WF_FUNCTION_TRACE();
   blocks_.push_back(std::make_unique<ir::block>(0));
 
   // First pass where we sort things into a canonical order, and count operations.
@@ -205,11 +208,13 @@ control_flow_graph::control_flow_graph(std::vector<expression_group> groups) {
 }
 
 control_flow_graph control_flow_graph::convert_conditionals_to_control_flow() && {
+  WF_FUNCTION_TRACE();
   return ir_control_flow_converter{std::move(*this)}.convert();
 }
 
 // ReSharper disable once CppMemberFunctionMayBeConst
 void control_flow_graph::eliminate_duplicates() {
+  WF_FUNCTION_TRACE();
   value_table table{};
   table.reserve(values_.size());
   local_value_numbering(first_block(), table);

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -3,6 +3,7 @@
 
 #include "wf/common_visitors.h"
 #include "wf/expression_visitor.h"
+#include "wf/scoped_trace.h"
 
 namespace wf {
 
@@ -427,6 +428,7 @@ mul_add_count_visitor::mul_add_count_visitor() {
 }
 
 void mul_add_count_visitor::count_group_expressions(const expression_group& group) {
+  WF_FUNCTION_TRACE();
   for (const scalar_expr& expr : group.expressions) {
     visit(expr, *this);
   }

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -7,6 +7,8 @@
 #include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
 #include "wf/matrix_expression.h"
+#include "wf/scoped_trace.h"
+
 #include "wrenfold/span.h"
 
 namespace wf {
@@ -66,6 +68,7 @@ scalar_expr derivative_visitor::apply(const scalar_expr& expression) {
 
 // Differentiate every argument to make a new sum.
 scalar_expr derivative_visitor::operator()(const addition& add) {
+  WF_SCOPED_TRACE_STR("wf::derivative_visitor::operator()(const addition&)");
   return add.map_children([this](const scalar_expr& expr) { return apply(expr); });
 }
 
@@ -303,6 +306,7 @@ scalar_expr diff(const scalar_expr& function, const scalar_expr& var, const int 
 matrix_expr jacobian(const absl::Span<const scalar_expr> functions,
                      const absl::Span<const scalar_expr> vars,
                      const non_differentiable_behavior behavior) {
+  WF_FUNCTION_TRACE();
   if (functions.empty()) {
     throw dimension_error("Need at least one function to differentiate.");
   }

--- a/components/core/wf/scoped_trace.cc
+++ b/components/core/wf/scoped_trace.cc
@@ -1,0 +1,147 @@
+#include "wf/scoped_trace.h"
+
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <optional>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <unistd.h>  // getpid
+#ifdef __APPLE__
+#include <pthread.h>  // pthread_mach_thread_np
+#else
+#include <sys/syscall.h>  // syscall
+#include <sys/types.h>
+#endif  // __APPLE__
+#endif  // _WIN32
+
+#include "wf/assertions.h"
+#include "wf/third_party_imports.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/core.h>
+WF_END_THIRD_PARTY_INCLUDES
+
+// Format wf::trace_event to JSON.
+template <>
+struct fmt::formatter<wf::trace_event> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const wf::trace_event& event, FormatContext& ctx) const -> decltype(ctx.out()) {
+    constexpr std::string_view phase = "X";  //  Complete event.
+    constexpr std::string_view fmt_template =
+        R"json({{ "name": "{name}", "cat": "", "ph": "{ph}", "ts": {ts}, "pid": {pid}, "tid": {tid}, "dur": {dur}, "dur_ns": {dur_ns} }})json";
+    return fmt::format_to(ctx.out(), fmt_template, fmt::arg("name", event.name),
+                          fmt::arg("ph", phase), fmt::arg("ts", event.ts),
+                          fmt::arg("pid", event.pid), fmt::arg("tid", event.tid),
+                          fmt::arg("dur", event.dur_ns / 1000), fmt::arg("dur_ns", event.dur_ns));
+  }
+};
+
+namespace wf {
+
+// Object that initializes the PID and TID on construction.
+struct pid_and_tid {
+  pid_and_tid() noexcept {
+#ifdef _WIN32
+    // These return long (on 64-bit windows), but the underlying value is 32 bits.
+    pid = static_cast<std::uint32_t>(GetCurrentProcessId());
+    tid = static_cast<std::uint32_t>(GetCurrentThreadId());
+#elif defined(__APPLE__)
+    pid = static_cast<std::uint32_t>(getpid());
+    tid = static_cast<std::uint32_t>(pthread_mach_thread_np(pthread_self()));
+#else
+    // Linux
+    // https://stackoverflow.com/questions/21091000
+    pid = static_cast<std::uint32_t>(getpid());
+    tid = static_cast<std::uint32_t>(syscall(__NR_gettid));
+#endif
+  }
+
+  std::uint32_t pid;
+  std::uint32_t tid;
+};
+
+struct trace_collector_impl {
+  std::deque<trace_event> events;
+  std::mutex mutex;
+  std::string output_path{};
+};
+
+trace_collector* trace_collector::get_instance() {
+  static trace_collector global_collector{};
+  return &global_collector;
+}
+
+inline constexpr std::string_view json_object_template = R"json(
+{{
+  "traceEvents": [
+    {}
+  ],
+  "displayTimeUnit": "ns"
+}}
+)json";
+
+trace_collector::trace_collector() : impl_(std::make_unique<trace_collector_impl>()) {
+  WF_ASSERT(impl_);
+}
+
+trace_collector::~trace_collector() {
+  if (std::uncaught_exceptions() > 0) {
+    // Don't do anything that could throw if exceptions are in flight.
+    return;
+  }
+  write_traces();
+}
+
+void trace_collector::submit_event(trace_event event) {
+  // TODO: Do this without locking+unlocking.
+  std::lock_guard guard{impl().mutex};
+  impl().events.push_back(std::move(event));
+}
+
+void trace_collector::set_output_path(const std::string& path) { impl().output_path = path; }
+
+// ReSharper disable once CppMemberFunctionMayBeConst
+trace_collector_impl& trace_collector::impl() noexcept { return *impl_; }
+
+void trace_collector::write_traces() const {
+  // Format to JSON and write to the output path.
+  if (!impl_->output_path.empty()) {
+    const auto abs_path = std::filesystem::weakly_canonical(impl_->output_path);
+    if (std::ofstream output(abs_path); output.good()) {
+      fmt::print("Writing trace events to: {}\n", abs_path.string());
+      output << fmt::format(json_object_template, fmt::join(impl_->events, ",\n    "));
+      output.flush();
+    }
+  }
+}
+
+template <typename U, typename T>
+static auto cast_time(const T& dur) {
+  return std::chrono::duration_cast<U>(dur).count();
+}
+
+scoped_trace::~scoped_trace() {
+  const auto end = std::chrono::high_resolution_clock::now();
+  if (std::uncaught_exceptions() > 0) {
+    return;
+  }
+  if (trace_collector* const collector = trace_collector::get_instance(); collector != nullptr) {
+    // Our events are "complete" events, so we compute the `dur` field.
+    const std::int64_t duration_nanos = cast_time<std::chrono::nanoseconds>(end - start_);
+    const std::int64_t start_micros =
+        cast_time<std::chrono::microseconds>(start_.time_since_epoch());
+
+    const thread_local pid_and_tid ids{};
+    collector->submit_event(trace_event{name_, start_micros, ids.pid, ids.tid, duration_nanos});
+  }
+}
+
+}  // namespace wf

--- a/components/core/wf/scoped_trace.h
+++ b/components/core/wf/scoped_trace.h
@@ -1,0 +1,86 @@
+// Copyright 2024 Gareth Cross
+#pragma once
+#include <chrono>
+#include <memory>
+#include <string_view>
+
+#ifdef WF_ENABLE_TRACING
+// Concatenate `a` with `b`.
+#define WF_CONCAT_(a, b) a##b
+#define WF_CONCAT(a, b) WF_CONCAT_(a, b)
+
+// Create a scoped trace with the provided name.
+// This version of the macro accepts a string literal.
+#define WF_SCOPED_TRACE_STR(str) \
+  wf::scoped_trace WF_CONCAT(__timer, __LINE__) { str }
+#else
+// Do nothing when tracing is disabled.
+#define WF_SCOPED_TRACE_STR(str)
+#endif  // WF_ENABLE_TRACING
+
+#define WF_SCOPED_TRACE(name) WF_SCOPED_TRACE_STR(#name)
+#define WF_FUNCTION_TRACE() WF_SCOPED_TRACE_STR(__FUNCTION__)
+
+namespace wf {
+
+// Fields are documented in this doc - I only support the bare minimum required:
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/
+struct trace_event {
+  // Name of the event.
+  std::string_view name;
+  // Timestamp in microseconds.
+  std::int64_t ts;
+  // Process ID.
+  std::uint32_t pid;
+  // Thread ID.
+  std::uint32_t tid;
+  // Duration in nanoseconds.
+  std::int64_t dur_ns;
+};
+
+// Aggregates tracing events and writes them out in chrome://trace format.
+class trace_collector {
+ public:
+  trace_collector();
+
+  // Write all traces out on destruction, assuming no exceptions are in flight.
+  ~trace_collector();
+
+  // Access global instance of the trace collector.
+  static trace_collector* get_instance();
+
+  // Log an event.
+  void submit_event(trace_event event);
+
+  // Set the output path for traces.
+  void set_output_path(const std::string& path);
+
+ private:
+  struct trace_collector_impl& impl() noexcept;
+
+  // Write all traces to disk as JSON.
+  void write_traces() const;
+
+  // Minimize header bloat with pimpl pattern.
+  std::unique_ptr<trace_collector_impl> impl_;
+};
+
+// Measure time elapsed in a particular scope.
+class scoped_trace {
+ public:
+  explicit scoped_trace(const std::string_view name) noexcept
+      : name_(name), start_(std::chrono::high_resolution_clock::now()) {}
+  ~scoped_trace();
+
+  // non-copyable and non-moveable
+  scoped_trace(const scoped_trace&) = delete;
+  scoped_trace(scoped_trace&&) = delete;
+  scoped_trace& operator=(const scoped_trace&) = delete;
+  scoped_trace& operator=(scoped_trace&&) = delete;
+
+ private:
+  std::string_view name_;
+  std::chrono::high_resolution_clock::time_point start_;
+};
+
+}  // namespace wf

--- a/components/wrapper/pywrenfold/wrapper.cc
+++ b/components/wrapper/pywrenfold/wrapper.cc
@@ -2,6 +2,8 @@
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 #include <pybind11/pybind11.h>
 
+#include "wf/scoped_trace.h"
+
 namespace py = pybind11;
 using namespace py::literals;
 
@@ -79,4 +81,14 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
 
   wrap_codegen_operations(m_gen);
   wrap_code_formatting_operations(m_gen);
+
+  m.def(
+      "set_tracing_output_path",
+      [](const std::string& path) {
+        if (trace_collector* const collector = trace_collector::get_instance();
+            collector != nullptr) {
+          collector->set_output_path(path);
+        }
+      },
+      "path"_a);
 }  // PYBIND11_MODULE


### PR DESCRIPTION
Add a simple tracing system that measures time spent in a scope. The results are written out in `chrome://trace` format.

By default it is disabled and does nothing, and must be enabled with the cmake option `-DWF_BUILD_WITH_TRACING=ON`.