### PR TITLE
Rename RealScalar to FloatScalar to clarify type

### DIFF
--- a/components/core/tests/generation_test_2.py
+++ b/components/core/tests/generation_test_2.py
@@ -8,7 +8,7 @@ from wrenfold import sym
 from wrenfold import type_info
 from wrenfold.code_generation import CppGenerator, RustGenerator
 from wrenfold.external_functions import declare_external_function
-from wrenfold.type_annotations import RealScalar, Opaque
+from wrenfold.type_annotations import FloatScalar, Opaque
 
 
 @dataclasses.dataclass
@@ -38,7 +38,7 @@ vector_interpolate_access = declare_external_function(
     return_type=StructType)
 
 
-def lookup_and_compute_inner_product(vec: VectorOfStructs, a: RealScalar, b: RealScalar):
+def lookup_and_compute_inner_product(vec: VectorOfStructs, a: FloatScalar, b: FloatScalar):
     """
     A simplified test case that calls a user-provided function to access two elements in a vector,
     then computes the inner product between them.

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -86,10 +86,10 @@ def create_function_description(func: T.Callable[..., CodegenFuncInvocationResul
       An instance of :class:`wrenfold.code_generation.FunctionDescription`.
 
     Example:
-      >>> from wrenfold.type_annotations import RealScalar
+      >>> from wrenfold.type_annotations import FloatScalar
       >>> from wrenfold import code_generation
       >>>
-      >>> def foo(x: RealScalar, y: RealScalar):
+      >>> def foo(x: FloatScalar, y: FloatScalar):
       >>>     # One return value, and one output argument named `z`:
       >>>     return [code_generation.ReturnValue(x * y), code_generation.OutputArg(x + y, "z")]
       >>> description = code_generation.create_function_description(func=foo)
@@ -216,10 +216,10 @@ def generate_function(func: T.Callable[..., CodegenFuncInvocationResult],
     Returns: Generated code.
 
     Example:
-      >>> from wrenfold.type_annotations import RealScalar
+      >>> from wrenfold.type_annotations import FloatScalar
       >>> from wrenfold import code_generation
       >>>
-      >>> def foo(x: RealScalar, y: RealScalar):
+      >>> def foo(x: FloatScalar, y: FloatScalar):
       >>>     # One return value, and one output argument named `z`:
       >>>     return [code_generation.ReturnValue(x * y), code_generation.OutputArg(x + y, "z")]
       >>>

--- a/components/python/wrenfold/type_annotations.py
+++ b/components/python/wrenfold/type_annotations.py
@@ -10,7 +10,7 @@ import typing as T
 from . import sym
 
 
-class RealScalar(sym.Expr):
+class FloatScalar(sym.Expr):
     """Denote a floating-point scalar variable."""
 
 

--- a/components/wrapper/pywrenfold/docs/codegen_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/codegen_wrapper.h
@@ -58,7 +58,7 @@ Returns:
 
 Example:
   >>> from wrenfold import sym, code_generation, type_annotations
-  >>> def func(x: type_annotations.RealScalar, y: type_annotations.RealScalar):
+  >>> def func(x: type_annotations.FloatScalar, y: type_annotations.FloatScalar):
   >>>   return sym.abs(x * y) * sym.cos(x * y)
   >>> desc = code_generation.create_function_description(func)
   >>> outputs, intermediate_values = code_generation.cse_function_description(desc)

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -16,17 +16,17 @@ from wrenfold import sym
 from wrenfold import type_info
 from wrenfold.code_generation import ReturnValue, OutputArg
 from wrenfold.enumerations import StdMathFunction
-from wrenfold.type_annotations import RealScalar, Vector2, Opaque
+from wrenfold.type_annotations import FloatScalar, Vector2, Opaque
 
 from test_base import MathTestBase
 
 
-def func1(x: RealScalar, y: RealScalar, v: Vector2):
+def func1(x: FloatScalar, y: FloatScalar, v: Vector2):
     """A test function."""
     return (v.T * v)[0] * x + 5 * x * sym.pow(y, 3.1)
 
 
-def func2(x: Vector2, y: Vector2, z: RealScalar):
+def func2(x: Vector2, y: Vector2, z: FloatScalar):
     """Another test function with some output args."""
     m = sym.where(z > x[1], (x * y.transpose() + sym.eye(2) * sym.cos(z / x[0])).squared_norm(),
                   z * 5)
@@ -44,11 +44,11 @@ def func2(x: Vector2, y: Vector2, z: RealScalar):
 @dataclasses.dataclass
 class Point2d:
     """A custom type."""
-    x: RealScalar
-    y: RealScalar
+    x: FloatScalar
+    y: FloatScalar
 
 
-def rotate_point(angle: RealScalar, p: Point2d):
+def rotate_point(angle: FloatScalar, p: Point2d):
     R = sym.matrix([[sym.cos(angle), -sym.sin(angle)], [sym.sin(angle), sym.cos(angle)]])
     p_rotated = R * sym.vector(p.x, p.y)
     p_out = Point2d(*p_rotated)

--- a/docs/source/python_api/type_annotations.rst
+++ b/docs/source/python_api/type_annotations.rst
@@ -6,7 +6,7 @@ type_annotations
   :special-members:
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
 
-.. autoclass:: wrenfold.type_annotations.RealScalar
+.. autoclass:: wrenfold.type_annotations.FloatScalar
   :members:
   :special-members:
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__

--- a/docs/source/tutorial/custom_types_script.py
+++ b/docs/source/tutorial/custom_types_script.py
@@ -14,8 +14,8 @@ from wrenfold import type_info
 @dataclasses.dataclass
 class Vec2:
     """Symbolic version of geo::vec2."""
-    x: type_annotations.RealScalar
-    y: type_annotations.RealScalar
+    x: type_annotations.FloatScalar
+    y: type_annotations.FloatScalar
 
     def to_vector(self) -> sym.MatrixExpr:
         return sym.vector(self.x, self.y)
@@ -28,7 +28,7 @@ class Vec2:
 
 
 # [function_definition_start]
-def rotate_vector(angle: type_annotations.RealScalar, v: Vec2):
+def rotate_vector(angle: type_annotations.FloatScalar, v: Vec2):
     """Rotate vector `v` by `angle` radians."""
     R = sym.matrix([[sym.cos(angle), -sym.sin(angle)], [sym.sin(angle), sym.cos(angle)]])
     v_rot = R * v.to_vector()

--- a/docs/source/tutorial/external_functions_script.py
+++ b/docs/source/tutorial/external_functions_script.py
@@ -20,8 +20,8 @@ class LookupTable(type_annotations.Opaque):
 # [interpolate_table_start]
 interpolate_table = external_functions.declare_external_function(
     name="interpolate_table",
-    arguments=[("table", LookupTable), ("arg", type_annotations.RealScalar)],
-    return_type=type_annotations.RealScalar)  # [interpolate_table_end]
+    arguments=[("table", LookupTable), ("arg", type_annotations.FloatScalar)],
+    return_type=type_annotations.FloatScalar)  # [interpolate_table_end]
 
 
 # [function_definition_start]

--- a/docs/source/tutorial/generating_code.rst
+++ b/docs/source/tutorial/generating_code.rst
@@ -23,12 +23,12 @@ At first, we will assume the input variable :math:`x` is already in the domain `
     from wrenfold import sym
     from wrenfold import type_annotations
 
-    def step(x: type_annotations.RealScalar):
+    def step(x: type_annotations.FloatScalar):
         """The smoothstep polynomial."""
         return 3 * sym.pow(x, 2) - 2 * sym.pow(x, 3)
 
 Note the presence of the type annotation on argument ``x``. This is important, as it communicates
-type information required to create a function signature. In actuality, ``RealScalar`` is just
+type information required to create a function signature. In actuality, ``FloatScalar`` is just
 a scalar-valued expression of type :class:`wrenfold.sym.Expr`.
 
 .. note::
@@ -123,7 +123,7 @@ output argument:
 
 .. code:: python
 
-    def step_deriv(x: type_annotations.RealScalar):
+    def step_deriv(x: type_annotations.FloatScalar):
         """The smoothstep polynomial."""
         f = 3 * sym.pow(x, 2) - 2 * sym.pow(x, 3)
         # Place the first and second derivative into a 2x1 vector:
@@ -189,7 +189,7 @@ are shorthand for ``sym.where``:
 
 .. code:: python
 
-    def step_clamped(x: type_annotations.RealScalar):
+    def step_clamped(x: type_annotations.FloatScalar):
         """The clamped smoothstep polynomial."""
         # First express the polynomials in terms of `xv`.
         xv = sym.symbols('xv', real=True)

--- a/docs/source/tutorial/new_language.rst
+++ b/docs/source/tutorial/new_language.rst
@@ -55,7 +55,7 @@ With a ``BaseGenerator`` subclass in hand, we can generate code:
 
 .. code:: python
 
-    def some_symbolic_func(x: type_annotations.RealScalar):
+    def some_symbolic_func(x: type_annotations.FloatScalar):
         return x * 2
 
     description = code_generation.create_function_description(some_symbolic_func)

--- a/examples/bspline/bspline.py
+++ b/examples/bspline/bspline.py
@@ -17,7 +17,7 @@ import argparse
 import typing as T
 import collections
 
-from wrenfold.type_annotations import RealScalar
+from wrenfold.type_annotations import FloatScalar
 from wrenfold import code_generation
 from wrenfold.code_generation import OutputArg, CppGenerator, RustGenerator
 from wrenfold import sym
@@ -159,7 +159,7 @@ def create_polynomial_functions(x: sym.Expr, polynomials: T.Sequence[sym.Expr], 
     descriptions: T.List[code_generation.FunctionDescription] = []
     for i in range(0, len(polynomials)):
 
-        def bspline(arg: RealScalar, arg_scale: RealScalar):
+        def bspline(arg: FloatScalar, arg_scale: FloatScalar):
             # Output the function, plus (order - 2) derivatives that are continuous.
             # The last non-zero derivative is discontinuous.
             rows = [polynomials[i].subs(x, arg)]

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -19,7 +19,7 @@ from wrenfold import sym
 from wrenfold import type_info
 from wrenfold.code_generation import ReturnValue, OutputArg, CppGenerator, RustGenerator
 from wrenfold.geometry import Quaternion
-from wrenfold.type_annotations import RealScalar, Vector3, Vector6
+from wrenfold.type_annotations import FloatScalar, Vector3, Vector6
 
 
 @dataclasses.dataclass
@@ -30,10 +30,10 @@ class EigenQuaternion:
 
     In Rust code we will use nalgebra.
     """
