### PR TITLE
Add missing SymPy conversions for `Min`, `Max`, and `Heaviside`

### DIFF
--- a/components/wrapper/pywrenfold/sympy_conversion.cc
+++ b/components/wrapper/pywrenfold/sympy_conversion.cc
@@ -64,6 +64,15 @@ class sympy_conversion_visitor {
   py::object operator()(const complex_infinity&) const { return get_sympy_attr("zoo"); }
 
   py::object operator()(const conditional& cond) {
+    const auto& x = cond.if_branch();
+    const auto& y = cond.else_branch();
+    if (cond.condition().is_identical_to(y < x)) {
+      // max(...)
+      return invoke_sympy_object("Max", operator()(x), operator()(y), "evaluate"_a = evaluate_);
+    } else if (cond.condition().is_identical_to(x < y)) {
+      // min(...)
+      return invoke_sympy_object("Min", operator()(x), operator()(y), "evaluate"_a = evaluate_);
+    }
     return invoke_sympy_object(
         "Piecewise", py::make_tuple(operator()(cond.if_branch()), operator()(cond.condition())),
         py::make_tuple(operator()(cond.else_branch()), true), "evaluate"_a = evaluate_);
@@ -104,7 +113,7 @@ class sympy_conversion_visitor {
       }
       rows.append(cols);
     }
-    return invoke_sympy_object("Matrix", rows, "evaluate"_a = evaluate_);
+    return invoke_sympy_object("Matrix", rows);
   }
 
   py::object operator()(const multiplication& mul) {

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -247,6 +247,24 @@ class SympyConversionTest(MathTestBase):
         # sympy --> wf
         self.assertIdenticalFromSp(sym.iverson(x < y), sp.Piecewise((1, spy(x < y)), (0, True)))
 
+    def test_min_max(self):
+        x, y = sym.symbols('x, y')
+        self.assertEqualSp(sp.Min(spy(x), spy(y)), sym.min(x, y))
+        self.assertEqualSp(sp.Max(spy(x), spy(y)), sym.max(x, y))
+
+        # sympy --> wf
+        self.assertIdenticalFromSp(sym.min(x, y), sp.Min(spy(x), spy(y)))
+        self.assertIdenticalFromSp(sym.max(x, y), sp.Max(spy(x), spy(y)))
+
+    def test_heaviside(self):
+        # Heaviside only goes one way for now:
+        x = sym.symbols('x')
+        # sympy --> wf
+        self.assertIdenticalFromSp(
+            sym.where(0 < x, 1, sym.where(x < 0, -1, sym.rational(1, 2))), sp.Heaviside(spy(x)))
+        self.assertIdenticalFromSp(
+            sym.where(0 < x, 1, sym.where(x < 0, -1, sym.nan)), sp.Heaviside(spy(x), sp.nan))
+
     def test_matrix(self):
         x, y = sym.symbols('x, y')
 


### PR DESCRIPTION
Conversions were missing for the min/max and heaviside operations. This change adds basic implementations.

Caveat: For now I have limited `min` and `max` to the 2-operand versions, pending better support for that in wrenfold.