### PR TITLE
Add `unique_symbols` method to the python wrapper

### DIFF
--- a/components/wrapper/pywrenfold/docs/scalar_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/scalar_wrapper.h
@@ -221,6 +221,22 @@ Caution:
   ``sym.symbols('x:5')`` will not produce the expected result.
 )doc";
 
+inline constexpr std::string_view unique_symbols = R"doc(
+Create instances of ``variable`` expressions with unique identities that can never be accidentally
+re-used. This is useful if you need temporary variables that will later be replaced by substitution,
+and want to be certain that their names do not conflict with other symbols.
+
+Args:
+  count: Number of symbols to create. If one, a single expression is returned. If greater than one,
+    a list of expressions is returned.
+
+Examples:
+  >>> sym.unique_symbols(count=2)
+  [$u_1, $u_2]
+  >>> sym.unique_symbols(count=1)
+  $u_3
+)doc";
+
 inline constexpr std::string_view integer = R"doc(
 Create a constant expression from an integer.
 

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -43,6 +43,15 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertRaises(exceptions.InvalidArgumentError,
                           lambda: sym.symbols("z", real=True, complex=True))
 
+    def test_create_unique_symbols(self):
+        """Test calling unique_symbols."""
+        a = sym.unique_symbols(count=1)
+        b, c = sym.unique_symbols(count=2)
+        self.assertNotIdentical(a, b)
+        self.assertNotIdentical(b, c)
+        self.assertEqual('Variable', a.type_name)
+        self.assertEqual((), a.args)
+
     def test_is_identical_to(self):
         """Test calling is_identical_to and __eq__."""
         x, y = sym.symbols("x, y")

--- a/docs/source/python_api/sym.rst
+++ b/docs/source/python_api/sym.rst
@@ -89,6 +89,8 @@ sym
 
 .. autofunction:: wrenfold.sym.unevaluated
 
+.. autofunction:: wrenfold.sym.unique_symbols
+
 .. autofunction:: wrenfold.sym.vec
 
 .. autofunction:: wrenfold.sym.vector


### PR DESCRIPTION
- Add a wrapper for `make_unique_variable_symbol`.
- Add basic test that it can be invoked.