### PR TITLE
Add missing `__hash__` and `__eq__` implementation to Quaternion type

### DIFF
--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -202,4 +202,17 @@ quaternion operator*(const quaternion& a, const quaternion& b);
 // When the norm of `w` falls below `epsilon`, the small angle approximation is used.
 matrix_expr left_jacobian_of_so3(const matrix_expr& w, const std::optional<scalar_expr>& epsilon);
 
+template <>
+struct hash_struct<quaternion> {
+  std::size_t operator()(const quaternion& q) const { return hash_all(0, q.wxyz()); }
+};
+
+template <>
+struct is_identical_struct<quaternion> {
+  bool operator()(const quaternion& a, const quaternion& b) const {
+    return std::equal(a.wxyz().begin(), a.wxyz().end(), b.wxyz().begin(),
+                      is_identical_struct<scalar_expr>{});
+  }
+};
+
 }  // namespace wf

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -54,7 +54,7 @@ static py::array eval_quaternion(const quaternion& q) {
 }
 
 void wrap_geometry_operations(py::module_& m) {
-  py::class_<quaternion>(m, "Quaternion")
+  wrap_class<quaternion>(m, "Quaternion")
       .def(py::init<scalar_expr, scalar_expr, scalar_expr, scalar_expr>(), "w"_a, "x"_a, "y"_a,
            "z"_a, docstrings::quaternion_constructor.data())
       .def(py::init<>(), docstrings::quaternion_identity_constructor.data())


### PR DESCRIPTION
Python `Quaternion` type lacked a proper implementation of hash and equality test.