### PR TITLE
Fix integer overflow in bspline example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "bspline_demo"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "arrayvec",
  "bspline_rust_test",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "wrenfold-test-utils"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "approx 0.5.1",
  "nalgebra",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "wrenfold-traits"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "nalgebra",
 ]

--- a/examples/bspline/bspline_rust_test/src/lib.rs
+++ b/examples/bspline/bspline_rust_test/src/lib.rs
@@ -83,7 +83,7 @@ fn determine_poly_index(interval: usize, num_intervals: usize, order: usize) -> 
     } else if interval < num_intervals {
         order - 1
     } else {
-        order - (num_intervals - interval)
+        order + (interval - num_intervals)
     }
 }
 

--- a/examples/bspline/bspline_test.cc
+++ b/examples/bspline/bspline_test.cc
@@ -57,7 +57,7 @@ constexpr std::size_t determine_poly_index(const std::size_t interval,
   } else if (interval < num_intervals) {
     return order - 1;
   } else {
-    return order - (num_intervals - interval);
+    return order + (interval - num_intervals);
   }
 }
 


### PR DESCRIPTION
The bspline example (both in C++ and Rust) implicitly depended on integer overflow behavior. This change resolves this bug.