### PR TITLE
Pin rust toolchain version to 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: Install rust
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install 1.77 --profile minimal
 
       - name: Dump rustc version
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}


### PR DESCRIPTION
Rust toolchain version 1.78 fails to compile under `ubuntu-latest` with the error:
```
note: /home/runner/miniconda3/envs/build-env/bin/../lib/gcc/x86_64-conda-linux-gnu/12.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: /home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d2ef02247056996e.rlib(std-d2ef02247056996e.std.e4dfbc2c3f4b09f1-cgu.0.rcgu.o): in function `std::sys::pal::unix::stack_overflow::imp::sigstack_size':
          /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys/pal/unix/stack_overflow.rs:216: undefined reference to `getauxval'
          /home/runner/miniconda3/envs/build-env/bin/../lib/gcc/x86_64-conda-linux-gnu/12.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys/pal/unix/stack_overflow.rs:216: undefined reference to `getauxval'
          collect2: error: ld returned 1 exit status
```

For now I am pinning CI to 1.77 so it can pass and merge other changes. Will come back and investigate when time permits.