### PR TITLE
Add `Unevaluated` expression type to avoid automatic simplifications

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -90,6 +90,8 @@ add_library(
   wf/expressions/relational.cc
   wf/expressions/relational.h
   wf/expressions/special_constants.h
+  wf/expressions/unevaluated.cc
+  wf/expressions/unevaluated.h
   wf/expressions/variable.cc
   wf/expressions/variable.h
   wf/external_function.cc

--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -255,4 +255,14 @@ TEST(DerivativesTest, TestDerivativeExpression) {
   ASSERT_IDENTICAL(0, f.diff(z));
 }
 
+TEST(DerivativesTest, TestUnevaluated) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+
+  // Terms between parentheses should remain in parentheses:
+  ASSERT_IDENTICAL(make_unevaluated(2 * x), make_unevaluated(x * x).diff(x));
+  ASSERT_IDENTICAL(make_unevaluated(x * cos(x * y)) * make_unevaluated(y * y) +
+                       make_unevaluated(sin(x * y)) * make_unevaluated(2 * y),
+                   (make_unevaluated(sin(x * y)) * make_unevaluated(y * y)).diff(y));
+}
+
 }  // namespace wf

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -253,6 +253,11 @@ ir::value_ptr ir_form_visitor::exponentiate_by_squaring(ir::value_ptr base, std:
   return result.value();
 }
 
