### PR TITLE
Add `compare()` function to the python wrapper to enable canonical ordering from python

### DIFF
--- a/components/wrapper/pywrenfold/docs/scalar_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/scalar_wrapper.h
@@ -237,6 +237,34 @@ Examples:
   $u_3
 )doc";
 
+inline constexpr std::string_view compare = R"doc(
+Determine relative ordering of two scalar-valued expressions. Note that this is *not* a
+mathematical ordering. Expressions are first ordered by their expression type, and then by the
+contents of the underlying concrete expressions. For non-leaf expressions (for instance
+addition or multiplication), a lexicographical ordering of the children is used to determine
+relative order.
+
+Args:
+  a: The first expression.
+  b: The second expression.
+
+Returns:
+  * ``-1`` if ``a`` belongs before ``b``.
+  * ``0`` if ``a`` is identical to ``b``.
+  * ``+1`` if ``a`` belongs after ``b``.
+
+Examples:
+  >>> x, y = sym.symbols('x, y')
+  >>> sym.compare(x, y)
+  -1
+  >>> sym.compare(y, x)
+  1
+  >>> sym.compare(5, 8)
+  -1
+  >>> sym.compare(sym.sin(x), sym.cos(x))
+  1
+)doc";
+
 inline constexpr std::string_view integer = R"doc(
 Create a constant expression from an integer.
 

--- a/components/wrapper/pywrenfold/scalar_wrapper.cc
+++ b/components/wrapper/pywrenfold/scalar_wrapper.cc
@@ -23,7 +23,6 @@
 #include "wf/expressions/variable.h"
 #include "wf/functions.h"
 #include "wf/numerical_casts.h"
-#include "wf/substitute.h"
 #include "wf/utility_visitors.h"
 
 #include "args_visitor.h"
@@ -245,6 +244,14 @@ void wrap_scalar_operations(py::module_& m) {
   m.def("unique_symbols", &create_unique_variables, py::arg("count"), py::arg("real") = false,
         py::arg("positive") = false, py::arg("nonnegative") = false, py::arg("complex") = false,
         docstrings::unique_symbols.data());
+
+  m.def(
+      "compare",
+      [](const scalar_expr& a, const scalar_expr& b) {
+        const relative_order order = order_by(a, b);
+        return static_cast<int>(order);
+      },
+      "a"_a, "b"_a, docstrings::compare.data());
 
   // Built-in functions:
   m.def("log", &wf::log, "arg"_a, docstrings::log.data());

--- a/components/wrapper/pywrenfold/wrapper_utils.h
+++ b/components/wrapper/pywrenfold/wrapper_utils.h
@@ -8,7 +8,6 @@
 #include <pybind11/pybind11.h>
 
 #include "wf/expression.h"
-#include "wf/expressions/numeric_expressions.h"
 #include "wf/substitute.h"
 #include "wf/utility/algorithms.h"
 


### PR DESCRIPTION
This change exposes `sym.compare`, a function for determining the canonical relative order of scalar-valued expressions. This has utility for sorting/ordering expressions in python.

```
>>> x, y = sym.symbols('x, y')
>>> sym.compare(x, y)
-1
>>> sym.compare(y**2, x**2)
1
```