### PR TITLE
Disable PyPy wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ wheel.packages = ["components/python/wrenfold"]
 wheel.license-files = ["LICENSE"]
 
 [tool.cibuildwheel]
-skip = ["*musllinux_*", "*-win32", "*_i686"]
+skip = ["*musllinux_*", "*-win32", "*_i686", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 test-command = [
     "python -m unittest discover \"{package}/components/wrapper/tests\" --pattern \"*_test.py\"",


### PR DESCRIPTION
If somebody would like PyPy wheels, it is easy enough to re-enable this. My instinct is that it won't be a much requested feature.