### PR TITLE
build-wheels creates archive of all wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Copy wheels
         run: rsync -av downloaded_artifacts/*.whl wheels/
 
+      - name: Create wheel archive
+        run: tar -czvf wrenfold-wheels.tar.gz wheels/
+
       - name: "Build Changelog"
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
@@ -101,6 +104,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: wheels/*.whl
+          files: |
+            wheels/*.whl
+            wrenfold-wheels.tar.gz
           draft: true
           body: ${{steps.build_changelog.outputs.changelog}}


### PR DESCRIPTION
The `build-wheels` job creates a tar archive of all the wheels for different platforms, and includes it in the release.