### PR TITLE
Add rust example to custom types docs, show how to customize constructor

### DIFF
--- a/docs/source/tutorial/custom_types.rst
+++ b/docs/source/tutorial/custom_types.rst
@@ -6,7 +6,7 @@ arguments and return values. This can unlock some useful functionality:
 
   * Leverage existing group or manifold types in your codebase. For example, if your optimization is
     implemented in `GTSAM <https://gtsam.org>`_ you might wish to pass ``gtsam::Pose3`` directly to
-    and from a generated function.
+    and from generated functions.
   * Pass parameter structs directly to a generated function without breaking them into scalar/vector
     pieces.
 
@@ -114,6 +114,38 @@ custom generator:
 
 Voila - our generated methods uses ``geo::vec2`` for input arguments, output arguments, and the
 return value.
+
+Emitting a custom constructor call
+----------------------------------
+
+Suppose we want to generate this method in Rust as well, and invoke a *custom constructor*
+``geo::Vec2::new(...)``. To override the construction logic, we implement
+``format_construct_custom_type``:
+
+.. literalinclude:: custom_types_script.py
+    :language: python
+    :start-after: rust_code_generator_start
+    :end-before: rust_code_generator_end
+
+The generated code now looks like:
+
+.. code:: rust
+
+  #[inline]
+  #[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if,
+          clippy::needless_late_init, unused_variables)]
+  pub fn rotate_vector<>(angle: f64, v: &geo::Vec2, v_rot_D_angle: &mut geo::Vec2) -> geo::Vec2
+  {
+    let v001: f64 = angle;
+    let v004: f64 = v.y();
+    let v002: f64 = (v001).sin();
+    let v008: f64 = v.x();
+    let v007: f64 = (v001).cos();
+    let v013: f64 = v004 * v007 + v002 * v008;
+    let v010: f64 = v007 * v008 + -(v002 * v004);
+    *v_rot_D_angle = geo::Vec2::new(-v013, v010);
+    geo::Vec2::new(v010, v013)
+  }
 
 .. note::
 

--- a/docs/source/tutorial/custom_types_script.py
+++ b/docs/source/tutorial/custom_types_script.py
@@ -66,6 +66,31 @@ class CustomCppGenerator(code_generation.CppGenerator):
         # [code_generator_end]
 
 
+# [rust_code_generator_start]
+class CustomRustGenerator(code_generation.RustGenerator):
+
+    def format_get_field(self, element: ast.GetField) -> str:
+        if element.struct_type.python_type == Vec2:
+            return f"{self.format(element.arg)}.{element.field_name}()"
+        return self.super_format(element)
+
+    def format_custom_type(self, element: type_info.CustomType) -> str:
+        """
+        Place our custom type into the `geo` crate.
+        """
+        if element.python_type == Vec2:
+            return 'geo::Vec2'
+        return self.super_format(element)
+
+    def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
+        if element.type.python_type == Vec2:
+            x = self.format(element.get_field_value('x'))
+            y = self.format(element.get_field_value('y'))
+            return f"geo::Vec2::new({x}, {y})"
+        return self.super_format(element)
+        # [rust_code_generator_end]
+
+
 # [transpilation_start]
 code = code_generation.generate_function(func=rotate_vector, generator=CustomCppGenerator())
 print(code)


### PR DESCRIPTION
At suggestion of @anuragmakineni, I added an example of customizing _rust_ code generation as well to the `Interfacing with existing types`.