-    x: RealScalar
-    y: RealScalar
-    z: RealScalar
-    w: RealScalar
+    x: FloatScalar
+    y: FloatScalar
+    z: FloatScalar
+    w: FloatScalar
 
     def to_quaternion(self) -> Quaternion:
         """Convert to the wrenfold quaternion type, so we can more easily manipulate symbolically."""
@@ -108,9 +108,9 @@ class Point3d:
     """
     Another hypothetical custom type, a point in 3d space.
     """
-    x: RealScalar
-    y: RealScalar
-    z: RealScalar
+    x: FloatScalar
+    y: FloatScalar
+    z: FloatScalar
 
     def to_vector(self) -> sym.MatrixExpr:
         """

--- a/examples/imu_integration/imu_integration.py
+++ b/examples/imu_integration/imu_integration.py
@@ -12,7 +12,7 @@ In practice, there is a larger space of design choices you could make. For insta
 import argparse
 import typing as T
 
-from wrenfold.type_annotations import RealScalar, Vector4, Vector3
+from wrenfold.type_annotations import FloatScalar, Vector4, Vector3
 from wrenfold import code_generation
 from wrenfold.code_generation import OutputArg, CppGenerator
 
@@ -52,7 +52,7 @@ def integrate_imu(
     accelerometer_bias: Vector3,
     angular_velocity: Vector3,
     linear_acceleration: Vector3,
-    dt: RealScalar,
+    dt: FloatScalar,
 ):
     """
     We take an incremental navigation state represented by the 9DOF product of:
