### PR TITLE
Add inverse left Jacobian of SO(3) to geometry module

### DIFF
--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -197,10 +197,18 @@ quaternion operator*(const quaternion& a, const quaternion& b);
 // This is also the derivative of: log(exp(w + dw) * R^T) with respect to the additive
 // perturbation `dw`, evaluated about `dw = 0`.
 //
-// You can obtain the right jacobian of SO(3) by transposing this quantity.
+// You can obtain the right jacobian of SO(3) by transposing this matrix.
 //
 // When the norm of `w` falls below `epsilon`, the small angle approximation is used.
 matrix_expr left_jacobian_of_so3(const matrix_expr& w, const std::optional<scalar_expr>& epsilon);
+
+// Compute the _inverse_ of the left Jacobian of SO(3) as a function of a rodrigues vector `w`.
+// If `left_jacobian_of_so3` produces V(w), then `inverse_left_jacobian_of_so3` produces V^-1(w)
+// such that V^-1(w) * V(w) = I3.
+//
+// When the norm of `w` falls below epsilon, the small angle approximation is used.
+matrix_expr inverse_left_jacobian_of_so3(const matrix_expr& w,
+                                         const std::optional<scalar_expr>& epsilon);
 
 template <>
 struct hash_struct<quaternion> {

--- a/components/wrapper/pywrenfold/docs/geometry_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/geometry_wrapper.h
@@ -415,4 +415,34 @@ References:
   * `Associating Uncertainty With Three-Dimensional Poses for Use in Estimation Problems <https://ieeexplore.ieee.org/document/6727494>`_
 )doc";
 
+inline constexpr std::string_view inverse_left_jacobian_of_so3 = R"doc(
+Compute the **inverse** of the *left* jacobian of SO(3). Given a rotation vector ``w``, this method
+computes the 3x3 derivative:
+
+.. math::
+  \mathbf{J}_l^{-1} = \frac{
+    \partial \left(\text{log}\left(
+    \text{exp}\left(\delta\mathbf{x}\right) \cdot
+    \text{exp}\left(\mathbf{w}\right)\right)
+    - \mathbf{w}\right)
+  }
+  {\partial \delta\mathbf{x}} \biggr\rvert_{\delta\mathbf{x} = 0}
+
+Where ``exp(...)`` maps from a rotation vector to a quaternion, and ``log(...)`` maps from a
+quaternion to a rotation vector.
+
+Args:
+  w: 3x1 rotation vector, in radians.
+  epsilon: If provided, ``epsilon`` specifies the threshold below which a small-angle approximation
+    is used. A conditional will be inserted using :func:`wrenfold.sym.where` to switch between the
+    normal and small-angle code paths. This value should be positive.
+
+Returns:
+  The 3x3 inverse left jacobian of SO(3).
+
+References:
+  * `A micro Lie theory for state estimation in robotics <https://arxiv.org/abs/1812.01537>`_
+  * `Associating Uncertainty With Three-Dimensional Poses for Use in Estimation Problems <https://ieeexplore.ieee.org/document/6727494>`_
+)doc";
+
 }  // namespace  wf::docstrings

--- a/components/wrapper/pywrenfold/geometry_wrapper.cc
+++ b/components/wrapper/pywrenfold/geometry_wrapper.cc
@@ -169,5 +169,8 @@ void wrap_geometry_operations(py::module_& m) {
 
   m.def("left_jacobian_of_so3", &left_jacobian_of_so3, "w"_a, "epsilon"_a,
         docstrings::left_jacobian_of_so3.data());
+
+  m.def("inverse_left_jacobian_of_so3", &inverse_left_jacobian_of_so3, "w"_a, "epsilon"_a,
+        docstrings::inverse_left_jacobian_of_so3.data());
 }
 }  // namespace wf

--- a/docs/source/python_api/geometry.rst
+++ b/docs/source/python_api/geometry.rst
@@ -1,6 +1,8 @@
 geometry
 ========
 
+.. autofunction:: wrenfold.geometry.inverse_left_jacobian_of_so3
+
 .. autofunction:: wrenfold.geometry.left_jacobian_of_so3
 
 .. autoclass:: wrenfold.geometry.Quaternion

--- a/docs/source/python_api/sym.rst
+++ b/docs/source/python_api/sym.rst
@@ -87,6 +87,8 @@ sym
 
 .. autofunction:: wrenfold.sym.tanh
 
+.. autofunction:: wrenfold.sym.unevaluated
+
 .. autofunction:: wrenfold.sym.vec
 
 .. autofunction:: wrenfold.sym.vector

--- a/docs/source/python_api/type_annotations.rst
+++ b/docs/source/python_api/type_annotations.rst
@@ -1,12 +1,57 @@
 type_annotations
 ================
 
-.. autoclass:: wrenfold.type_annotations.Opaque
+.. autoclass:: wrenfold.type_annotations.FloatScalar
   :members:
   :special-members:
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
 
-.. autoclass:: wrenfold.type_annotations.FloatScalar
+.. autoclass:: wrenfold.type_annotations.Matrix1
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix2
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix3
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix4
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix5
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix6
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix7
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix8
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Matrix9
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Opaque
   :members:
   :special-members:
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
@@ -37,6 +82,21 @@ type_annotations
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
 
 .. autoclass:: wrenfold.type_annotations.Vector6
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Vector7
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Vector8
+  :members:
+  :special-members:
+  :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__
+
+.. autoclass:: wrenfold.type_annotations.Vector9
   :members:
   :special-members:
   :exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__


### PR DESCRIPTION
As the title describes, this change implements the _inverse_ of the left Jacobian of SO(3) analytically, and adds it to the geometry module.

Tests and documentation are also added.