+ir::value_ptr ir_form_visitor::operator()(const unevaluated& u) {
+  // Parenthetical only matters in the context of the symbolic tree.
+  return operator()(u.contents());
+}
+
 ir::value_ptr ir_form_visitor::operator()(const power& power) {
   const ir::value_ptr base =
       maybe_cast(operator()(power.base()), code_numeric_type::floating_point);

--- a/components/core/wf/code_generation/ir_form_visitor.h
+++ b/components/core/wf/code_generation/ir_form_visitor.h
@@ -53,6 +53,7 @@ class ir_form_visitor {
   ir::value_ptr operator()(const relational& relational);
   ir::value_ptr operator()(const symbolic_constant& constant);
   ir::value_ptr operator()(const undefined&) const;
+  ir::value_ptr operator()(const unevaluated& u);
   ir::value_ptr operator()(const variable& var);
 
   // Apply to any expression.

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -289,6 +289,11 @@ scalar_expr derivative_visitor::operator()(const relational&, const scalar_expr&
 
 scalar_expr derivative_visitor::operator()(const undefined&) const { return constants::undefined; }
 
+scalar_expr derivative_visitor::operator()(const unevaluated& u) {
+  // Keep the derivative between parentheses.
+  return u.map_children([this](const scalar_expr& x) { return apply(x); });
+}
+
 scalar_expr derivative_visitor::operator()(const variable& var) const {
   if (const variable* arg = get_if<const variable>(argument_);
       arg != nullptr && are_identical(*arg, var)) {

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -38,6 +38,7 @@ class derivative_visitor {
   scalar_expr operator()(const rational_constant&) const;
   scalar_expr operator()(const relational&, const scalar_expr& rel_expr) const;
   scalar_expr operator()(const undefined&) const;
+  scalar_expr operator()(const unevaluated& u);
   scalar_expr operator()(const variable& var) const;
 
  private:

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -29,43 +29,6 @@ matrix_expr distribute_visitor::operator()(const matrix_expr& input) {
       input, [this](const matrix_expr& m) { return map_matrix_expression(m, *this); });
 }
 
-scalar_expr distribute_visitor::operator()(const addition& add) { return add.map_children(*this); }
-
-boolean_expr distribute_visitor::operator()(const boolean_constant&,
-                                            const boolean_expr& arg) const {
-  return arg;
-}
-
-scalar_expr distribute_visitor::operator()(const iverson_bracket& cast) {
-  return cast.map_children(*this);
-}
-scalar_expr distribute_visitor::operator()(const compound_expression_element& el) {
-  return el.map_children(*this);
-}
-scalar_expr distribute_visitor::operator()(const complex_infinity&) const {
-  return constants::complex_infinity;
-}
-scalar_expr distribute_visitor::operator()(const conditional& conditional) {
-  return conditional.map_children(*this);
-}
-scalar_expr distribute_visitor::operator()(const derivative& diff) {
-  return diff.map_children(*this);
-}
-
-scalar_expr distribute_visitor::operator()(const imaginary_unit&) const {
-  return constants::imaginary_unit;
-}
-
-scalar_expr distribute_visitor::operator()(const integer_constant&, const scalar_expr& arg) const {
-  return arg;
-}
-
-scalar_expr distribute_visitor::operator()(const float_constant&, const scalar_expr& arg) const {
-  return arg;
-}
-
-scalar_expr distribute_visitor::operator()(const function& f) { return f.map_children(*this); }
-
 scalar_expr distribute_visitor::operator()(const multiplication& mul) {
   return distribute_multiplied_terms(mul);
 }
@@ -103,22 +66,13 @@ scalar_expr distribute_visitor::operator()(const power& pow) {
   return power::create(std::move(b), std::move(e));
 }
 
-scalar_expr distribute_visitor::operator()(const rational_constant&, const scalar_expr& arg) const {
-  return arg;
-}
-
-boolean_expr distribute_visitor::operator()(const relational& relation) {
-  return relation.map_children(*this);
-}
-
-scalar_expr distribute_visitor::operator()(const symbolic_constant&, const scalar_expr& arg) const {
-  return arg;
-}
-
-scalar_expr distribute_visitor::operator()(const undefined&) const { return constants::undefined; }
-
-scalar_expr distribute_visitor::operator()(const variable&, const scalar_expr& arg) const {
-  return arg;
+template <typename T, typename X, typename>
+X distribute_visitor::operator()(const T& concrete, const X& expr) {
+  if constexpr (T::is_leaf_node) {
+    return expr;
+  } else {
+    return concrete.map_children(*this);
+  }
 }
 
 scalar_expr distribute_visitor::distribute_power(scalar_expr base, std::size_t power) {

--- a/components/core/wf/distribute.h
+++ b/components/core/wf/distribute.h
@@ -16,24 +16,12 @@ class distribute_visitor {
   boolean_expr operator()(const boolean_expr& input);
   matrix_expr operator()(const matrix_expr& input);
 
-  scalar_expr operator()(const addition& add);
-  boolean_expr operator()(const boolean_constant&, const boolean_expr& arg) const;
-  scalar_expr operator()(const compound_expression_element& el);
-  scalar_expr operator()(const complex_infinity&) const;
-  scalar_expr operator()(const conditional& conditional);
-  scalar_expr operator()(const derivative& diff);
-  scalar_expr operator()(const imaginary_unit&) const;
-  scalar_expr operator()(const integer_constant&, const scalar_expr& arg) const;
-  scalar_expr operator()(const iverson_bracket& cast);
-  scalar_expr operator()(const float_constant&, const scalar_expr& arg) const;
-  scalar_expr operator()(const function& f);
   scalar_expr operator()(const multiplication& mul);
   scalar_expr operator()(const power& pow);
-  scalar_expr operator()(const rational_constant&, const scalar_expr& arg) const;
-  boolean_expr operator()(const relational& relation);
-  scalar_expr operator()(const symbolic_constant&, const scalar_expr& arg) const;
-  scalar_expr operator()(const undefined&) const;
-  scalar_expr operator()(const variable&, const scalar_expr& arg) const;
+
+  template <typename T, typename X,
+            typename = enable_if_does_not_contain_type_t<T, type_list<power, multiplication>>>
+  X operator()(const T& concrete, const X& expr);
 
  private:
   // Expand base^power.

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -41,6 +41,7 @@ struct type_list_trait<scalar_meta_type> {
     class power,
     class rational_constant,
     class undefined,
+    class unevaluated,
     class variable
     >;
   // clang-format on

--- a/components/core/wf/expressions/all_expressions.h
+++ b/components/core/wf/expressions/all_expressions.h
@@ -16,4 +16,5 @@
 #include "wf/expressions/power.h"
 #include "wf/expressions/relational.h"
 #include "wf/expressions/special_constants.h"
+#include "wf/expressions/unevaluated.h"
 #include "wf/expressions/variable.h"

--- a/components/core/wf/expressions/unevaluated.cc
+++ b/components/core/wf/expressions/unevaluated.cc
@@ -1,0 +1,19 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#include "wf/expressions/unevaluated.h"
+
+namespace wf {
+
+scalar_expr unevaluated::create(scalar_expr contents) {
+  // Don't nest parentheses - this would be meaningless.
+  if (const unevaluated* p = get_if<const unevaluated>(contents); p != nullptr) {
+    return contents;
+  } else {
+    return make_expr<unevaluated>(std::move(contents));
+  }
+}
+
+scalar_expr make_unevaluated(scalar_expr expr) { return unevaluated::create(std::move(expr)); }
+
+}  // namespace wf

--- a/components/core/wf/expressions/unevaluated.h
+++ b/components/core/wf/expressions/unevaluated.h
@@ -1,0 +1,56 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+#include "wf/expression.h"
+
+namespace wf {
+
+// A set of parentheses about a scalar-valued expression that stops further simplification.
+class unevaluated {
+ public:
+  static constexpr std::string_view name_str = "Unevaluated";
+  static constexpr bool is_leaf_node = false;
+
+  explicit unevaluated(scalar_expr contents) noexcept : contents_(std::move(contents)) {}
+
+  template <typename Operation>
+  scalar_expr map_children(Operation&& operation) const {
+    return create(operation(contents_));
+  }
+
+  // Create a new unevaluated expression.
+  static scalar_expr create(scalar_expr contents);
+
+  constexpr const scalar_expr& contents() const noexcept { return contents_; }
+
+  // Support iteration.
+  constexpr auto begin() const noexcept { return std::addressof(contents_); }
+  constexpr auto end() const noexcept { return begin() + 1; }
+
+  static constexpr std::size_t size() noexcept { return 1; }
+
+ protected:
+  scalar_expr contents_;
+};
+
+template <>
+struct hash_struct<unevaluated> {
+  std::size_t operator()(const unevaluated& c) const noexcept { return hash(c.contents()); }
+};
+
+template <>
+struct is_identical_struct<unevaluated> {
+  bool operator()(const unevaluated& a, const unevaluated& b) const {
+    return are_identical(a.contents(), b.contents());
+  }
+};
+
+template <>
+struct order_struct<unevaluated> {
+  relative_order operator()(const unevaluated& a, const unevaluated& b) const {
+    return wf::order_by(a.contents(), b.contents());
+  }
+};
+
+}  // namespace wf

--- a/components/core/wf/functions.h
+++ b/components/core/wf/functions.h
@@ -82,4 +82,9 @@ matrix_expr where(const boolean_expr& condition, const matrix_expr& if_true,
 // Evaluates to 1 if bool_expression is true, and 0 if bool_expression is false.
 scalar_expr iverson(const boolean_expr& bool_expression);
 
+// Insert a parenthetical around an expression: x * y --> (x * y)
+// This prevents downstream operations from simplifying further.
+// Implemented in unevaluated.cc
+scalar_expr make_unevaluated(scalar_expr expr);
+
 }  // namespace wf

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -239,6 +239,8 @@ class determine_set_visitor {
     return number_set::unknown;
   }
 
+  number_set operator()(const unevaluated& u) const { return determine_numeric_set(u.contents()); }
+
   constexpr number_set operator()(const variable& var) const noexcept { return var.set(); }
 };
 

--- a/components/core/wf/ordering.cc
+++ b/components/core/wf/ordering.cc
@@ -32,8 +32,8 @@ relative_order order_struct<scalar_expr>::operator()(const scalar_expr& a,
   using order_of_types =
       type_list<float_constant, integer_constant, rational_constant, symbolic_constant,
                 complex_infinity, imaginary_unit, variable, multiplication, addition, power,
-                function, conditional, iverson_bracket, compound_expression_element, derivative,
-                undefined>;
+                function, unevaluated, conditional, iverson_bracket, compound_expression_element,
+                derivative, undefined>;
   static constexpr auto order =
       get_type_order_indices(scalar_expr::storage_type::types{}, order_of_types{});
 

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -287,6 +287,12 @@ void plain_formatter::operator()(const relational& relational) {
 
 void plain_formatter::operator()(const undefined&) { output_.append("nan"); }
 
+void plain_formatter::operator()(const unevaluated& u) {
+  output_ += "(";
+  operator()(u.contents());
+  output_ += ")";
+}
+
 void plain_formatter::operator()(const variable& var) { output_.append(var.to_string()); }
 
 void plain_formatter::format_precedence(const precedence parent, const scalar_expr& expr) {

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -36,6 +36,7 @@ class plain_formatter {
   void operator()(const relational& relational);
   void operator()(const function& func);
   void operator()(const undefined&);
+  void operator()(const unevaluated& u);
   void operator()(const variable& var);
 
   // Get the output string (transferring ownership to the caller).

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -123,6 +123,11 @@ void tree_formatter_visitor::operator()(const symbolic_constant& constant) {
 
 void tree_formatter_visitor::operator()(const undefined&) { format_append(undefined::name_str); }
 
+void tree_formatter_visitor::operator()(const unevaluated& u) {
+  format_append("{}:", unevaluated::name_str);
+  visit_all(u);
+}
+
 void tree_formatter_visitor::operator()(const variable& var) {
   format_append("{} ({}, {})", variable::name_str, var.to_string(),
                 string_from_number_set(var.set()));

--- a/components/core/wf/tree_formatter.h
+++ b/components/core/wf/tree_formatter.h
@@ -41,6 +41,7 @@ class tree_formatter_visitor {
   void operator()(const relational& relational);
   void operator()(const symbolic_constant& constant);
   void operator()(const undefined&);
+  void operator()(const unevaluated& u);
   void operator()(const variable& var);
 
   // Get the output string. Result is returned via move.

--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -68,6 +68,7 @@ class Conversions:
             sp.StrictGreaterThan: sym.gt,
             sp.GreaterThan: sym.ge,
             sp.Eq: sym.eq,
+            sp.UnevaluatedExpr: sym.unevaluated,
         }
         self.custom_converters = {
             sp.Add: self.convert_add,

--- a/components/wrapper/pywrenfold/docs/scalar_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/scalar_wrapper.h
@@ -691,6 +691,22 @@ Examples:
   1
 )doc";
 
+inline constexpr std::string_view unevaluated = R"doc(
+Wrap a scalar-valued expression to prevent automatic simplifications/combinations in downstream
+operations. This is similar in intent to SymPy's ``UnevaluatedExpr``.
+
+Args:
+  arg: Scalar-valued expression to wrap.
+
+Examples:
+  >>> x, y = sym.symbols('x, y')
+  >>> f = sym.unevaluated(x * y) * y
+  >>> f # Products are not combined automatically.
+  y*(x*y)
+  >>> f.diff(y) # Derivatives retain the parentheses.
+  y*(x) + (x*y)
+)doc";
+
 inline constexpr std::string_view eliminate_subexpressions = R"doc(
 Extract common subexpressions from a scalar-valued expression. The expression tree is traversed and
 unique expressions are counted. Those that appear ``min_occurrences`` or more times are replaced

--- a/components/wrapper/pywrenfold/scalar_wrapper.cc
+++ b/components/wrapper/pywrenfold/scalar_wrapper.cc
@@ -263,6 +263,8 @@ void wrap_scalar_operations(py::module_& m) {
 
   m.def("iverson", &wf::iverson, "arg"_a, docstrings::iverson.data());
 
+  m.def("unevaluated", &wf::make_unevaluated, "arg"_a, docstrings::unevaluated.data());
+
   m.def(
       "eliminate_subexpressions",
       [](const scalar_expr& expr,

--- a/components/wrapper/pywrenfold/sympy_conversion.cc
+++ b/components/wrapper/pywrenfold/sympy_conversion.cc
@@ -161,6 +161,10 @@ class sympy_conversion_visitor {
 
   py::object operator()(const undefined&) const { return get_sympy_attr("nan"); }
 
+  py::object operator()(const unevaluated& p) {
+    return invoke_sympy_object("UnevaluatedExpr", *convert_to_args(p));
+  }
+
   py::object operator()(const variable& var) const {
     py::dict kwargs{};
     switch (var.set()) {

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -284,6 +284,12 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(0, sym.iverson(sym.eq(sym.one, sym.zero)))
         self.assertEqual((x < y,), sym.iverson(x < y).args)
 
+    def test_unevaluated(self):
+        """Test calling `unevaluated`."""
+        x, y = sym.symbols('x, y')
+        self.assertIdentical(sym.unevaluated(x), sym.unevaluated(x))
+        self.assertIdentical(sym.unevaluated(x), sym.unevaluated(sym.unevaluated(x)))
+
     def test_subs(self):
         """Test calling subs() on expressions."""
         x, y, z = sym.symbols('x, y, z')

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -265,6 +265,16 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(
             sym.where(0 < x, 1, sym.where(x < 0, -1, sym.nan)), sp.Heaviside(spy(x), sp.nan))
 
+    def test_unevaluated(self):
+        x, y = sym.symbols('x, y')
+        self.assertEqualSp(sp.UnevaluatedExpr(spy(x)), sym.unevaluated(x))
+        self.assertEqualSp(sp.UnevaluatedExpr(spy(x) * spy(y)) * spy(y), sym.unevaluated(x * y) * y)
+
+        # sympy --> wf
+        self.assertIdenticalFromSp(
+            sym.unevaluated(x * y) * y,
+            sp.UnevaluatedExpr(spy(x) * spy(y)) * spy(y))
+
     def test_matrix(self):
         x, y = sym.symbols('x, y')
 


### PR DESCRIPTION
This change adds an `unevaluated` expression type that allows the user finer grained control over automatic combinations of expressions. It effectively behaves like a parenthetical, and wraps a subexpression so that terms are not combined. 

For example:
```python
>>> sym.unevaluated(x * y) * y
y*(x*y)
```

The use case is similar to SymPy's `UnevaluatedExpr`. I think there are some cases where this will enable meaningful code-generation improvements (fewer operations).

I also cleaned up the implementation of distribute/collect.