### PR TITLE
Fix issue where `distribute` did not recurse, causing some products of fractional powers to not expand

### DIFF
--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -865,6 +865,10 @@ TEST(ScalarOperationsTest, TestDistribute1) {
   // Expression where distribution of two factors produces an existing factor:
   ASSERT_IDENTICAL(pow(x, 4) - 2 * pow(x, 2) + 1,
                    ((1 - x) * (1 + x) * (1 - pow(x, 2))).distribute());
+
+  ASSERT_IDENTICAL(x * sqrt(w + 2) + w * y - 3 * w + 2 * y - 6,
+                   (sqrt(w + 2) * (x + sqrt(w + 2) * (y - 3))).distribute());
+
   ASSERT_IDENTICAL(-pow(x, 4) - pow(x, 3) * sqrt(pow(x, 2) + 4 * x - 1) - 6 * pow(x, 3) -
                        2 * pow(x, 2) * sqrt(pow(x, 2) + 4 * x - 1) - 6 * pow(x, 2) +
                        9 * x * sqrt(pow(x, 2) + 4 * x - 1) + 6 * x -

--- a/components/core/wf/distribute.h
+++ b/components/core/wf/distribute.h
@@ -25,13 +25,12 @@ class distribute_visitor {
 
  private:
   // Expand base^power.
-  static scalar_expr distribute_power(scalar_expr base, std::size_t power);
+  scalar_expr distribute_power(scalar_expr base, std::size_t power);
 
   // Expand the multiplication `a * b`. If either of `a` or `b` is an addition, we distribute terms.
-  static scalar_expr distribute_multiplied_terms(const scalar_expr& a, const scalar_expr& b);
+  scalar_expr distribute_multiplied_terms(const scalar_expr& a, const scalar_expr& b);
 
-  template <typename Container>
-  scalar_expr distribute_multiplied_terms(const Container& multiplied_terms);
+  scalar_expr distribute_multiplied_terms(const multiplication& multiplied_terms);
 
   wf::expression_cache cache_;
 };


### PR DESCRIPTION
This change fixes an issue where `distribute()` did not sufficiently recurse, causing some expressions of fractional powers to not be fully expanded.

For example `sqrt(w + 2) * (sqrt(w + 2) * (y - 3) + x)` should expand twice, since the distribution will produce the term: `sqrt(w + 2) ** 2 --> w + 2`, which then needs to be multiplied times `y - 3`. Depending on the internal storage order of the `multiplication` object, this bug may or may not manifest. I have added another test case and resolved the issue.