### PR TITLE
Operation counts report maximum over all branches

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(
   wf/code_generation/ir_types.h
   wf/code_generation/ir_value.cc
   wf/code_generation/ir_value.h
+  wf/code_generation/operation_counts.cc
+  wf/code_generation/operation_counts.h
   wf/code_generation/rust_code_generator.cc
   wf/code_generation/rust_code_generator.h
   wf/code_generation/type_registry.cc

--- a/components/core/tests/ir_conversion_test.cc
+++ b/components/core/tests/ir_conversion_test.cc
@@ -311,6 +311,12 @@ TEST(IrTest, TestConditionals2) {
   ASSERT_EQ(8, output_ir.num_operations()) << output_ir;
   ASSERT_EQ(1, output_ir.num_conditionals()) << output_ir;
   check_expressions_with_output_permutations(expected_expressions, output_ir);
+
+  const operation_counts counts = output_ir.compute_operation_counts();
+  ASSERT_EQ(1, counts[operation_count_label::add]);
+  ASSERT_EQ(1, counts[operation_count_label::branch]);
+  ASSERT_EQ(1, counts[operation_count_label::call]);
+  ASSERT_EQ(1, counts[operation_count_label::compare]);
 }
 
 TEST(IrTest, TestConditionals3) {

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -116,9 +116,9 @@ pub fn heaviside<>(x: f64) -> f64
 pub fn exclusive_or<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
-  // branch: 3
+  // branch: 2
   // compare: 2
-  // total: 5
+  // total: 4
   
   let v004: f64 = y;
   let v001: f64 = x;
@@ -294,12 +294,12 @@ pub fn nested_conditionals_1<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
   // add: 2
-  // branch: 3
-  // call: 10
-  // compare: 3
-  // multiply: 4
+  // branch: 2
+  // call: 5
+  // compare: 2
+  // multiply: 2
   // negate: 1
-  // total: 23
+  // total: 14
   
   let v002: f64 = x;
   let v000: f64 = y;
@@ -344,14 +344,14 @@ pub fn nested_conditionals_1<>(x: f64, y: f64) -> f64
 pub fn nested_conditionals_2<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
-  // add: 3
+  // add: 1
   // branch: 3
-  // call: 7
+  // call: 4
   // compare: 3
   // divide: 1
-  // multiply: 8
+  // multiply: 4
   // negate: 1
-  // total: 26
+  // total: 17
   
   let v002: f64 = x;
   let v000: f64 = y;
@@ -400,14 +400,14 @@ where
   T2: wrenfold_traits::OutputSpan2D<9, 3, ValueType = f64>,
 {
   // Operation counts:
-  // add: 88
+  // add: 85
   // branch: 3
   // call: 4
   // compare: 1
-  // divide: 5
-  // multiply: 151
+  // divide: 4
+  // multiply: 129
   // negate: 6
-  // total: 258
+  // total: 232
   
   let v0005: f64 = w.get(1, 0);
   let v0003: f64 = w.get(0, 0);
@@ -744,14 +744,14 @@ where
   T1: wrenfold_traits::OutputSpan2D<4, 1, ValueType = f64>,
 {
   // Operation counts:
-  // add: 19
-  // branch: 4
-  // call: 4
-  // compare: 4
-  // divide: 4
-  // multiply: 20
+  // add: 15
+  // branch: 3
+  // call: 2
+  // compare: 3
+  // divide: 2
+  // multiply: 10
   // negate: 6
-  // total: 61
+  // total: 41
   
   let v0002: f64 = R.get(1, 1);
   let v0001: f64 = R.get(0, 0);
@@ -859,13 +859,13 @@ where
 {
   // Operation counts:
   // add: 21
-  // branch: 9
+  // branch: 7
   // call: 6
   // compare: 5
   // divide: 5
-  // multiply: 31
+  // multiply: 19
   // negate: 6
-  // total: 83
+  // total: 69
   
   let v0004: f64 = R.get(2, 2);
   let v0002: f64 = R.get(0, 0);
@@ -1259,8 +1259,8 @@ pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
   // branch: 1
   // call: 4
   // compare: 1
-  // multiply: 2
-  // total: 8
+  // multiply: 1
+  // total: 7
   
   let v002: f64 = x;
   let v000: f64 = y;

--- a/components/core/wf/code_generation/ast_conversion.h
+++ b/components/core/wf/code_generation/ast_conversion.h
@@ -11,27 +11,9 @@
 #include "wf/code_generation/ir_block.h"
 
 namespace wf {
-// Forwar declare.
+// Forward declare.
 class control_flow_graph;
-
-// Different categories of operations we count in order to generate summaries for the user.
-enum class operation_count_label {
-  add,
-  branch,
-  call,
-  compare,
-  divide,
-  multiply,
-  negate,
-};
-
-template <>
-struct hash_struct<operation_count_label> {
-  constexpr std::size_t operator()(operation_count_label enum_value) const noexcept {
-    return static_cast<std::size_t>(enum_value);
-  }
-};
-
+class operation_counts;
 }  // namespace wf
 
 namespace wf::ast {
@@ -46,7 +28,8 @@ class ast_form_visitor {
         signature_{description.name(), description.return_value_type(), description.arguments()} {}
 
   // Convert a function, starting from `block`.
-  ast::function_definition convert_function(ir::const_block_ptr block);
+  ast::function_definition convert_function(ir::const_block_ptr block,
+                                            const operation_counts& counts);
 
  private:
   // Sort and move all the provided assignments into `operations_`.
@@ -124,9 +107,6 @@ class ast_form_visitor {
   static ast::ast_element make_field_access_sequence(ast::ast_element prev, const custom_type& c,
                                                      std::size_t element_index);
 
-  // Format a comment describing the total number of operations in each category.
-  ast::ast_element format_operation_count_comment() const;
-
   std::size_t value_width_;
   function_signature signature_;
 
@@ -135,10 +115,6 @@ class ast_form_visitor {
 
   // Blocks we can't process yet (pending processing of all their ancestors).
   std::unordered_set<ir::const_block_ptr> non_traversable_blocks_;
-
-  // Operation counts
-  std::unordered_map<operation_count_label, std::size_t, hash_struct<operation_count_label>>
-      operation_counts_{};
 };
 
 // Create function_definition from the intermediate representation:

--- a/components/core/wf/code_generation/control_flow_graph.h
+++ b/components/core/wf/code_generation/control_flow_graph.h
@@ -4,9 +4,11 @@
 #pragma once
 #include <vector>
 
+#include "wf/assertions.h"
 #include "wf/code_generation/expression_group.h"
 #include "wf/code_generation/ir_block.h"
 #include "wf/code_generation/ir_types.h"
+#include "wf/code_generation/operation_counts.h"
 #include "wf/enumerations.h"
 
 namespace wf {
@@ -62,6 +64,9 @@ class control_flow_graph {
 
   // Count instances of a function call.
   std::size_t count_function(std_math_function enum_value) const noexcept;
+
+  // Generate a summary of operations.
+  operation_counts compute_operation_counts() const;
 
  private:
   control_flow_graph(std::vector<ir::block::unique_ptr> blocks,

--- a/components/core/wf/code_generation/ir_block.h
+++ b/components/core/wf/code_generation/ir_block.h
@@ -80,9 +80,15 @@ class block {
     return operations_.back();
   }
 
-  // Count instances of operation of type `T`.
+  // Count operations matching predicate `Func`.
   template <typename Func>
   std::size_t count_operation(Func&& func) const;
+
+  // Count operations of type `T`.
+  template <typename T>
+  std::size_t count_operation() const {
+    return count_operation([](const T&) constexpr { return true; });
+  }
 
   // Access operations.
   constexpr const auto& operations() const noexcept { return operations_; }

--- a/components/core/wf/code_generation/operation_counts.cc
+++ b/components/core/wf/code_generation/operation_counts.cc
@@ -1,0 +1,38 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#include "wf/code_generation/operation_counts.h"
+
+#include <algorithm>
+#include <numeric>
+
+namespace wf {
+
+operation_counts::operation_counts() noexcept { std::fill_n(counts_.data(), counts_.size(), 0); }
+
+void operation_counts::increment(const operation_counts& other) noexcept {
+  std::transform(counts_.cbegin(), counts_.cend(), other.counts_.cbegin(), counts_.begin(),
+                 std::plus<std::size_t>{});
+}
+
+operation_counts operation_counts::max(const operation_counts& other) const noexcept {
+  operation_counts result{};
+  std::transform(counts_.cbegin(), counts_.cend(), other.counts_.cbegin(), result.counts_.begin(),
+                 [](std::size_t a, std::size_t b) { return std::max(a, b); });
+  return result;
+}
+
+std::array<std::tuple<operation_count_label, std::size_t>, operation_counts::num_counters>
+operation_counts::labels_and_counts() const noexcept {
+  std::array<std::tuple<operation_count_label, std::size_t>, num_counters> out{};
+  for (std::size_t i = 0; i < num_counters; ++i) {
+    out[i] = std::make_tuple(static_cast<operation_count_label>(i), counts_[i]);
+  }
+  return out;
+}
+
+std::size_t operation_counts::total() const noexcept {
+  return std::accumulate(counts_.cbegin(), counts_.cend(), static_cast<std::size_t>(0));
+}
+
+}  // namespace wf

--- a/components/core/wf/code_generation/operation_counts.h
+++ b/components/core/wf/code_generation/operation_counts.h
@@ -1,0 +1,86 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+#include <array>
+#include <string_view>
+
+#include "wf/assertions.h"
+
+namespace wf {
+
+// Different categories of operations we count in order to generate summaries for the user.
+enum class operation_count_label {
+  add = 0,
+  branch,
+  call,
+  compare,
+  divide,
+  multiply,
+  negate,
+  MAX_VALUE,
+};
+
+// Store a count of operations in an array.
+class operation_counts {
+ public:
+  static constexpr std::size_t num_counters =
+      static_cast<std::size_t>(operation_count_label::MAX_VALUE);
+
+  // Zero initialize counts.
+  operation_counts() noexcept;
+
+  // Increment all counters by the values in `other`.
+  void increment(const operation_counts& other) noexcept;
+
+  // Take the maximum of self and another set of counts.
+  operation_counts max(const operation_counts& other) const noexcept;
+
+  // Const access to a counter.
+  constexpr const std::size_t& operator[](const operation_count_label label) const {
+    WF_ASSERT_LESS(static_cast<std::size_t>(label), counts_.size());
+    return counts_[static_cast<std::size_t>(label)];
+  }
+
+  // Access a counter to update it.
+  constexpr std::size_t& operator[](const operation_count_label label) {
+    WF_ASSERT_LESS(static_cast<std::size_t>(label), counts_.size());
+    return counts_[static_cast<std::size_t>(label)];
+  }
+
+  // Get array of labels and counts.
+  std::array<std::tuple<operation_count_label, std::size_t>, num_counters> labels_and_counts()
+      const noexcept;
+
+  // Total of all the counters.
+  std::size_t total() const noexcept;
+
+ private:
+  std::array<std::size_t, num_counters> counts_;
+};
+
+// Convert operation_count_label to string.
+inline constexpr std::string_view string_from_operation_count_label(
+    const operation_count_label label) noexcept {
+  switch (label) {
+    case operation_count_label::add:
+      return "add";
+    case operation_count_label::branch:
+      return "branch";
+    case operation_count_label::call:
+      return "call";
+    case operation_count_label::compare:
+      return "compare";
+    case operation_count_label::divide:
+      return "divide";
+    case operation_count_label::multiply:
+      return "multiply";
+    case operation_count_label::negate:
+      return "negate";
+    default:
+      break;
+  }
+  return "<NOT A VALID ENUM VALUE>";
+}
+
+}  // namespace wf


### PR DESCRIPTION
- Operation counts were somewhat misleading because they would previously sum over all branches. I think in practice, taking the "max" over all branches more intuitively communicates complexity.
- This change makes it so operation counts now reports the maximum number of operations through any conditional path, which is a more useful upper bound when comparing outputs.