### PR TITLE
Fix bug preventing nesting of vectors/matrices in custom types

### DIFF
--- a/components/python/wrenfold/custom_types.py
+++ b/components/python/wrenfold/custom_types.py
@@ -100,7 +100,8 @@ def map_expressions_into_custom_type(expressions: T.List[sym.Expr],
             expressions = expressions[1:]
         elif issubclass(field.type, sym.MatrixExpr):
             # Expressions were packed in row-major order as expected by our matrix type.
-            mat = sym.matrix(expressions).reshape(_get_matrix_shape(field.type))
+            mat_rows, mat_cols = _get_matrix_shape(field.type)
+            mat = sym.matrix(expressions[:(mat_rows * mat_cols)]).reshape(mat_rows, mat_cols)
             constructor_kwargs[field.name] = mat
             expressions = expressions[mat.size:]
         elif dataclasses.is_dataclass(field.type):


### PR DESCRIPTION
There is a bug that prevents nesting a vector inside a custom type if it is _not_ the last element of the type. Specifically, the matrix would receive an invalid shape that did not match the expected # of expressions.

Previous tests did not address this case. This change fixes the issue, and adds a test to catch it in future.