### PR TITLE
Add parameter to `CppCodeGenerator.apply_preamble` to specify imports

### DIFF
--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -5,6 +5,7 @@
 
 #include "wf/code_generation/ast_formatters.h"
 #include "wf/code_generation/ast_visitor.h"
+#include "wf/utility/assertions.h"
 #include "wf/utility/index_range.h"
 #include "wf/utility/overloaded_visit.h"
 
@@ -366,6 +367,7 @@ inline constexpr std::string_view preamble = R"code(// Machine generated code.
 
 #include <wrenfold/span.h>
 
+{imports}
 namespace {namespace} {{
 
 {code}
@@ -373,10 +375,15 @@ namespace {namespace} {{
 }} // namespace {namespace})code";
 
 std::string cpp_code_generator::apply_preamble(const std::string_view code,
-                                               const std::string_view ns) {
+                                               const std::string_view ns,
+                                               const std::string_view imports) {
   WF_ASSERT(code.data());
   WF_ASSERT(ns.data());
-  return fmt::format(preamble, fmt::arg("code", code), fmt::arg("namespace", ns));
+  WF_ASSERT(imports.data());
+  const std::string imports_formatted =
+      imports.size() > 0 ? fmt::format("// User-specified imports:\n{}\n\n", imports) : "";
+  return fmt::format(preamble, fmt::arg("code", code), fmt::arg("namespace", ns),
+                     fmt::arg("imports", imports_formatted));
 }
 
 }  // namespace wf

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 Gareth Cross
 // For license information refer to accompanying LICENSE file.
 #pragma once
+#include <string_view>
 #include "wf/code_generation/ast.h"
 #include "wf/utility/strings.h"
 
@@ -81,7 +82,8 @@ class cpp_code_generator {
   std::string operator()(const ast::ast_element& element) const;
 
   // Wrap generated function code in a preamble with includes and a namespace.
-  static std::string apply_preamble(std::string_view code, std::string_view ns);
+  static std::string apply_preamble(std::string_view code, std::string_view ns,
+                                    std::string_view imports = "");
 
  protected:
   // Create a fmt_view. All args will be forwarded back to the operator on this class that matches

--- a/components/wrapper/pywrenfold/code_formatting_wrapper.cc
+++ b/components/wrapper/pywrenfold/code_formatting_wrapper.cc
@@ -343,7 +343,7 @@ static auto wrap_code_generator(py::module_& m, const std::string_view name) {
 void wrap_code_formatting_operations(py::module_& m) {
   wrap_code_generator<cpp_code_generator>(m, "CppGenerator")
       .def_static("apply_preamble", &cpp_code_generator::apply_preamble, py::arg("code"),
-                  py::arg("namespace"),
+                  py::arg("namespace"), py::arg("imports") = py::str(),
                   "Apply a preamble that incorporates necessary runtime includes.")
       .doc() = "Generate C++ code.";
 

--- a/docs/source/tutorial/integrating_code.rst
+++ b/docs/source/tutorial/integrating_code.rst
@@ -136,7 +136,7 @@ Generated C++ functions depend directly on:
     depends on ``<tuple>`` and ``<type_traits>``.
 
 You can add these includes to your output code manually, or use the provided convenience function:
-:func:`wrenfold.code_generation.apply_cpp_preamble`.
+:func:`wrenfold.code_generation.CppGenerator.apply_preamble`.
 
 Rust
 ----


### PR DESCRIPTION
Add an `imports` parameter to the C++ generator to allow specification of third-party includes in the preamble code.