### PR TITLE
Remove unused traits from the rust traits crate

### DIFF
--- a/components/rust/wrenfold-traits/src/traits.rs
+++ b/components/rust/wrenfold-traits/src/traits.rs
@@ -6,24 +6,6 @@
 #[cfg(feature = "nalgebra")]
 use nalgebra as na;
 
-/// A one-dimensional immutable input span with length `D0`.
-pub trait Span1D<const D0: usize> {
-    /// The spanned scalar type.
-    type ValueType;
-
-    /// Access element `i`
-    fn get(&self, i: usize) -> Self::ValueType;
-}
-
-/// A one-dimensional mutable output span with length `D0`.
-pub trait OutputSpan1D<const D0: usize> {
-    /// The spanned scalar type.
-    type ValueType;
-
-    /// Set element `i` to `val`.
-    fn set(&mut self, i: usize, val: Self::ValueType);
-}
-
 /// A two-dimensional immutable input span with shape `(D0, D1)`.
 pub trait Span2D<const D0: usize, const D1: usize> {
     /// The spanned scalar type.
@@ -40,36 +22,6 @@ pub trait OutputSpan2D<const D0: usize, const D1: usize> {
 
     /// Set element `(i, j)` to `val`.
     fn set(&mut self, i: usize, j: usize, val: Self::ValueType);
-}
-
-/// Implementation of `Span1D` for nalgebra column vectors.
-#[cfg(feature = "nalgebra")]
-impl<T, S, const D0: usize> Span1D<D0> for na::Matrix<T, na::Const<D0>, na::Const<1>, S>
-where
-    T: na::Scalar + Copy,
-    S: na::RawStorage<T, na::Const<D0>, na::Const<1>>,
-{
-    type ValueType = T;
-
-    #[inline(always)]
-    fn get(&self, i: usize) -> Self::ValueType {
-        self[i]
-    }
-}
-
-/// Implementation of `OutputSpan1D` for nalgebra column vectors.
-#[cfg(feature = "nalgebra")]
-impl<T, S, const D0: usize> OutputSpan1D<D0> for na::Matrix<T, na::Const<D0>, na::Const<1>, S>
-where
-    T: na::Scalar + Copy,
-    S: na::RawStorageMut<T, na::Const<D0>, na::Const<1>>,
-{
-    type ValueType = T;
-
-    #[inline(always)]
-    fn set(&mut self, i: usize, val: Self::ValueType) {
-        self[i] = val;
-    }
 }
 
 /// Implementation of `Span2D` for statically size nalgebra matrices.


### PR DESCRIPTION
`Span1D` and `OutputSpan1D` are never used in output code. They can be added back later if necessary - this change cleans things up for now.