### PR TITLE
Add ability to convert CSE outputs back to symbolic tree (from python)

### DIFF
--- a/components/core/tests/ir_conversion_test.cc
+++ b/components/core/tests/ir_conversion_test.cc
@@ -97,7 +97,7 @@ void check_output_expressions(const std::vector<expression_group>& expected_expr
 
 void check_expressions(const std::vector<expression_group>& expected_expressions,
                        const control_flow_graph& ir) {
-  const auto output_expressions = create_output_expression_map(ir.first_block(), {});
+  const auto [output_expressions, _] = rebuild_expression_tree(ir.first_block(), {});
   check_output_expressions(expected_expressions, output_expressions, ir);
 }
 
@@ -107,7 +107,7 @@ void check_expressions_with_output_permutations(
   for (std::size_t i = 0; i < permutations.num_permutations(); ++i) {
     // test permutation `i`:
     auto output_map = permutations.get_permutation(i);
-    auto output_expressions = create_output_expression_map(ir.first_block(), std::move(output_map));
+    auto [output_expressions, _] = rebuild_expression_tree(ir.first_block(), std::move(output_map));
     check_output_expressions(expected_expressions, output_expressions, ir);
   }
 }

--- a/components/core/wf/code_generation/expr_from_ir.cc
+++ b/components/core/wf/code_generation/expr_from_ir.cc
@@ -9,51 +9,32 @@
 #include "wf/code_generation/control_flow_graph.h"
 #include "wf/code_generation/ir_types.h"
 #include "wf/expressions/all_expressions.h"
+#include "wf/scoped_trace.h"
 #include "wf/template_utils.h"
 
 namespace wf {
 
-template <typename... Ts>
-class castable_variant {
- public:
-  template <typename U>
-  using enable_if_valid_type_t = enable_if_contains_type_t<std::decay_t<U>, type_list<Ts...>>;
-
-  template <typename U, typename = enable_if_valid_type_t<U>>
-  castable_variant(U&& u) noexcept(
-      std::is_nothrow_constructible_v<std::variant<Ts...>, decltype(u)>)
-      : v_(std::forward<U>(u)) {}
-
-  template <typename U, typename = enable_if_valid_type_t<U>>
-  operator const U&() const {
-    const U* as_u = std::get_if<U>(&v_);
-    WF_ASSERT(as_u != nullptr, "Variant does not contain type `{}`. index = {}", typeid(U).name(),
-              v_.index());
-    return *as_u;
-  }
-
-  constexpr const auto& inner() const noexcept { return v_; }
-
- private:
-  std::variant<Ts...> v_;
-};
-
 // Convert the IR operations back to expressions.
 // This is supported so we can do round-trip tests.
-struct expression_from_ir_visitor {
-  using expr_variant = castable_variant<scalar_expr, matrix_expr, compound_expr, boolean_expr>;
-
-  explicit expression_from_ir_visitor(std::unordered_map<std::string, bool>&& output_arg_exists)
-      : output_arg_exists_(std::move(output_arg_exists)) {
+class expression_from_ir_visitor {
+ public:
+  explicit expression_from_ir_visitor(std::unordered_map<std::string, bool>&& output_arg_exists,
+                                      const bool use_intermediate_values)
+      : output_arg_exists_(std::move(output_arg_exists)),
+        use_intermediate_values_(use_intermediate_values) {
     value_to_expression_.reserve(200);
+    if (use_intermediate_values_) {
+      scalar_variables_.reserve(50);
+      scalar_variable_order_.reserve(50);
+    }
   }
 
   scalar_expr operator()(const ir::add&, const ir::value::operands_container& args) const {
-    return map_scalar_value(args[0]) + map_scalar_value(args[1]);
+    return map_value<scalar_expr>(args[0]) + map_value<scalar_expr>(args[1]);
   }
 
   scalar_expr operator()(const ir::mul&, const ir::value::operands_container& args) const {
-    return map_scalar_value(args[0]) * map_scalar_value(args[1]);
+    return map_value<scalar_expr>(args[0]) * map_value<scalar_expr>(args[1]);
   }
 
   boolean_expr operator()(const ir::output_required& output,
@@ -109,13 +90,10 @@ struct expression_from_ir_visitor {
     WF_ASSERT_ALWAYS("Invalid enum value: {}", string_from_standard_library_function(func));
   }
 
-  expr_variant operator()(const ir::call_external_function& func,
-                          const ir::value::operands_container& args) const {
+  any_expression operator()(const ir::call_external_function& func,
+                            const ir::value::operands_container& args) const {
     auto args_converted = transform_map<external_function_invocation::container_type>(
-        args, [this](const ir::value_ptr val) {
-          return std::visit([](const auto& x) -> any_expression { return x; },
-                            map_value(val).inner());
-        });
+        args, [this](const ir::value_ptr val) { return map_value_to_variant(val); });
 
     compound_expr invocation{std::in_place_type_t<external_function_invocation>{}, func.function(),
                              std::move(args_converted)};
@@ -131,7 +109,7 @@ struct expression_from_ir_visitor {
   scalar_expr operator()(const ir::call_std_function& func,
                          const ir::value::operands_container& args) const {
     auto container = transform_map<function::container_type>(
-        args, [this](const ir::value_ptr v) { return map_scalar_value(v); });
+        args, [this](const ir::const_value_ptr v) { return map_value<scalar_expr>(v); });
 
     if (func.name() == std_math_function::powi || func.name() == std_math_function::powf) {
       return pow(container[0], container[1]);
@@ -147,55 +125,52 @@ struct expression_from_ir_visitor {
   scalar_expr operator()(const ir::cast&, const ir::value::operands_container& args) const {
     WF_ASSERT(!args.empty());
     if (args[0]->numeric_type() == code_numeric_type::boolean) {
-      return iverson(map_value(args[0]));
+      return iverson(map_value<boolean_expr>(args[0]));
     } else {
-      return map_scalar_value(args[0]);
+      return map_value<scalar_expr>(args[0]);
     }
   }
 
   boolean_expr operator()(const ir::compare& cmp, const ir::value::operands_container& args) const {
-    return relational::create(cmp.operation(), map_scalar_value(args[0]),
-                              map_scalar_value(args[1]));
+    return relational::create(cmp.operation(), map_value<scalar_expr>(args[0]),
+                              map_value<scalar_expr>(args[1]));
   }
 
-  expr_variant operator()(const ir::construct& construct,
-                          const ir::value::operands_container& args) const {
-    std::vector<scalar_expr> args_converted{};
-    args_converted.reserve(args.size());
-    for (const ir::value_ptr arg : args) {
-      args_converted.push_back(map_scalar_value(arg));
-    }
+  any_expression operator()(const ir::construct& construct,
+                            const ir::value::operands_container& args) const {
+    std::vector<scalar_expr> args_converted = transform_map<std::vector>(
+        args, [this](const ir::const_value_ptr v) { return map_value<scalar_expr>(v); });
     return overloaded_visit(
         construct.type(),
-        [&](const matrix_type& mat) -> expr_variant {
+        [&](const matrix_type& mat) -> any_expression {
           return matrix_expr::create(mat.rows(), mat.cols(), std::move(args_converted));
         },
-        [&](const custom_type& custom) -> expr_variant {
+        [&](const custom_type& custom) -> any_expression {
           return custom_type_construction::create(custom, std::move(args_converted));
         });
   }
 
   scalar_expr operator()(const ir::cond&, const ir::value::operands_container& args) const {
-    return where(map_value(args[0]), map_scalar_value(args[1]), map_scalar_value(args[2]));
+    return where(map_value<boolean_expr>(args[0]), map_value<scalar_expr>(args[1]),
+                 map_value<scalar_expr>(args[2]));
   }
 
   scalar_expr operator()(const ir::copy&, const ir::value::operands_container& args) const {
-    return map_scalar_value(args[0]);
+    return map_value<scalar_expr>(args[0]);
   }
 
   scalar_expr operator()(const ir::div&, const ir::value::operands_container& args) const {
-    return map_scalar_value(args[0]) / map_scalar_value(args[1]);
+    return map_value<scalar_expr>(args[0]) / map_value<scalar_expr>(args[1]);
   }
 
   scalar_expr operator()(const ir::get& get, const ir::value::operands_container& args) const {
-    compound_expr provenance = static_cast<compound_expr>(map_value(args.front()));
-    return scalar_expr{std::in_place_type_t<compound_expression_element>{}, std::move(provenance),
-                       get.index()};
+    return scalar_expr{std::in_place_type_t<compound_expression_element>{},
+                       map_value<compound_expr>(args.front()), get.index()};
   }
 
-  expr_variant operator()(const ir::load& load, const ir::value::operands_container&) const {
+  any_expression operator()(const ir::load& load, const ir::value::operands_container&) const {
     return std::visit(
-        [](const auto& expression) -> expr_variant {
+        [](const auto& expression) -> any_expression {
           using T = std::decay_t<decltype(expression)>;
           if constexpr (type_list_contains_v<T, scalar_expr::types>) {
             return scalar_expr{expression};
@@ -209,61 +184,116 @@ struct expression_from_ir_visitor {
   }
 
   scalar_expr operator()(const ir::neg&, const ir::value::operands_container& args) const {
-    return -map_scalar_value(args.front());
+    return -map_value<scalar_expr>(args.front());
   }
 
   scalar_expr operator()(const ir::phi&, const ir::value::operands_container& args) const {
     WF_ASSERT_EQUAL(2, args.size());
 
     // We find to find the condition for this jump:
-    const ir::block_ptr jump_block = find_merge_point(args.front()->parent(), args.back()->parent(),
-                                                      ir::search_direction::upwards);
+    const ir::const_block_ptr jump_block = find_merge_point(
+        args.front()->parent(), args.back()->parent(), ir::search_direction::upwards);
 
     // Determine the condition:
-    const ir::value_ptr jump_val = jump_block->last_operation();
+    const ir::const_value_ptr jump_val = jump_block->last_operation();
     WF_ASSERT(jump_val->is_op<ir::jump_condition>());
 
-    return where(map_value(jump_val->first_operand()), map_scalar_value(args[0]),
-                 map_scalar_value(args[1]));
+    return where(map_value<boolean_expr>(jump_val->first_operand()),
+                 map_value<scalar_expr>(args[0]), map_value<scalar_expr>(args[1]));
   }
 
-  const expr_variant& map_value(const ir::value_ptr value) const {
+  const any_expression& map_value_to_variant(const ir::const_value_ptr value) const {
     const auto arg_it = value_to_expression_.find(value);
     WF_ASSERT(arg_it != value_to_expression_.end(), "Missing value: {}", value->name());
     return arg_it->second;
   }
 
-  scalar_expr map_scalar_value(const ir::value_ptr value) const {
-    return static_cast<scalar_expr>(map_value(value));  // implicit cast
+  template <typename T>
+  const T& map_value(const ir::const_value_ptr value) const {
+    if constexpr (std::is_same_v<T, scalar_expr>) {
+      // Don't insert loads, since these
+      if (use_intermediate_values_) {
+        if (const auto var_it = scalar_variables_.find(value); var_it != scalar_variables_.end()) {
+          return var_it->second;
+        }
+      }
+    }
+    const auto& var = map_value_to_variant(value);
+    const T* result = std::get_if<T>(&var);
+    WF_ASSERT(result, "Variant does not contain type `{}`", typeid(T).name());
+    return *result;
+  }
+
+  std::vector<std::tuple<scalar_expr, scalar_expr>> get_intermediate_values() const {
+    return transform_map<std::vector>(
+        scalar_variable_order_, [this](const ir::const_value_ptr val) {
+          const auto variable_it = scalar_variables_.find(val);
+          WF_ASSERT(variable_it != scalar_variables_.end());
+
+          const auto variable_value_it = value_to_expression_.find(val);
+          WF_ASSERT(variable_value_it != value_to_expression_.end());
+
+          const scalar_expr* const as_scalar = std::get_if<scalar_expr>(&variable_value_it->second);
+          WF_ASSERT(as_scalar != nullptr);
+
+          return std::make_tuple(variable_it->second, *as_scalar);
+        });
   }
 
   template <typename T>
-  void process(const ir::value_ptr key, const T& op, const ir::value::operands_container& args) {
-    value_to_expression_.emplace(key, operator()(op, args));
+  void process(const ir::const_value_ptr key, const T& op,
+               const ir::value::operands_container& args) {
+    const auto [it, was_inserted] = value_to_expression_.emplace(key, operator()(op, args));
+    if (use_intermediate_values_ && was_inserted &&
+        std::holds_alternative<scalar_expr>(it->second)) {
+      // Make a variable expression for this as well:
+      scalar_variables_.emplace(
+          key, make_expr<variable>(fmt::format("v{}", key->name()), number_set::unknown));
+      scalar_variable_order_.push_back(key);
+    }
   }
 
-  std::unordered_map<ir::value_ptr, expr_variant> value_to_expression_;
+ private:
+  // Map from value to rebuilt expression:
+  std::unordered_map<ir::const_value_ptr, any_expression> value_to_expression_;
+
+  // If `use_intermediate_values_` is true, we leave immediately children of expressions as
+  // variables. This map stores the variable expressions for each name.
+  std::unordered_map<ir::const_value_ptr, scalar_expr> scalar_variables_;
+
+  // Store the order in which `scalar_variables_` was filled.
+  std::vector<ir::const_value_ptr> scalar_variable_order_;
+
+  // Map that indicates whether a given optional output should be computed.
   const std::unordered_map<std::string, bool> output_arg_exists_;
+
+  // If false, we recursively substitute expressions into each other as we reconstitute
+  // the expression tree - effectively rebuilding the original input tree completely.
+  // If true, we capture each intermediate expression and produce sub-expressions that
+  // reference each other via variables (effectively making a CSE-style output).
+  bool use_intermediate_values_;
 };
 
-std::unordered_map<output_key, std::vector<scalar_expr>, hash_struct<output_key>>
-create_output_expression_map(const ir::block_ptr starting_block,
-                             std::unordered_map<std::string, bool> output_arg_exists) {
+rebuilt_expressions rebuild_expression_tree(const ir::const_block_ptr starting_block,
+                                            std::unordered_map<std::string, bool> output_arg_exists,
+                                            const bool use_intermediate_values) {
+  WF_FUNCTION_TRACE();
+
   // Set of all visited blocks:
-  std::unordered_set<ir::block_ptr> completed;
+  std::unordered_set<ir::const_block_ptr> completed;
 
   // Queue of pending blocks
-  std::deque<ir::block_ptr> queue;
+  std::deque<ir::const_block_ptr> queue;
   queue.emplace_back(starting_block);
 
   // Map from key to ordered output expressions:
-  std::unordered_map<output_key, std::vector<scalar_expr>, hash_struct<output_key>> output_map{};
-  output_map.reserve(5);
+  rebuilt_expressions result{};
+  result.output_expressions.reserve(5);
 
-  expression_from_ir_visitor visitor{std::move(output_arg_exists)};
+  expression_from_ir_visitor visitor{std::move(output_arg_exists), use_intermediate_values};
   while (!queue.empty()) {
     // de-queue the next block
-    const ir::block_ptr block = queue.front();
+    const ir::const_block_ptr block = queue.front();
     queue.pop_front();
 
     if (completed.count(block)) {
@@ -271,19 +301,18 @@ create_output_expression_map(const ir::block_ptr starting_block,
     }
     completed.insert(block);
 
-    for (const ir::value_ptr& code : block->operations()) {
+    for (const ir::const_value_ptr code : block->operations()) {
       // Visit the operation, and convert it to an expression.
       // We don't do anything w/ jumps - they do not actually translate to an output value directly.
       overloaded_visit(
           code->value_op(), [](const ir::jump_condition&) constexpr {},
           [&](const ir::save& save) {
             // Get all the output expressions for this output:
-            std::vector<scalar_expr> output_expressions{};
-            output_expressions.reserve(code->num_operands());
-            for (const ir::value_ptr operand : code->operands()) {
-              output_expressions.push_back(visitor.map_scalar_value(operand));
-            }
-            output_map.emplace(save.key(), std::move(output_expressions));
+            std::vector<scalar_expr> output_expressions = transform_map<std::vector>(
+                code->operands(),
+                [&visitor](const ir::value_ptr v) { return visitor.map_value<scalar_expr>(v); });
+
+            result.output_expressions.emplace(save.key(), std::move(output_expressions));
           },
           [&](const auto& op) { visitor.process(code, op, code->operands()); });
     }
@@ -291,14 +320,19 @@ create_output_expression_map(const ir::block_ptr starting_block,
     // If all the ancestors of a block are done, we can queue it:
     for (const ir::block_ptr b : block->descendants()) {
       const auto& b_ancestors = b->ancestors();
-      const bool valid = std::all_of(b_ancestors.begin(), b_ancestors.end(),
-                                     [&](auto blk) { return completed.count(blk) > 0; });
-      if (valid) {
+      if (const bool valid =
+              std::all_of(b_ancestors.begin(), b_ancestors.end(),
+                          [&](const ir::const_block_ptr blk) { return completed.count(blk) > 0; });
+          valid) {
         queue.push_back(b);
       }
     }
   }
-  return output_map;
+
+  if (use_intermediate_values) {
+    result.intermediate_values = visitor.get_intermediate_values();
+  }
+  return result;
 }
 
 }  // namespace wf

--- a/components/core/wf/code_generation/expr_from_ir.h
+++ b/components/core/wf/code_generation/expr_from_ir.h
@@ -11,9 +11,20 @@
 
 namespace wf {
 
-// Create `scalar_expr` tree from the IR representation. For use in round-trip unit tests.
-std::unordered_map<output_key, std::vector<scalar_expr>, hash_struct<output_key>>
-create_output_expression_map(ir::block_ptr starting_block,
-                             std::unordered_map<std::string, bool> output_arg_exists);
+struct rebuilt_expressions {
+  // Map from function output to a vector of scalar expressions.
+  // TODO: This should probably be generalized to store `any_expression`.
+  std::unordered_map<output_key, std::vector<scalar_expr>, hash_struct<output_key>>
+      output_expressions{};
+
+  // Intermediate values used in the computation of the output.
+  // Stores tuples of (variable name, expression).
+  std::vector<std::tuple<scalar_expr, scalar_expr>> intermediate_values{};
+};
+
+// Reconstitute the symbolic expression tree from the IR representation.
+rebuilt_expressions rebuild_expression_tree(ir::const_block_ptr starting_block,
+                                            std::unordered_map<std::string, bool> output_arg_exists,
+                                            bool use_intermediate_values = false);
 
 }  // namespace wf

--- a/components/core/wf/code_generation/expression_group.h
+++ b/components/core/wf/code_generation/expression_group.h
@@ -29,7 +29,8 @@ struct output_key {
   std::string name;
 
   // Construct w/ usage ane name.
-  output_key(expression_usage usage, std::string_view name) : usage(usage), name(name) {}
+  output_key(const expression_usage usage, const std::string_view name)
+      : usage(usage), name(name) {}
 
   // Equality test.
   bool operator==(const output_key& other) const noexcept {
@@ -54,8 +55,7 @@ struct expression_group {
 };
 
 // Convert `expression_usage` to a string.
-inline constexpr std::string_view string_from_expression_usage(
-    const expression_usage usage) noexcept {
+constexpr std::string_view string_from_expression_usage(const expression_usage usage) noexcept {
   switch (usage) {
     case expression_usage::return_value:
       return "return_value";
@@ -70,9 +70,15 @@ inline constexpr std::string_view string_from_expression_usage(
 // Hash `output_key` type.
 template <>
 struct hash_struct<output_key> {
-  std::size_t operator()(const output_key& k) const {
+  std::size_t operator()(const output_key& k) const noexcept {
     return hash_combine(static_cast<std::size_t>(k.usage), hash_string_fnv(k.name));
   }
+};
+
+// Test `output_key` for equality.
+template <>
+struct is_identical_struct<output_key> {
+  bool operator()(const output_key& a, const output_key& b) const noexcept { return a == b; }
 };
 
 }  // namespace wf

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -17,7 +17,9 @@ from pywrenfold.gen import (
     BaseGenerator,
     CppGenerator,
     FunctionDescription,
+    OutputKey,
     RustGenerator,
+    cse_function_description,
     transpile,
 )
 

--- a/components/wrapper/pywrenfold/docs/codegen_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/codegen_wrapper.h
@@ -36,4 +36,39 @@ Stores information required to emit the function signature, including:
 create a syntax tree representation, which may then be converted into usable code.
 )doc";
 
+inline constexpr std::string_view cse_function_description = R"doc(
+Given a :class:`wrenfold.code_generation.FunctionDescription` object, run the code-generation CSE
+and then convert the simplified result *back* to a list of symbolic expressions. This function will
+apply all the simplifications and subexpression elimination steps normally applied during
+code-generation.
+
+The first returned object is a dict mapping from ``OutputKey`` to output expressions. The outputs
+will be expressed as a function of variables ``[v0, v1, ... v{N}]``. The second returned object is a
+list of tuples of the form ``[(v0, <v0 expr>), (v1, <v1 expr>), ...]`` - these are the eliminated
+subexpressions required to evaluate the function.
+
+Args:
+  desc: :class:`wrenfold.code_generation.FunctionDescription` object.
+
+Returns:
+  A dict mapping from ``OutputKey`` to output expressions, and a list of intermediate subexpressions
+  required to compute the function outputs.
+
+Example:
+  >>> from wrenfold import sym, code_generation, type_annotations
+  >>> def func(x: type_annotations.RealScalar, y: type_annotations.RealScalar):
+  >>>   return sym.abs(x * y) * sym.cos(x * y)
+  >>> desc = code_generation.create_function_description(func)
+  >>> outputs, intermediate_values = code_generation.cse_function_description(desc)
+  >>> outputs
+  {OutputKey(return_value): [v5]}
+  >>> intermediate_values
+  [(v0, $arg(0, 0)),
+   (v1, $arg(1, 0)),
+   (v2, v0*v1),
+   (v3, abs(v2)),
+   (v4, cos(v2)),
+   (v5, v3*v4)]
+)doc";
+
 }  // namespace wf::docstrings

--- a/docs/source/python_api/code_generation.rst
+++ b/docs/source/python_api/code_generation.rst
@@ -3,6 +3,8 @@ code_generation
 
 .. autofunction:: wrenfold.code_generation.create_function_description
 
+.. autofunction:: wrenfold.code_generation.cse_function_description
+
 .. autofunction:: wrenfold.code_generation.generate_function
 
 .. autofunction:: wrenfold.code_generation.mkdir_and_write_file


### PR DESCRIPTION
This change implements the ability to run the code-gen CSE and simplifications from python, and convert the result back into symbolic expressions. This is useful when debugging the code-generation, since the symbolic expression tree is easier to visualize and manipulate. I decided to make it part of the public API since it can also be useful for inspecting symbolic expressions, and may be useful to users who _only_ want to run the CSE and do the code-generation themselves via an alternative mechanism.

- `code_generation` module now exposes `cse_function_description` method.
- `rebuild_expression_tree` can produce both output expressions and intermediate expressions.
- Improve `codegen_wrapper_test` so it tests the interface better, and tests `rebuild_expression_tree`.
- Get rid of `castable_variant` kludge that was used in `expression_from_ir_visitor`. This was an unnecessary addition that just made it harder to understand. (Also fix the const-ness of the value_ptrs).