### PR TITLE
Improve performance of derivatives of multiplications

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -38,9 +38,8 @@ TEST(DerivativesTest, TestAdditionAndSubtraction) {
 }
 
 TEST(DerivativesTest, TestMultiplication) {
-  const scalar_expr w{"w"};
-  const scalar_expr x{"x"};
-  const scalar_expr y{"y"};
+  const auto [w, x, y] = make_symbols("w", "x", "y");
+
   ASSERT_IDENTICAL(0, (x * y).diff(w));
   ASSERT_IDENTICAL(y, (x * y).diff(x));
   ASSERT_IDENTICAL(x, (x * y).diff(y));
@@ -58,6 +57,11 @@ TEST(DerivativesTest, TestMultiplication) {
   ASSERT_IDENTICAL(2 * y / pow(x, 3), (y / x).diff(x, 2));
   ASSERT_IDENTICAL(x * y + sin(w) * y - 3 * log(x) * pow(w, 2),
                    (w * x * y - cos(w) * y - log(x) * pow(w, 3)).diff(w));
+  ASSERT_IDENTICAL(5 * cos(x) * sin(w) * sin(x) / x + 5 * pow(cos(x), 2) * log(x) * sin(w) -
+                       5 * log(x) * sin(w) * pow(sin(x), 2),
+                   (cos(x) * sin(x) * log(x) * 5 * sin(w)).diff(x));
+  ASSERT_IDENTICAL(w * pow(x, 2) / pow(cos(x), 2) + 2 * w * x * tan(x),
+                   (tan(x) * pow(x, 2) * w).diff(x));
 }
 
 TEST(DerivativesTest, TestPower) {


### PR DESCRIPTION
- The derivative visitor had an inefficient implementation for `multiplication`. When taking the derivative of `a(x) * b(x) * c(x)`, we need to apply the product rule. However, if a term in one of the products (say `db(x)/dx`) is zero, we can early exit from that part of the sum.
- I also replaced some uses of `std::vector` with `InlinedVector<_, 8>` for another speedup.
- In total, on the `motion_planning` example (which computes a large jacobian), the time spent in `jacobian` was around `~0.89` seconds (on my laptop). This change reduces it to `0.26` seconds.