### PR TITLE
Fix assignment to non-optional custom type output arguments in rust

### DIFF
--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -384,6 +384,13 @@ TEST(CppGenerationTest, TestCustomType2) {
   EXPECT_EIGEN_NEAR(D_num, D_gen, 1.0e-15);
 }
 
+TEST(CppGenerationTest, TestCustomType3) {
+  numeric::Point2d p{};
+  gen::custom_type_3<double>(p);
+  EXPECT_EQ(M_PI * 0.5, p.x);
+  EXPECT_EQ(M_E * 3.0, p.y);
+}
+
 // Convert to/from symbolic::Circle --> numeric::Circle.
 template <>
 struct custom_type_native_converter<symbolic::Circle> {

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -777,6 +777,17 @@ where
 
 #[inline]
 #[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+pub fn custom_type_3<>(out: &mut crate::types::Point2d) -> ()
+{
+  // Operation counts:
+  // multiply: 2
+  // total: 2
+  
+  *out = crate::types::Point2d::new(0.5f64 * std::f64::consts::PI, std::f64::consts::E * (3i64) as f64);
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
 pub fn nested_custom_type_1<>(c: &crate::types::Circle, p: &crate::types::Point2d) -> crate::types::Circle
 {
   // Operation counts:

--- a/components/core/tests/rust_generation_test/src/lib.rs
+++ b/components/core/tests/rust_generation_test/src/lib.rs
@@ -311,6 +311,14 @@ fn test_custom_type_2() {
 }
 
 #[test]
+fn test_custom_type_3() {
+    let mut p = types::Point2d::new(0.0, 0.0);
+    generated::custom_type_3(&mut p);
+    approx::assert_abs_diff_eq!(std::f64::consts::PI * 0.5f64, p.x());
+    approx::assert_abs_diff_eq!(std::f64::consts::E * 3.0f64, p.y());
+}
+
+#[test]
 fn test_nested_custom_type_1() {
     let c1 = types::Circle {
         center: types::Point2d::new(-0.25, 0.5),

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -162,6 +162,12 @@ inline auto custom_type_2(scalar_expr theta, scalar_expr radius) {
   return std::make_tuple(optional_output_arg("out", p), optional_output_arg("D_inputs", D_inputs));
 }
 
+// Check that we can assign to a non-optional custom-type output argument.
+inline auto custom_type_3() {
+  symbolic::Point2d p{constants::pi / 2, constants::euler * 3};
+  return std::make_tuple(output_arg("out", p));
+}
+
 // Construct a nested custom type.
 inline auto nested_custom_type_1(symbolic::Circle a, symbolic::Point2d b) {
   // Expand circle `a` if required to fit point `b`.

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -36,6 +36,7 @@ std::string generate_test_expressions(Generator gen) {
   generate_func(gen, code, &no_required_outputs, "no_required_outputs", arg("x"));
   generate_func(gen, code, &custom_type_1, "custom_type_1", arg("p"));
   generate_func(gen, code, &custom_type_2, "custom_type_2", arg("theta"), arg("radius"));
+  generate_func(gen, code, &custom_type_3, "custom_type_3");
   generate_func(gen, code, &nested_custom_type_1, "nested_custom_type_1", arg("c"), arg("p"));
   generate_func(gen, code, &external_function_call_1, "external_function_call_1", arg("x"),
                 arg("y"));

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -159,11 +159,7 @@ std::string rust_code_generator::operator()(const ast::assign_output_scalar& x) 
 }
 
 std::string rust_code_generator::operator()(const ast::assign_output_struct& x) const {
-  if (x.arg.is_optional()) {
-    return fmt::format("*{} = {};", x.arg.name(), make_view(x.value));
-  } else {
-    return fmt::format("{} = {};", x.arg.name(), make_view(x.value));
-  }
+  return fmt::format("*{} = {};", x.arg.name(), make_view(x.value));
 }
 
 std::string rust_code_generator::operator()(const ast::assign_temporary& x) const {


### PR DESCRIPTION
While adding an example for PR https://github.com/wrenfold/wrenfold/pull/227 I realized that the output generation for non-optional custom-type output arguments was broken in Rust.

The code was correct for optional arguments, but not non-optional ones (a test case was missing as well). This change implements a fix, and adds missing test coverage for this case (for both C++ and Rust).