### PR TITLE
Speed up ordering operator for scalar expressions

### DIFF
--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -163,8 +163,16 @@ boolean_expr operator==(const scalar_expr& a, const scalar_expr& b);
 // This is not a mathematical ordering - rather it is a canonical ordering we impose on expressions.
 template <>
 struct order_struct<scalar_expr> {
+  relative_order operator()(const scalar_expr& a, const scalar_expr& b) const {
+    if (a.has_same_address(b)) {
+      return relative_order::equal;
+    }
+    return compare(a, b);
+  }
+
+ private:
   // Implemented in ordering.cc
-  relative_order operator()(const scalar_expr& a, const scalar_expr& b) const;
+  relative_order compare(const scalar_expr& a, const scalar_expr& b) const;
 };
 
 // Predicate for sorting expressions.

--- a/components/core/wf/expressions/numeric_expressions.h
+++ b/components/core/wf/expressions/numeric_expressions.h
@@ -280,7 +280,12 @@ template <>
 struct order_struct<rational_constant> {
   constexpr relative_order operator()(const rational_constant& a,
                                       const rational_constant& b) const noexcept {
-    return order_by_comparison(a, b);
+    if (a.denominator() == b.denominator()) {
+      return order_by_comparison(a.numerator(), b.numerator());
+    }
+    const auto left = a.numerator() * b.denominator();
+    const auto right = b.numerator() * a.denominator();
+    return order_by_comparison(left, right);
   }
 };
 

--- a/components/core/wf/ordering.cc
+++ b/components/core/wf/ordering.cc
@@ -3,6 +3,7 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/ordering.h"
 
+#include "wf/enumerations.h"
 #include "wf/expression.h"
 #include "wf/expression_visitor.h"
 #include "wf/expressions/all_expressions.h"
@@ -27,8 +28,8 @@ static constexpr auto get_type_order_indices(type_list<AllTypes...>,
       static_cast<uint16_t>(type_list_index_v<AllTypes, ordered_list>)...};
 }
 
-relative_order order_struct<scalar_expr>::operator()(const scalar_expr& a,
-                                                     const scalar_expr& b) const {
+relative_order order_struct<scalar_expr>::compare(const scalar_expr& a,
+                                                  const scalar_expr& b) const {
   using order_of_types =
       type_list<float_constant, integer_constant, rational_constant, symbolic_constant,
                 complex_infinity, imaginary_unit, variable, multiplication, addition, power,


### PR DESCRIPTION
This change allows the `order_struct<scalar_expr>` operation to shortcut by first checking the addresses of the two operands. Since identical expressions often have the same memory address (which we ensure through memoization), this can deliver a significant speedup in some cases.

While testing generation times for `integrate_and_project` in `gen_rolling_shutter_camera_wf.py` (under Ubuntu 22.04 on GCC12), the total time for code-generation went from ~0.1 seconds to ~0.021 seconds.

I also introduced a minor optimization into `order_struct<rational_constant>`: The `operator*(const checked_int&, const checked_int&)` method is relatively slow (since it first applies overflow checks. If the denominators are identical, we can skip this step and just compare the numerators.