### PR TITLE
Substitute visitor uses caching

### DIFF
--- a/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
@@ -42,11 +42,12 @@ void wrap_boolean_expression(py::module_& m) {
       .def_property_readonly(
           "args", [](const boolean_expr& self) { return args_visitor{}(self); },
           "Arguments of ``self`` as a tuple.")
-      .def("subs", &substitute_wrapper_single<boolean_expr, scalar_expr>,
+      .def("subs", &substitute_wrapper_single<boolean_expr, scalar_expr>, py::arg("target"),
+           py::arg("substitute"), "See :func:`wrenfold.sym.Expr.subs`")
+      .def("subs", &substitute_wrapper_single<boolean_expr, boolean_expr>, py::arg("target"),
+           py::arg("substitute"), "See :func:`wrenfold.sym.Expr.subs`")
+      .def("subs", &substitute_wrapper<boolean_expr>, py::arg("pairs"),
            "See :func:`wrenfold.sym.Expr.subs`")
-      .def("subs", &substitute_wrapper_single<boolean_expr, boolean_expr>,
-           "See :func:`wrenfold.sym.Expr.subs`")
-      .def("subs", &substitute_wrapper<boolean_expr>)
       .def("__bool__", &coerce_to_bool, py::doc("Coerce expression to boolean."))
       .doc() = "A boolean-valued symbolic expression.";
 

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -361,7 +361,7 @@ void wrap_matrix_operations(py::module_& m) {
       .def("subs", &substitute_wrapper_single<matrix_expr, boolean_expr>, py::arg("target"),
            py::arg("substitute"),
            "Overload of ``subs`` that performs a single boolean-valued substitution.")
-      .def("subs", &substitute_wrapper<matrix_expr>,
+      .def("subs", &substitute_wrapper<matrix_expr>, py::arg("pairs"),
            "Invoke :func:`wrenfold.sym.Expr.subs` on every element of the matrix.")
       .def(
           "eval",

--- a/components/wrapper/pywrenfold/scalar_wrapper.cc
+++ b/components/wrapper/pywrenfold/scalar_wrapper.cc
@@ -17,7 +17,6 @@
 #include "wf/expression.h"
 #include "wf/expressions/addition.h"
 #include "wf/expressions/multiplication.h"
-#include "wf/expressions/special_constants.h"
 #include "wf/expressions/variable.h"
 #include "wf/functions.h"
 #include "wf/numerical_casts.h"


### PR DESCRIPTION
Add expression caching to the ordinary (non fast-path) substitute visitor. This dramatically speeds up substitutions on complex expression trees.

Also added some missing argument annotations to the wrapper for `subs` as well.