@@ -126,7 +126,7 @@ def compute_pim_delta_from_endpoints(
     world_R_k_xyzw: Vector4,
     world_t_k: Vector3,
     world_v_k: Vector3,
-    duration: RealScalar,
+    duration: FloatScalar,
     gravity_world: Vector3,
 ) -> T.Tuple[Quaternion, Vector3, Vector3]:
     """
@@ -203,7 +203,7 @@ def unweighted_imu_preintegration_error(
     i_R_k_measured_xyzw: Vector4,
     i_t_k_measured: Vector3,
     i_v_k_measured: Vector3,
-    duration: RealScalar,
+    duration: FloatScalar,
     gravity_world: Vector3,
 ):
     """
@@ -265,7 +265,7 @@ def unweighted_imu_preintegration_error(
     ]
 
 
-def integration_test_sequence(t: RealScalar):
+def integration_test_sequence(t: FloatScalar):
     """
     A motion sequence parameterized as a function of time `t`. We use this as a test sequence
     for evaluating our IMU integration code.

--- a/examples/motion_planning/problem.py
+++ b/examples/motion_planning/problem.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from wrenfold import code_generation, sym, type_info
 from wrenfold.code_generation import OutputArg
-from wrenfold.type_annotations import RealScalar, Vector3
+from wrenfold.type_annotations import FloatScalar, Vector3
 
 # Modify to change the planning horizon and time discretization of problem
 # A larger N will result in a more accurate trajectory, but will take longer to solve
@@ -42,8 +42,8 @@ class Weights:
     Associated with the `Weights` struct in `problem.rs`
     """
 
