### PR TITLE
Fix bug in to_rotation_vector, add more test coverage

### DIFF
--- a/components/core/wf/geometry/quaternion.h
+++ b/components/core/wf/geometry/quaternion.h
@@ -87,6 +87,9 @@ class quaternion {
   // Invert the quaternion by conjugating and dividing by squared norm.
   [[nodiscard]] quaternion inverse() const;
 
+  // Negate every element of the quaternion.
+  quaternion operator-() const;
+
   // Convert a unit-norm to a rotation matrix. If the input does not have unit norm, the
   // result will not be a valid member of SO(3).
   matrix_expr to_rotation_matrix() const;

--- a/components/wrapper/pywrenfold/docs/geometry_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/geometry_wrapper.h
@@ -302,7 +302,8 @@ Recover a rotation vector from a unit-norm quaternion. The following formula is 
 
 .. math::
   \mathbf{v} = \frac{2}{\lvert \mathbf{q}_v \rvert}
-  \cdot \text{atan2}\left(\lvert \mathbf{q}_v \rvert, q_w\right)
+  \cdot \text{atan2}\left(\lvert \mathbf{q}_v \rvert, \text{abs}\left(q_w\right)\right)
+  \cdot \text{sign}\left(q_w\right)
   \cdot \mathbf{q}_v
 
 Where :math:`\mathbf{q}_v` is the vector component of the quaternion.

--- a/examples/quaternion_interpolation/quat_interpolation_expressions.h
+++ b/examples/quaternion_interpolation/quat_interpolation_expressions.h
@@ -17,7 +17,7 @@ inline auto quaternion_interpolation(const ta::static_matrix<4, 1>& q0_vec,
                                      const std::optional<scalar_expr>& epsilon) {
   const quaternion q0 = quaternion::from_vector_xyzw(q0_vec);
   const quaternion q1 = quaternion::from_vector_xyzw(q1_vec);
-  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon);
+  const matrix_expr q_delta_tangent = (q0.conjugate() * q1).to_rotation_vector(epsilon, true);
   const quaternion q_interp =
       q0 * quaternion::from_rotation_vector(q_delta_tangent * alpha, epsilon);
 

--- a/examples/quaternion_interpolation/quat_interpolation_test.cc
+++ b/examples/quaternion_interpolation/quat_interpolation_test.cc
@@ -6,6 +6,10 @@
 #include "wf_test_support/numerical_jacobian.h"
 #include "wf_test_support/test_macros.h"
 
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ostream.h>
+WF_END_THIRD_PARTY_INCLUDES
+
 #include "quat_interpolation_expressions.h"
 
 #define WF_SPAN_EIGEN_SUPPORT
@@ -37,82 +41,141 @@ auto quat_interpolation_no_conditional(ta::static_matrix<4, 1> q0_vec,
   return quaternion_interpolation(q0_vec, q1_vec, alpha, std::nullopt);
 }
 
+// Forward declare, defined below.
+const std::vector<Eigen::Quaterniond>& get_test_quats();
+
 // Test the quaternion interpolation result numerically.
 TEST(QuaternionInterpolationTest, TestQuatInterpolation) {
   auto evaluator = create_evaluator(&quat_interpolation);
 
-  const Quaterniond q0 = Quaterniond{AngleAxisd(M_PI / 3, Vector3d::UnitX())} *
-                         Quaterniond{AngleAxisd(M_PI / 6, Vector3d::UnitZ())};
-  const Quaterniond q1{AngleAxisd(-M_PI / 4, Vector3d::UnitY())};
+  for (const auto& q0 : get_test_quats()) {
+    for (const auto& q1 : get_test_quats()) {
+      for (const double alpha : {0.0, 0.001, 0.5, 0.999, 1.0}) {
+        Quaterniond q_eval{};
+        Matrix3d D0_eval, D1_eval;
+        evaluator(q0.coeffs(), q1.coeffs(), alpha, q_eval.coeffs(), D0_eval, D1_eval);
 
-  Quaterniond q_eval{};
-  Matrix3d D0_eval, D1_eval;
-  evaluator(q0.coeffs(), q1.coeffs(), 0.25, q_eval.coeffs(), D0_eval, D1_eval);
+        Quaterniond q_gen{};
+        Matrix3d D0_gen{}, D1_gen{};
+        gen::quaternion_interpolation(q0, q1, alpha, q_gen, D0_gen, D1_gen);
 
-  Quaterniond q_gen{};
-  Matrix3d D0_gen{}, D1_gen{};
-  gen::quaternion_interpolation(q0, q1, 0.25, q_gen, D0_gen, D1_gen);
+        ASSERT_EIGEN_NEAR(q_eval.coeffs(), q_gen.coeffs(), 2.0e-15) << fmt::format(
+            "q0 = [{}], q1 = [{}], alpha = {}", fmt::streamed(q0), fmt::streamed(q1), alpha);
+        ASSERT_EIGEN_NEAR(D0_eval, D0_gen, 5.0e-15) << fmt::format(
+            "q0 = [{}], q1 = [{}], alpha = {}", fmt::streamed(q0), fmt::streamed(q1), alpha);
+        ASSERT_EIGEN_NEAR(D1_eval, D1_gen, 5.0e-15) << fmt::format(
+            "q0 = [{}], q1 = [{}], alpha = {}", fmt::streamed(q0), fmt::streamed(q1), alpha);
 
-  EXPECT_EIGEN_NEAR(q_eval.coeffs(), q_gen.coeffs(), 2.0e-16);
-  EXPECT_EIGEN_NEAR(D0_eval, D0_gen, 5.0e-16);
-  EXPECT_EIGEN_NEAR(D1_eval, D1_gen, 5.0e-16);
+        // compare to interpolation with eigen
+        ASSERT_EIGEN_NEAR(quat_interp(q0, q1, alpha).coeffs(), q_gen.coeffs(), 2.0e-15)
+            << fmt::format("q0 = [{}], q1 = [{}], alpha = {}", fmt::streamed(q0), fmt::streamed(q1),
+                           alpha);
 
-  // compare to interpolation with eigen
-  EXPECT_EIGEN_NEAR(quat_interp(q0, q1, 0.25).coeffs(), q_gen.coeffs(), 2.0e-16);
+        const Eigen::AngleAxisd foo{q0.conjugate() * q1};
 
-  // compute derivatives numerically
-  const Matrix3d D0_num = numerical_jacobian(Vector3d::Zero(), [&](const Vector3d& w) {
-    return manifold<Quaterniond>::local_coordinates(
-        quat_interp(q0, q1, 0.25), quat_interp(manifold<Quaterniond>::retract(q0, w), q1, 0.25));
-  });
-  const Matrix3d D1_num = numerical_jacobian(Vector3d::Zero(), [&](const Vector3d& w) {
-    return manifold<Quaterniond>::local_coordinates(
-        quat_interp(q0, q1, 0.25), quat_interp(q0, manifold<Quaterniond>::retract(q1, w), 0.25));
-  });
+        // compute derivatives numerically
+        const Matrix3d D0_num = numerical_jacobian(
+            Vector3d::Zero(),
+            [&](const Vector3d& w) {
+              return manifold<Quaterniond>::local_coordinates(
+                  quat_interp(q0, q1, alpha),
+                  quat_interp(manifold<Quaterniond>::retract(q0, w), q1, alpha));
+            },
+            1.0e-5);
+        const Matrix3d D1_num = numerical_jacobian(
+            Vector3d::Zero(),
+            [&](const Vector3d& w) {
+              return manifold<Quaterniond>::local_coordinates(
+                  quat_interp(q0, q1, alpha),
+                  quat_interp(q0, manifold<Quaterniond>::retract(q1, w), alpha));
+            },
+            1.0e-5);
 
-  EXPECT_EIGEN_NEAR(D0_num, D0_gen, 1.0e-12);
-  EXPECT_EIGEN_NEAR(D1_num, D1_gen, 1.0e-12);
+        ASSERT_EIGEN_NEAR(D0_num, D0_gen, 1.0e-6) << fmt::format(
+            "q0 = [{}], q1 = [{}], alpha = {}, blah = {}", fmt::streamed(q0), fmt::streamed(q1),
+            alpha, fmt::streamed((foo.axis() * foo.angle() * alpha).eval().transpose()));
+        ASSERT_EIGEN_NEAR(D1_num, D1_gen, 1.0e-6) << fmt::format(
+            "q0 = [{}], q1 = [{}], alpha = {}", fmt::streamed(q0), fmt::streamed(q1), alpha);
+      }
+    }
+  }
 }
 
 // Test the version with no conditionals.
 TEST(QuaternionInterpolationTest, TestQuatInterpolationNoConditional) {
   auto evaluator = create_evaluator(&quat_interpolation_no_conditional);
 
-  const Quaterniond q0 = Quaterniond{AngleAxisd(M_PI / 8, Vector3d::UnitX())} *
-                         Quaterniond{AngleAxisd(-M_PI / 6, Vector3d::UnitY())};
-  const Quaterniond q1{AngleAxisd(-M_PI / 3, Vector3d::UnitZ())};
+  for (const auto& q0 : get_test_quats()) {
+    for (const auto& q1 : get_test_quats()) {
+      if ((q0.coeffs() - q1.coeffs()).cwiseAbs().array().maxCoeff() < 1.0e-16) {
+        // No conditional version cannot handle this case.
+        continue;
+      }
+      for (const double alpha : {0.001, 0.5, 0.999}) {
+        Quaterniond q_eval{};
+        Matrix3d D0_eval, D1_eval;
+        evaluator(q0.coeffs(), q1.coeffs(), alpha, q_eval.coeffs(), D0_eval, D1_eval);
 
-  for (const double alpha : {0.01, 0.1, 0.25, 0.5, 0.82, 0.99}) {
-    Quaterniond q_eval{};
-    Matrix3d D0_eval, D1_eval;
-    evaluator(q0.coeffs(), q1.coeffs(), alpha, q_eval.coeffs(), D0_eval, D1_eval);
+        Quaterniond q_gen{};
+        Matrix3d D0_gen{}, D1_gen{};
+        gen::quaternion_interpolation_no_conditional(q0, q1, alpha, q_gen, D0_gen, D1_gen);
 
-    Quaterniond q_gen{};
-    Matrix3d D0_gen{}, D1_gen{};
-    gen::quaternion_interpolation_no_conditional(q0, q1, alpha, q_gen, D0_gen, D1_gen);
+        ASSERT_EIGEN_NEAR(q_eval.coeffs(), q_gen.coeffs(), 1.0e-15);
+        ASSERT_EIGEN_NEAR(D0_eval, D0_gen, 1.0e-14);
+        ASSERT_EIGEN_NEAR(D1_eval, D1_gen, 1.0e-14);
 
-    EXPECT_EIGEN_NEAR(q_eval.coeffs(), q_gen.coeffs(), 2.0e-16);
-    EXPECT_EIGEN_NEAR(D0_eval, D0_gen, 5.0e-16);
-    EXPECT_EIGEN_NEAR(D1_eval, D1_gen, 5.0e-16);
+        // compare to interpolation with eigen
+        ASSERT_EIGEN_NEAR(quat_interp(q0, q1, alpha).coeffs(), q_gen.coeffs(), 1.0e-15);
 
-    // compare to interpolation with eigen
-    EXPECT_EIGEN_NEAR(quat_interp(q0, q1, alpha).coeffs(), q_gen.coeffs(), 2.0e-16);
+        // compute derivatives numerically
+        const Matrix3d D0_num = numerical_jacobian(
+            Vector3d::Zero(),
+            [&](const Vector3d& w) {
+              return manifold<Quaterniond>::local_coordinates(
+                  quat_interp(q0, q1, alpha),
+                  quat_interp(manifold<Quaterniond>::retract(q0, w), q1, alpha));
+            },
+            1.0e-5);
+        const Matrix3d D1_num = numerical_jacobian(
+            Vector3d::Zero(),
+            [&](const Vector3d& w) {
+              return manifold<Quaterniond>::local_coordinates(
+                  quat_interp(q0, q1, alpha),
+                  quat_interp(q0, manifold<Quaterniond>::retract(q1, w), alpha));
+            },
+            1.0e-5);
 
-    // compute derivatives numerically
-    const Matrix3d D0_num = numerical_jacobian(Vector3d::Zero(), [&](const Vector3d& w) {
-      return manifold<Quaterniond>::local_coordinates(
-          quat_interp(q0, q1, alpha),
-          quat_interp(manifold<Quaterniond>::retract(q0, w), q1, alpha));
-    });
-    const Matrix3d D1_num = numerical_jacobian(Vector3d::Zero(), [&](const Vector3d& w) {
-      return manifold<Quaterniond>::local_coordinates(
-          quat_interp(q0, q1, alpha),
-          quat_interp(q0, manifold<Quaterniond>::retract(q1, w), alpha));
-    });
-
-    EXPECT_EIGEN_NEAR(D0_num, D0_gen, 1.0e-12);
-    EXPECT_EIGEN_NEAR(D1_num, D1_gen, 1.0e-12);
+        ASSERT_EIGEN_NEAR(D0_num, D0_gen, 1.0e-6);
+        ASSERT_EIGEN_NEAR(D1_num, D1_gen, 1.0e-6);
+      }
+    }
   }
+}
+
+// Approximately uniformly distributed quaternions to test with:
+const std::vector<Eigen::Quaterniond>& get_test_quats() {
+  static const std::vector<Eigen::Quaterniond> qs = {
+      {-0.57298648, -0.08750189, 0.06677656, 0.81213965},
+      {-0.2370452, 0.14964947, -0.05382689, -0.95839307},
+      {-0.05667896, 0.9098583, -0.40514895, 0.06927982},
+      {0.36729586, -0.83911827, 0.04949433, 0.39815147},
+      {0.80939134, 0.49074925, -0.18582131, 0.26366886},
+      {0.07408736, -0.52878892, -0.75088736, -0.38866633},
+      {-0.96280537, -0.11736205, 0.11123707, 0.21646773},
+      {-0.30721295, -0.56297515, 0.75847701, -0.115723},
+      {0.10692899, -0.23943148, -0.36935472, -0.89152445},
+      {-0.05170143, -0.99148252, -0.09745459, -0.06922411},
+      {0.02992758, 0.16170645, -0.98260312, -0.08629296},
+      {0.13617515, -0.04442757, -0.40290028, -0.90396564},
+      {0.57572434, -0.0157669, -0.31692404, -0.75355958},
+      {0.19109932, 0.50931141, 0.53628868, 0.64535059},
+      {0.89106998, -0.41739639, 0.17515614, 0.0330888},
+      {-0.45677614, 0.14769249, -0.0698937, 0.87444689},
+      {0.24841122, -0.31902749, -0.73918904, -0.53862129},
+      {-0.21849917, 0.83212554, 0.42977397, 0.27407942},
+      {-0.49591105, 0.75591709, -0.26506932, -0.33526084},
+      {-0.54581159, 0.12241662, -0.58730306, -0.58496068}};
+  return qs;
 }
 
 }  // namespace wf


### PR DESCRIPTION
There was an issue where the atan2 method of `to_rotation_vector` incorrectly handled things when `q.w` was negative. This change explicitly takes the absolute value of `q.w`, and handles the sign explicitly in the resulting vector.

I also added more test coverage to the quaternion type to prevent this from regressing.