### PR TITLE
Fix CI runner build parallelism specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,26 @@ jobs:
         run: |
           cmake ${{github.workspace}} -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -Wno-deprecated -G Ninja
 
-      - name: Build
+      - if: runner.os == 'Windows'
+        name: Build (Windows)
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
         run: |
-          cmake --build . --config ${{matrix.build_type}}
+          $threads = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads
+
+      - if: runner.os == 'macOS'
+        name: Build (OSX)
+        working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
+        run: |
+          threads=`sysctl -n hw.logicalcpu`
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads
+
+      - if: runner.os == 'Linux'
+        name: Build (Linux)
+        working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
+        run: |
+          threads=`nproc`
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads
 
       - name: Run CTest
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}


### PR DESCRIPTION
I noticed that some combination of switching:
- `cmake 3.29.2 --> 3.29.6`
- `ninja 1.12.0 --> ninja 1.12.1`

Appears to have stopped `cmake --build` from using all cores by default. At least on my Ubuntu 22.04 test machine it falls back to a single core, unless `-j` or `--parallel` is specified.

To prevent this from affecting the CI runners, I updated the workflow to query the number of cores and pass it to `cmake --build`.