### PR TITLE
Remove non-deterministic hash from `custom_type`

### DIFF
--- a/components/core/wf/code_generation/types.h
+++ b/components/core/wf/code_generation/types.h
@@ -96,7 +96,6 @@ class erased_pytype {
    public:
     virtual ~concept() = default;
     virtual bool is_identical_to(const concept& other) const = 0;
-    virtual std::size_t hash() const = 0;
   };
 
   template <typename T, typename... Args,
@@ -107,8 +106,6 @@ class erased_pytype {
   bool is_identical_to(const erased_pytype& other) const {
     return impl_->is_identical_to(*other.impl_.get());
   }
-
-  std::size_t hash() const { return impl_->hash(); }
 
   // Unchecked cast.
   template <typename T>

--- a/components/wrapper/pywrenfold/types_wrapper.cc
+++ b/components/wrapper/pywrenfold/types_wrapper.cc
@@ -19,15 +19,12 @@ namespace wf {
 // We use this to type-erase a `py::type`, and pass it into `custom_type`.
 class pytype_wrapper final : public erased_pytype::concept {
  public:
-  explicit pytype_wrapper(py::type type) noexcept(std::is_nothrow_move_constructible_v<py::type>)
-      : type_(std::move(type)) {}
+  explicit pytype_wrapper(py::type type) noexcept : type_(std::move(type)) {}
 
   bool is_identical_to(const erased_pytype::concept& other) const override {
     // Cast is safe because there is only one implementation of `erased_pytype`.
-    return type_.is(static_cast<const pytype_wrapper&>(other).type_);
+    return type_.equal(static_cast<const pytype_wrapper&>(other).type_);
   }
-
-  std::size_t hash() const override { return py::hash(type_); }
 
   constexpr const py::type& type() const noexcept { return type_; }
 


### PR DESCRIPTION
The hash function for `custom_type` was (unintentionally) non-deterministic, because it depended on python's `hash()` function.

This change remedies this by removing the hash of the underlying python type. This might increase hash collisions a bit, but in practice it likely doesn't matter since this will only occur if two types are structurally identical and have the same name.