-    final_state: RealScalar
-    dynamics: RealScalar
+    final_state: FloatScalar
+    dynamics: FloatScalar
 
 
 @dataclass
@@ -53,8 +53,8 @@ class ProblemInfo:
     Associated with the `ProblemInfo` struct in `problem.rs`
     """
 
-    dt: RealScalar
-    mass: RealScalar
+    dt: FloatScalar
+    mass: FloatScalar
 
 
 def get_pos(state: State) -> Vector3:
@@ -73,7 +73,7 @@ def get_control(state: State) -> Vector3:
     return state[9:12, :]
 
 
-def dynamics(state: State, mass: RealScalar, dt: RealScalar) -> State:
+def dynamics(state: State, mass: FloatScalar, dt: FloatScalar) -> State:
     """
     Given a state, compute the next state after dt seconds
     """
@@ -98,7 +98,7 @@ def cost_hessian(cost: sym.Expr, state: State):
     return cost_jacobian(cost, state).jacobian(state)
 
 
-def desired_state_objective(state: State, desired_state: State, weight: RealScalar):
+def desired_state_objective(state: State, desired_state: State, weight: FloatScalar):
     """
     Penalize the distance between the current state and the desired state
     """
@@ -109,9 +109,9 @@ def desired_state_objective(state: State, desired_state: State, weight: RealScal
 def dynamics_objective(
     state: State,
     next_state: State,
-    weight: RealScalar,
-    mass: RealScalar,
-    dt: RealScalar,
+    weight: FloatScalar,
+    mass: FloatScalar,
+    dt: FloatScalar,
 ):
     """
     Penalize the distance between the next state and the state predicted by the dynamics

--- a/examples/python_generation/python_generation.py
+++ b/examples/python_generation/python_generation.py
@@ -287,7 +287,7 @@ def sample_function_1(w: type_annotations.Vector3, v: type_annotations.Vector3):
 
 
 def sample_function_2(position: type_annotations.Vector2, velocity: type_annotations.Vector2,
-                      dt: type_annotations.RealScalar, params: SimParamsSymbolic):
+                      dt: type_annotations.FloatScalar, params: SimParamsSymbolic):
     """
     An example function used to test code generation. We integrate some simple 2D dynamics
     for a projectile subject to gravity and drag.

--- a/examples/rotation_error/rotation_error.py
+++ b/examples/rotation_error/rotation_error.py
@@ -7,14 +7,14 @@ averaging optimization.
 import argparse
 import typing as T
 
-from wrenfold.type_annotations import RealScalar, Vector4
+from wrenfold.type_annotations import FloatScalar, Vector4
 from wrenfold import code_generation
 from wrenfold.code_generation import OutputArg, CppGenerator
 
 from wrenfold.geometry import Quaternion
 
 
-def rotation_error(q0_xyzw: Vector4, q1_xyzw: Vector4, weight: RealScalar):
+def rotation_error(q0_xyzw: Vector4, q1_xyzw: Vector4, weight: FloatScalar):
     """
     Tangent-space difference between two scalar-last quaternions, scaled by
     a positive weight value.


### PR DESCRIPTION
Rename `RealScalar` to `FloatScalar` to better clarify that the generated type will be a floating-point value wherever this annotation is employed.