### PR TITLE
Add conda recipe and build scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-yaml
-        exclude: '^dependencies/'
+        exclude: '(^dependencies/)|(support/conda/.*\.yaml)'
       - id: end-of-file-fixer
         exclude: '(^dependencies/)|(.*\.rs$)'
       - id: trailing-whitespace

--- a/components/runtime/CMakeLists.txt
+++ b/components/runtime/CMakeLists.txt
@@ -11,14 +11,22 @@ if(WF_BUILD_EXTRAS)
   add_subdirectory(tests)
 endif()
 
-if(DEFINED SKBUILD_HEADERS_DIR)
-  # This will install the headers under: `include/site/pythonX.Y/wrenfold`.
-  install(FILES ${RUNTIME_SOURCES} DESTINATION "${SKBUILD_HEADERS_DIR}")
-  install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
-          DESTINATION "${SKBUILD_HEADERS_DIR}")
+if("$ENV{WF_SKIP_HEADER_INSTALL}" STREQUAL "skip")
+  message(
+    STATUS "WF_SKIP_HEADER_INSTALL specified, skipping header installation.")
 else()
-  install(FILES ${RUNTIME_SOURCES}
-          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wrenfold")
-  install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
-          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wrenfold")
+  if(DEFINED SKBUILD_HEADERS_DIR)
+    # This will install the headers under: `include/site/pythonX.Y/wrenfold`.
+    message(STATUS "Installing headers to: ${SKBUILD_HEADERS_DIR}")
+    install(FILES ${RUNTIME_SOURCES} DESTINATION "${SKBUILD_HEADERS_DIR}")
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
+            DESTINATION "${SKBUILD_HEADERS_DIR}")
+  else()
+    # This will install headers to the normal include directory.
+    message(STATUS "Installing headers to: ${CMAKE_INSTALL_INCLUDEDIR}")
+    install(FILES ${RUNTIME_SOURCES}
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wrenfold")
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wrenfold")
+  endif()
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,18 @@ ninja.make-fallback = false
 logging.level = "WARNING"
 
 wheel.packages = ["components/python/wrenfold"]
-wheel.license-files = ["LICENSE"]
+wheel.license-files = [
+    "LICENSE",
+    "dependencies/abseil-cpp/LICENSE",
+    "dependencies/fmt/LICENSE",
+    "dependencies/pybind11/LICENSE"
+]
 
 [tool.cibuildwheel]
 skip = ["*musllinux_*", "*-win32", "*_i686", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 test-command = [
-    "python -m unittest discover \"{package}/components/wrapper/tests\" --pattern \"*_test.py\"",
-    "python \"{package}/examples/python_generation/python_generation.py\""
+    "python \"{package}/support/test_wheel.py\"",
 ]
 test-requires = ["numpy", "sympy"]
 

--- a/support/conda/README.md
+++ b/support/conda/README.md
@@ -1,0 +1,4 @@
+To test the conda build, run the following in this directory:
+```bash
+conda-build -c conda-forge wrenfold
+```

--- a/support/conda/wrenfold/bld.bat
+++ b/support/conda/wrenfold/bld.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Python library with no headers.
+set WF_SKIP_HEADER_INSTALL=skip
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+:: Install headers.
+mkdir /I %PREFIX%\include\wrenfold
+xcopy /s/v components\runtime\wrenfold\*.h %PREFIX%\include\wrenfold\
+xcopy LICENSE %PREFIX%\include\wrenfold\

--- a/support/conda/wrenfold/build.sh
+++ b/support/conda/wrenfold/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -x -e
+
+# First build the python library w/o installing headers.
+export WF_SKIP_HEADER_INSTALL=skip
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation
+
+# Then install just the runtime headers.
+# CMake can't install a single target, so we do this manually.
+mkdir $PREFIX/include/wrenfold
+cp components/runtime/wrenfold/*.h $PREFIX/include/wrenfold/
+cp LICENSE $PREFIX/include/wrenfold/

--- a/support/conda/wrenfold/meta.yaml
+++ b/support/conda/wrenfold/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "0.0.7" %}
+
+package:
+  name: wrenfold
+  version: {{ version }}
+
+source:
+  path: ../../..
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python >=3.9
+    - scikit-build-core ==0.9.8
+    - cmake >=3.20
+    - ninja >=1.5
+    - mypy ==1.9.0
+    - pip
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - wrenfold
+    - wrenfold.sym
+  requires:
+    - pip
+    - numpy
+    - sympy
+  source_files:
+    - components/wrapper/tests/*.py
+    - examples/**/*.py
+    - support/test_wheel.py
+  commands:
+    - pip check
+    - python support/test_wheel.py
+
+about:
+  summary: Toolkit for generating code from symbolic math expressions.
+  license: MIT
+  license_file:
+    - LICENSE
+    - dependencies/abseil-cpp/LICENSE
+    - dependencies/fmt/LICENSE
+    - dependencies/pybind11/LICENSE
+  dev_url: https://github.com/wrenfold/wrenfold
+  doc_url: https://wrenfold.org
+
+extra:
+  recipe-maintainers:
+    - gareth-cross

--- a/support/test_wheel.py
+++ b/support/test_wheel.py
@@ -1,0 +1,44 @@
+"""
+Run commands intended to test a built python wheel.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.absolute()
+
+
+def main():
+    # Run all the unit tests.
+    print("Running package tests...")
+    subprocess.check_call([
+        sys.executable, "-m", "unittest", "discover",
+        str(ROOT / "components" / "wrapper" / "tests"), "--pattern", "*_test.py"
+    ])
+
+    # Run all the generators to make sure they don't crash.
+    print("Running all examples...")
+    ex = ROOT / "examples"
+    subprocess.check_call([sys.executable, str(ex / "python_generation" / "python_generation.py")])
+
+    for script in [
+        [ex / "bspline" / "bspline.py", "--language", "cpp"],
+        [ex / "bspline" / "bspline.py", "--language", "rust"],
+        [ex / "custom_types" / "custom_types_gen.py", "--language", "cpp"],
+        [ex / "custom_types" / "custom_types_gen.py", "--language", "rust"],
+        [ex / "imu_integration" / "imu_integration.py"],
+        [ex / "motion_planning" / "problem.py"],
+        [ex / "quaternion_interpolation" / "quaternion_interpolation.py"],
+        [ex / "rosenbrock" / "rosenbrock.py"],
+        [ex / "rotation_error" / "rotation_error.py"],
+    ]:
+        with tempfile.NamedTemporaryFile("w", prefix="codegen_") as fd:
+            fd.close()  # Need to close it so we can overwrite the file.
+            cmd = " ".join([str(x) for x in script])
+            print(f'Running: {cmd}')
+            subprocess.check_call([sys.executable] + [str(x) for x in script] + [fd.name])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add a conda recipe and build scripts.
- Update CMake logic so headers are not installed by pip/scikit-build-core when building from conda. The conda build script installs the runtime headers to the correct place.
- Improve the test script that is run when building wheels and conda packages. It now runs every example in addition to the unit tests.
- Ensure that third party licenses for statically-linked dependencies are also packaged in the wheel.