### PR TITLE
Set rust version to 1.77 in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,13 @@ jobs:
         run: ctest --output-on-failure
 
       - name: Install rust
-        run: rustup toolchain install 1.77 --profile minimal
+        run: rustup toolchain install 1.77
+
+      - name: Set default rust version
+        run: rustup default 1.77
+
+      - name: Install clippy
+        run: rustup component add clippy
 
       - name: Dump rustc version
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}


### PR DESCRIPTION
When I set the default installed to `1.77` I neglected to make it the default. This change _actually_ pins it to 1.77 to work around a linker issue on Ubuntu.