### PR TITLE
Disable broken full-piv LU code path

### DIFF
--- a/components/core/tests/matrix_operations_test.cc
+++ b/components/core/tests/matrix_operations_test.cc
@@ -388,20 +388,24 @@ TEST(MatrixOperationsTest, TestFactorizeLU2) {
     check_full_piv_lu_solution(A, factorize_full_piv_lu(A));
   }
 
+#if 0
   for (const auto& [col, row] : dims) {
     // Transposed version:
     matrix_expr A = make_matrix_of_symbols("x", row, col);
     check_full_piv_lu_solution(A, factorize_full_piv_lu(A));
   }
+#endif
 
   matrix_expr Z24 = make_zeros(2, 4);
   check_full_piv_lu_solution(Z24, factorize_full_piv_lu(Z24));
 
+#if 0
   matrix_expr Z42 = make_zeros(4, 2);
   check_full_piv_lu_solution(Z42, factorize_full_piv_lu(Z42));
 
   matrix_expr Z53 = make_zeros(5, 3);
   check_full_piv_lu_solution(Z53, factorize_full_piv_lu(Z53));
+#endif
 }
 
 TEST(MatrixOperationsTest, TestFactorizeLU3) {
@@ -412,7 +416,7 @@ TEST(MatrixOperationsTest, TestFactorizeLU3) {
   A = make_matrix(4, 4, 0, 0, 0, 0, 0, "y", 0, 0, 0, 0, 0, 0, 0, 0, 0, -5);
   check_full_piv_lu_solution(A, factorize_full_piv_lu(A));
 
-  A = make_matrix(5, 3, 0, 0, 0, 0, "z", 0, 0, 0, 0, 0, 0, 0, 0, 0, 8);
+  A = make_matrix(3, 5, 0, 0, 0, 0, "z", 0, 0, 0, 0, 0, 0, 0, 0, 0, 8);
   check_full_piv_lu_solution(A, factorize_full_piv_lu(A));
 }
 
@@ -421,11 +425,11 @@ TEST(MatrixOperationsTest, TestFactorizeRandomLU) {
   std::default_random_engine engine{1399};
   std::uniform_int_distribution<int> distribution{-10, 10};
 
-  const std::vector<std::pair<index_t, index_t>> dims = {{2, 2}, {2, 3}, {3, 3}, {3, 4},
-                                                         {5, 3}, {4, 4}, {4, 6}};
+  const std::vector<std::pair<index_t, index_t>> dims = {{2, 2}, {2, 3}, {3, 3}, {3, 4}, {3, 5},
+                                                         {4, 4}, {4, 6}, {5, 7}, {5, 9}};
 
   for (const auto& [rows, cols] : dims) {
-    constexpr int num_trials = 25;
+    constexpr int num_trials = 500;
     for (int i = 0; i < num_trials; ++i) {
       std::vector<scalar_expr> data{};
       data.reserve(rows * cols);
@@ -448,6 +452,21 @@ TEST(MatrixOperationsTest, TestFactorizeLU4) {
   // clang-format on
   check_full_piv_lu_solution(M, factorize_full_piv_lu(M));
 }
+
+// See https://github.com/wrenfold/wrenfold/issues/235
+#if 0
+TEST(MatrixOperationsTest, TestFactorizeLU5) {
+  // clang-format off
+  auto M = make_matrix(5, 3,
+                       2, 3, -7,
+                       0, 0, 0,
+                       5, 7, -9,
+                       10, 7, -1,
+                       2, 8, 9);
+  // clang-format on
+  check_full_piv_lu_solution(M, factorize_full_piv_lu(M));
+}
+#endif
 
 TEST(MatrixOperationsTest, TestDeterminant2x2) {
   auto I2 = make_identity(2);

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -13,7 +13,6 @@
 #include "wf/derivative.h"
 #include "wf/expression.h"
 #include "wf/expressions/matrix.h"
-#include "wf/expressions/numeric_expressions.h"
 #include "wf/functions.h"
 #include "wf/matrix_functions.h"
 #include "wf/numerical_casts.h"


### PR DESCRIPTION
Related to https://github.com/wrenfold/wrenfold/issues/235

The code-path for factorizing a matrix `A` where `rows > cols` is currently broken for some matrices. For now I'm going to disable it with an exception, as I don't expect this to get that much use initially. I would like to fix this though when more time is available.