### PR TITLE
Value does not use hash-set to store consumers

### DIFF
--- a/components/core/benchmarks/bench_code_generation.cc
+++ b/components/core/benchmarks/bench_code_generation.cc
@@ -46,7 +46,7 @@ static void BM_CreateFlatIrLowComplexity(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_CreateFlatIrLowComplexity)->Iterations(200)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_CreateFlatIrLowComplexity)->Iterations(1000)->Unit(benchmark::kMillisecond);
 
 static void BM_ConvertIrLowComplexity(benchmark::State& state) {
   const function_description description = build_function_description(

--- a/components/core/wf/checked_pointers.h
+++ b/components/core/wf/checked_pointers.h
@@ -76,7 +76,7 @@ class non_null {
   constexpr decltype(auto) operator*() const noexcept { return *get(); }
 
   // Check underlying ptr is null. This can happen if we moved the underlying pointer out.
-  constexpr operator bool() const noexcept { return ptr_ != nullptr; }  //  NOLINT
+  constexpr explicit operator bool() const noexcept { return ptr_ != nullptr; }
 
  private:
   // Get r-value reference.
@@ -159,7 +159,7 @@ class maybe_null {
   maybe_null& operator=(maybe_null&& other) = default;
 
   // Check truthiness.
-  constexpr operator bool() const noexcept(detail::is_nothrow_castable_to_bool_v<T>) {  //  NOLINT
+  constexpr explicit operator bool() const noexcept(detail::is_nothrow_castable_to_bool_v<T>) {
     return static_cast<bool>(ptr_);
   }
 

--- a/components/core/wf/code_generation/control_flow_graph.cc
+++ b/components/core/wf/code_generation/control_flow_graph.cc
@@ -199,11 +199,10 @@ control_flow_graph::control_flow_graph(std::vector<expression_group> groups) {
   ir_form_visitor visitor{*this, std::move(count_visitor).take_counts()};
   for (const expression_group& group : groups) {
     // Transform expressions into Values
-    auto group_values = transform_map<ir::value::operands_container>(
-        group.expressions, [&](const scalar_expr& expr) {
-          // TODO: Allow returning other types - derive numeric type from the group.
-          return visitor.apply_output_value(expr, code_numeric_type::floating_point);
-        });
+    auto group_values = transform_map<std::vector>(group.expressions, [&](const scalar_expr& expr) {
+      // TODO: Allow returning other types - derive numeric type from the group.
+      return visitor.apply_output_value(expr, code_numeric_type::floating_point);
+    });
 
     // Then create a sink to consume these values, the `save` operation is the sink:
     create_operation(values_, first_block(), ir::save{group.key}, ir::void_type{},

--- a/components/core/wf/code_generation/ir_consumer_vector.h
+++ b/components/core/wf/code_generation/ir_consumer_vector.h
@@ -1,0 +1,121 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+
+#include "wf/checked_pointers.h"
+#include "wf/third_party_imports.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <absl/container/inlined_vector.h>
+WF_END_THIRD_PARTY_INCLUDES
+
+namespace wf::ir {
+
+class block;
+class value;
+using block_ptr = non_null<ir::block*>;
+using value_ptr = non_null<ir::value*>;
+using const_block_ptr = non_null<const ir::block*>;
+using const_value_ptr = non_null<const ir::value*>;
+
+// Stores a sparse vector of value_ptrs. Empty cells are denoted by a nullptr. When an insertion
+// occurs, we consult the free list to find a place to insert the new element. When a removal
+// occurs, we nullify the corresponding cell and add its index to the free list.
+// TODO: Would like to clean this up and generalize it a bit into a general purpose container.
+class consumer_vector {
+ public:
+  using container_type = absl::InlinedVector<maybe_null<ir::value*>, 8>;
+
+  // Skip iterator that passes over null values in our storage array.
+  class const_iterator {
+   public:
+    using value_type = ir::value_ptr;
+    using difference_type = void;
+    using pointer = void;
+    using reference = void;
+    using iterator_category = std::input_iterator_tag;
+
+    constexpr bool operator==(const const_iterator& other) const noexcept {
+      return it_ == other.it_;
+    }
+    constexpr bool operator!=(const const_iterator& other) const noexcept {
+      return !operator==(other);
+    }
+
+    constexpr const_iterator& operator++() noexcept {
+      ++it_;
+      advance_to_next();
+      return *this;
+    }
+
+    constexpr const_iterator operator++(int) noexcept {
+      const const_iterator copy = *this;
+      ++it_;
+      advance_to_next();
+      return copy;
+    }
+
+    // Occupied cells are never null, so convert to value_ptr.
+    constexpr value_type operator*() const noexcept { return ir::value_ptr{it_->get_unchecked()}; }
+
+   private:
+    explicit constexpr const_iterator(const container_type::const_iterator it,
+                                      const container_type::const_iterator end_it) noexcept
+        : it_(it), end_it_(end_it) {
+      advance_to_next();
+    }
+
+    constexpr void advance_to_next() noexcept {
+      for (; it_ != end_it_ && !it_->has_value(); ++it_) {
+      }
+    }
+
+    friend class consumer_vector;
+
+    container_type::const_iterator it_;
+    container_type::const_iterator end_it_;
+  };
+
+  // Insert the provided value. Returns the index indicating where this value was stored.
+  std::size_t insert(ir::value* v) {
+    if (freelist_.empty()) {
+      const std::size_t index = consumers_.size();
+      consumers_.emplace_back(v);
+      return index;
+    } else {
+      const std::size_t index = freelist_.back();
+      freelist_.pop_back();
+      consumers_[index] = v;
+      return index;
+    }
+  }
+
+  // Remove value indicated by the specified index.
+  void remove(const std::size_t index) {
+    WF_ASSERT_LESS(index, consumers_.size());
+    WF_ASSERT(consumers_[index]);
+    consumers_[index] = nullptr;
+    freelist_.push_back(static_cast<std::uint32_t>(index));
+  }
+
+  // True if there are no consumers.
+  bool empty() const noexcept { return size() == 0; }
+
+  // Number of consumers.
+  std::size_t size() const noexcept { return consumers_.size() - freelist_.size(); }
+
+  auto begin() const noexcept { return const_iterator{consumers_.begin(), consumers_.end()}; }
+  auto end() const noexcept { return const_iterator{consumers_.end(), consumers_.end()}; }
+
+  void clear() noexcept {
+    consumers_.clear();
+    freelist_.clear();
+  }
+
+ private:
+  absl::InlinedVector<maybe_null<ir::value*>, 8> consumers_;
+  absl::InlinedVector<std::uint32_t, 8> freelist_;
+};
+
+}  // namespace wf::ir

--- a/components/core/wf/code_generation/ir_control_flow_converter.cc
+++ b/components/core/wf/code_generation/ir_control_flow_converter.cc
@@ -231,7 +231,7 @@ static std::tuple<ir::value_ptr, std::vector<ir::value_ptr>> select_conditionals
 
   // Group together any conditionals that use this same condition:
   const auto matches_condition = [&](const ir::value_ptr v) {
-    return v->first_operand() == condition;
+    return v->first_operand().get() == condition.get();
   };
 
   // We'll copy and return them.

--- a/components/core/wf/code_generation/ir_value.cc
+++ b/components/core/wf/code_generation/ir_value.cc
@@ -12,24 +12,29 @@ void value::set_parent(const ir::block_ptr b) {
 
 bool value::is_consumed_by_phi() const noexcept {
   return std::any_of(consumers_.begin(), consumers_.end(),
-                     [](const value_ptr& v) { return v->is_phi(); });
+                     [](const value_ptr v) { return v->is_phi(); });
 }
 
-void value::replace_operand(const value_ptr old, const value_ptr replacement) {
-  const value_ptr self{this};
-  for (ir::value_ptr& operand : operands_) {
-    if (operand == old) {
+void value::replace_operand(const ir::value* old, const value_ptr replacement) {
+  // Traverse operands, and replace any that point to `old` with `replacement`.
+  // In the process, `replacement` has consumers added so the graph is intact.
+  for (operand_ptr& operand : operands_) {
+    if (operand.get() == old) {
       // Note we don't remove the consumer from `operand`, that happens in replace_with(...)
-      operand = replacement;
-      replacement->add_consumer(self);
+      operand = replacement->add_consumer(this);
     }
   }
   maybe_sort_operands();
 }
 
-void value::add_consumer(const ir::value_ptr v) { consumers_.insert(v); }
+operand_ptr value::add_consumer(ir::value* v) {
+  return operand_ptr{ir::value_ptr{this}, consumers_.insert(v)};
+}
 
-void value::remove_consumer(const value_ptr v) { consumers_.erase(v); }
+void value::remove_consumer(const operand_ptr v) {
+  WF_ASSERT(v.get() == this);
+  consumers_.remove(v.consumer_index());
+}
 
 absl::InlinedVector<ir::value_ptr, 8> value::ordered_consumers() const {
   absl::InlinedVector<ir::value_ptr, 8> result{consumers_.begin(), consumers_.end()};
@@ -45,22 +50,21 @@ bool value::operands_match(const value_ptr other) const noexcept {
 }
 
 void value::replace_with(const value_ptr other) {
-  const value_ptr self{this};
-  WF_ASSERT_NOT_EQUAL(self, other);
-  for (const value_ptr& consumer : consumers_) {
-    consumer->replace_operand(self, other);
+  WF_ASSERT(this != other.get());
+  for (const value_ptr consumer : consumers_) {
+    consumer->replace_operand(this, other);
   }
   consumers_.clear();
 }
 
 void value::remove() {
-  WF_ASSERT(consumers_.empty(), "Attempting to remove a value `{}` that is consumed by: [{}]",
-            name_, fmt::join(consumers_, ","));
+  WF_ASSERT(consumers_.empty(), "Attempting to remove a value `{}` that has {} consumers.", name_,
+            consumers_.size());
   // Notify our operands we no longer consume them.
-  for (const value_ptr& operand : operands_) {
-    operand->remove_consumer(this);
+  for (const operand_ptr& operand : operands_) {
+    operand.remove_operand();
   }
-  // This value is dead, so clear the operand vector
+  // This value is dead, so clear the operand vector so we don't accidentally access it.
   operands_.clear();
 }
 
@@ -69,8 +73,8 @@ type_variant value::non_void_type() const {
       [&](const auto& t) -> type_variant {
         using T = std::decay_t<decltype(t)>;
         if constexpr (std::is_same_v<T, ir::void_type>) {
-          WF_ASSERT_ALWAYS("Attempted to coerce void-typed value: {}, op index = {}, operands = {}",
-                           name(), op_.index(), fmt::join(operands_, ", "));
+          WF_ASSERT_ALWAYS("Attempted to coerce void-typed value: {}, op index = {}", name(),
+                           op_.index());
         } else {
           return t;
         }
@@ -82,13 +86,6 @@ void value::maybe_sort_operands() {
   if (const bool commutative = std::visit([](const auto& op) { return op.is_commutative(); }, op_);
       commutative) {
     sort_operands();
-  }
-}
-
-void value::notify_operands() {
-  const value_ptr self{this};
-  for (const value_ptr& operand : operands_) {
-    operand->add_consumer(self);
   }
 }
 

--- a/components/core/wf/traits.h
+++ b/components/core/wf/traits.h
@@ -81,4 +81,24 @@ constexpr bool is_variant_v = false;
 template <typename... Ts>
 constexpr bool is_variant_v<std::variant<Ts...>> = true;
 
+namespace detail {
+template <typename T, typename = void>
+struct has_begin_function : std::false_type {};
+template <typename T>
+struct has_begin_function<T, decltype(std::declval<T>().begin(), void())> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_end_function : std::false_type {};
+template <typename T>
+struct has_end_function<T, decltype(std::declval<T>().end(), void())> : std::true_type {};
+
+}  // namespace detail
+
+// True if the type is iterable (exposes begin() and end())
+template <typename T>
+struct is_iterable : std::conjunction<detail::has_begin_function<T>, detail::has_end_function<T>> {
+};
+template <typename T>
+constexpr bool is_iterable_v = is_iterable<T>::value;
+
 }  // namespace wf


### PR DESCRIPTION
While working on some improvements to the code-generation backend, I found an opportunity to improve performance by getting rid of the `consumers_` set in `ir::value`. Instead, I replace it with a sparse `consumer_vector`. Operands now store an index where they can be found in the `consumer_vector` of the value they point to.

On `main`, this speeds up simplification of the IR by around ~10%. It makes more difference (~20%) on a new branch I am iterating where more simplifications/optimizations are applied.

While iterating on this, I have come to really dislike the IR data structures. The "big pile of pointers" representation is sometimes tedious to iterate on. I _think_ I can now see a pathway to something simpler and easier to understand + debug, bug I'm going to defer that refactor until I merge the improvements to code-generation and add some performance results to the docs.