### PR TITLE
Remove `jacobian` method from quaternion type

### DIFF
--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -158,34 +158,6 @@ void wrap_geometry_operations(py::module_& m) {
            py::arg("epsilon") = constants::zero, docstrings::quaternion_to_rotation_vector.data())
       .def_static("from_rotation_matrix", &quaternion::from_rotation_matrix, py::arg("R"),
                   docstrings::quaternion_from_rotation_matrix.data())
-      // TODO: Get rid of `Quaternion` specific overrides of jacobian, and call the standalone
-      //  method.
-      .def(
-          "jacobian",
-          [](const quaternion& self, const matrix_expr& vars, const bool use_abstract) {
-            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
-                                                    : non_differentiable_behavior::constant);
-          },
-          py::arg("vars"), py::arg("use_abstract") = false,
-          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
-      .def(
-          "jacobian",
-          [](const quaternion& self, const std::vector<scalar_expr>& vars,
-             const bool use_abstract) {
-            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
-                                                    : non_differentiable_behavior::constant);
-          },
-          py::arg("vars"), py::arg("use_abstract") = false,
-          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables."))
-      .def(
-          "jacobian",
-          [](const quaternion& self, const quaternion& vars, const bool use_abstract) {
-            return self.jacobian(vars, use_abstract ? non_differentiable_behavior::abstract
-                                                    : non_differentiable_behavior::constant);
-          },
-          py::arg("vars"), py::arg("use_abstract") = false,
-          py::doc("Take jacobian of [w,x,y,z] quaternion elements with respect to variables in "
-                  "another quaternion."))
       .def("right_retract_derivative", &quaternion::right_retract_derivative,
            docstrings::quaternion_right_retract_derivative.data())
       .def("right_local_coordinates_derivative", &quaternion::right_local_coordinates_derivative,

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -417,6 +417,10 @@ class MatrixWrapperTest(MathTestBase):
         ])
         self.assertIdentical(jac_expected, m.jacobian([x, y, z]))
         self.assertIdentical(jac_expected, m.jacobian(sym.vector(x, y, z)))
+        self.assertIdentical(jac_expected, sym.jacobian(m, [x, y, z]))
+
+        self.assertRaises(exceptions.DimensionError, lambda: sym.jacobian(m, []))
+        self.assertRaises(exceptions.DimensionError, lambda: sym.jacobian(sym.zeros(2, 2), m))
 
     def test_subs(self):
         """Test calling subs on a matrix."""

--- a/examples/imu_integration/imu_integration.py
+++ b/examples/imu_integration/imu_integration.py
@@ -27,11 +27,12 @@ def blockwise_jacobians(
     for out_state in output_states:
         jacobians_row = []
         for in_state in input_states:
-            if isinstance(in_state, Quaternion):
-                in_expressions = in_state.to_vector_wxyz()
-            else:
-                in_expressions = in_state
-            out_D_in = out_state.jacobian(in_expressions)
+            out_expressions = out_state.to_vector_wxyz() if isinstance(out_state, Quaternion) else \
+                out_state
+            in_expressions = in_state.to_vector_wxyz() if isinstance(in_state, Quaternion) else \
+                in_state
+
+            out_D_in = sym.jacobian(out_expressions, in_expressions)
             if isinstance(out_state, Quaternion):
                 out_D_in = out_state.right_local_coordinates_derivative() * out_D_in
             if isinstance(in_state, Quaternion):


### PR DESCRIPTION
Remove some needless code duplication by removing `jacobian` from `Quaternion`. Instead it is easier to just call `sym.jacobian`, which I generalized in this change to accept either `MatrixExpr` or `T.List[ScalarExpr]`.