### PR TITLE
Support integer arguments to generated functions

### DIFF
--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -143,10 +143,10 @@ template <>
 struct collect_function_input<scalar_expr> {
   template <typename U, typename = enable_if_floating_point_t<U>>
   void operator()(substitute_variables_visitor& output, const std::size_t arg_index, const U arg,
-                  const scalar_type&) const {
+                  const scalar_type& scalar) const {
     const auto a = static_cast<float_constant::value_type>(arg);
     const bool added = output.add_substitution(
-        variable{function_argument_variable(arg_index, 0), number_set::real},
+        variable{function_argument_variable(arg_index, 0, scalar.numeric_type()), number_set::real},
         make_expr<float_constant>(a));
     WF_ASSERT(added);
   }
@@ -166,7 +166,9 @@ struct collect_function_input<type_annotations::static_matrix<Rows, Cols>> {
         const std::size_t element = static_cast<std::size_t>(i * Cols + j);
         const auto a_ij = static_cast<float_constant::value_type>(arg(i, j));
         const bool added = output.add_substitution(
-            variable{function_argument_variable(arg_index, element), number_set::real},
+            variable{function_argument_variable(arg_index, element,
+                                                numeric_primitive_type::floating_point),
+                     number_set::real},
             scalar_expr(a_ij));
         WF_ASSERT(added);
       }

--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -146,7 +146,7 @@ struct collect_function_input<scalar_expr> {
                   const scalar_type& scalar) const {
     const auto a = static_cast<float_constant::value_type>(arg);
     const bool added = output.add_substitution(
-        variable{function_argument_variable(arg_index, 0, scalar.numeric_type()), number_set::real},
+        variable{function_argument_variable(arg_index, 0, scalar.numeric_type())},
         make_expr<float_constant>(a));
     WF_ASSERT(added);
   }
@@ -167,8 +167,7 @@ struct collect_function_input<type_annotations::static_matrix<Rows, Cols>> {
         const auto a_ij = static_cast<float_constant::value_type>(arg(i, j));
         const bool added = output.add_substitution(
             variable{function_argument_variable(arg_index, element,
-                                                numeric_primitive_type::floating_point),
-                     number_set::real},
+                                                numeric_primitive_type::floating_point)},
             scalar_expr(a_ij));
         WF_ASSERT(added);
       }

--- a/components/core/tests/cpp_generation_gen.cc
+++ b/components/core/tests/cpp_generation_gen.cc
@@ -27,6 +27,9 @@ class custom_cpp_code_generator final : public cpp_code_generator {
     if (custom.is_native_type<symbolic::Circle>()) {
       return "wf::numeric::Circle";
     }
+    if (custom.is_native_type<symbolic::MixedNumerics>()) {
+      return "wf::numeric::MixedNumerics";
+    }
     return cpp_code_generator::operator()(custom);
   }
 

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -485,4 +485,29 @@ TEST(CppGenerationTest, TestExternalFunctionCall6) {
                     gen::external_function_call_6(-3.5, 4.75).to_vector(), 1.0e-15);
 }
 
+class convert_only_to_int {
+ public:
+  explicit convert_only_to_int(const std::int64_t value) noexcept : value_(value) {}
+
+  // An implicit conversion operator that only works for int64_t
+  template <typename T, typename = std::enable_if_t<std::is_same_v<T, std::int64_t>>>
+  operator T() const noexcept {  // NOLINT
+    return value_;
+  }
+
+ private:
+  std::int64_t value_;
+};
+
+static_assert(!std::is_convertible_v<convert_only_to_int, double>);
+static_assert(!std::is_convertible_v<convert_only_to_int, std::int32_t>);
+static_assert(std::is_convertible_v<convert_only_to_int, std::int64_t>);
+
+TEST(CppGenerationTest, TestIntegerArgument1) {
+  using return_type = decltype(gen::integer_argument_test_1(1, 2.0));
+  static_assert(std::is_same_v<return_type, double>);
+  ASSERT_EQ(2.0, gen::integer_argument_test_1(convert_only_to_int(1), 2.0));
+  ASSERT_EQ(67.2, gen::integer_argument_test_1(convert_only_to_int(16), 4.2));
+}
+
 }  // namespace wf

--- a/components/core/tests/cse_visitor_test.cc
+++ b/components/core/tests/cse_visitor_test.cc
@@ -67,12 +67,13 @@ TEST(CseVisitorTest, Test2) {
 TEST(CseVisitorTest, Test3) {
   const auto [x, y, z] = make_symbols("x", "y", "z");
 
-  const scalar_expr f = (x * y + abs(z)) + cos(z / 2) / log(x * y) - pow(cos(z / 2), abs(z)) -
+  const scalar_expr f = x * y + abs(z) + cos(z / 2) / log(x * y) - pow(cos(z / 2), abs(z)) -
                         abs(cos(z / 2)) * pow(abs(z), z / 2) - sin(z / 2);
 
-  // Replace only things occuring three times or more:
+  // Replace only things occurring three times or more:
   const auto [output, replacements] = eliminate_subexpressions(f, make_var, 3);
-  check_replacements({cos(make_var(1)), abs(z), z / 2}, replacements);
+
+  check_replacements({cos(make_var(0)), abs(z), z / 2}, replacements);
   ASSERT_IDENTICAL(f, apply_substitutions(output, replacements));
 }
 

--- a/components/core/tests/generation_test_2.py
+++ b/components/core/tests/generation_test_2.py
@@ -9,8 +9,8 @@ from wrenfold.external_functions import declare_external_function
 @dataclasses.dataclass
 class StructType:
     """A minimal custom type we will return from an external function."""
-    x: sym.Expr
-    y: sym.Expr
+    x: type_annotations.FloatScalar
+    y: type_annotations.FloatScalar
 
 
 class VectorOfStructs(type_annotations.Opaque):
@@ -29,7 +29,7 @@ class VectorOfStructs(type_annotations.Opaque):
 
 vector_interpolate_access = declare_external_function(
     name="interpolate_access",
-    arguments=[("vec", VectorOfStructs), ("x", sym.Expr)],
+    arguments=[("vec", VectorOfStructs), ("x", type_annotations.FloatScalar)],
     return_type=StructType)
 
 

--- a/components/core/tests/ir_conversion_test.cc
+++ b/components/core/tests/ir_conversion_test.cc
@@ -974,4 +974,19 @@ TEST(IrTest, TestExternalFunction6) {
       << ir;  //  Matrix and point are constructed.
 }
 
+TEST(IrTest, TestTypedScalarArgs1) {
+  auto [expected_expressions, ir] = create_ir(
+      [](ta::int_scalar_expr x, scalar_expr y) { return x * y; }, "func", arg("x"), arg("y"));
+  check_expressions(expected_expressions, ir);
+  ASSERT_EQ(1, ir.count_operation<ir::cast>()) << ir;  //  `x` should get casted
+}
+
+TEST(IrTest, TestTypedScalarArgs2) {
+  auto [expected_expressions, ir] =
+      create_ir([](ta::int_scalar_expr x, ta::int_scalar_expr y) { return x * y; }, "func",
+                arg("x"), arg("y"));
+  check_expressions(expected_expressions, ir);
+  ASSERT_EQ(1, ir.count_operation<ir::cast>()) << ir;  //  `x` and `y` are multiplied, then casted
+}
+
 }  // namespace wf

--- a/components/core/tests/rust_generation_gen.cc
+++ b/components/core/tests/rust_generation_gen.cc
@@ -22,6 +22,9 @@ class custom_rust_code_generator final : public rust_code_generator {
     if (custom.is_native_type<wf::symbolic::Circle>()) {
       return "crate::types::Circle";
     }
+    if (custom.is_native_type<wf::symbolic::MixedNumerics>()) {
+      return "crate::types::MixedNumerics";
+    }
     return rust_code_generator::operator()(custom);
   }
 

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -941,4 +941,17 @@ pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
   crate::external_functions::external_function_4(&crate::external_functions::external_function_4(&crate::types::Point2d::new(v005, v012)))
 }
 
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+pub fn integer_argument_test_1<>(x: i64, y: f64) -> f64
+{
+  // Operation counts:
+  // multiply: 1
+  // total: 1
+  
+  let v00: i64 = x;
+  let v01: f64 = y;
+  v01 * (v00) as f64
+}
+
 

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -943,7 +943,7 @@ pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
 
 #[inline]
 #[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
-pub fn integer_argument_test_1<>(x: i64, y: f64) -> f64
+pub fn integer_argument_1<>(x: i64, y: f64) -> f64
 {
   // Operation counts:
   // multiply: 1
@@ -952,6 +952,64 @@ pub fn integer_argument_test_1<>(x: i64, y: f64) -> f64
   let v00: i64 = x;
   let v01: f64 = y;
   v01 * (v00) as f64
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+pub fn integer_output_values_1<>(x: i64, y: f64, baz: &mut i64) -> i64
+{
+  // Operation counts:
+  // add: 1
+  // multiply: 1
+  // negate: 1
+  // total: 3
+  
+  let v002: f64 = y;
+  let v000: i64 = x;
+  let v005: f64 = (v000) as f64;
+  *baz = (v005 + -v002) as i64;
+  (v002 * v005) as i64
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+pub fn integer_struct_member_1<>(inputs: &crate::types::MixedNumerics, scale: f64) -> f64
+{
+  // Operation counts:
+  // branch: 1
+  // call: 2
+  // compare: 1
+  // multiply: 1
+  // total: 5
+  
+  let v002: i64 = inputs.mode;
+  let v006: f64 = inputs.value;
+  let v012: f64;
+  if (1i64) == ((v002).abs()) {
+    let v005: f64 = scale;
+    v012 = (v005 * v006).cos();
+  } else {
+    v012 = (v006).sin() * (v002) as f64;
+  }
+  v012
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+pub fn integer_struct_member_2<>(x: f64, y: f64) -> crate::types::MixedNumerics
+{
+  // Operation counts:
+  // add: 1
+  // multiply: 1
+  // negate: 1
+  // total: 3
+  
+  let v002: f64 = y;
+  let v000: f64 = x;
+  crate::types::MixedNumerics {
+    value: v000 + -v002,
+    mode: (v000 * v002) as i64
+  }
 }
 
 

--- a/components/core/tests/rust_generation_test/src/lib.rs
+++ b/components/core/tests/rust_generation_test/src/lib.rs
@@ -512,3 +512,84 @@ fn test_external_function_call_6() {
         epsilon = 1.0e-15
     );
 }
+
+#[test]
+fn test_integer_argument_1() {
+    assert_eq!(2.0, generated::integer_argument_1(1i64, 2.0));
+    assert_eq!(67.2, generated::integer_argument_1(16i64, 4.2));
+}
+
+#[test]
+fn test_integer_output_values_1() {
+    let mut baz: i64 = 0;
+    let f = generated::integer_output_values_1(4, 2.2, &mut baz);
+    assert_eq!((4.0 * 2.2) as i64, f);
+    assert_eq!((4.0 - 2.2) as i64, baz);
+}
+
+#[test]
+fn test_integer_struct_member_1() {
+    use types::MixedNumerics;
+    assert_eq!(
+        0.0,
+        generated::integer_struct_member_1(
+            &MixedNumerics {
+                value: 0.5,
+                mode: 0,
+            },
+            2.0
+        )
+    );
+    assert_eq!(
+        0.3f64.sin() * -2.0,
+        generated::integer_struct_member_1(
+            &MixedNumerics {
+                value: 0.3,
+                mode: -2,
+            },
+            2.0
+        )
+    );
+    assert_eq!(
+        -0.25f64.sin() * 9.0,
+        generated::integer_struct_member_1(
+            &MixedNumerics {
+                value: -0.25,
+                mode: 9,
+            },
+            0.0
+        )
+    );
+    // mode == 1
+    assert_eq!(
+        0.3f64.cos(),
+        generated::integer_struct_member_1(
+            &MixedNumerics {
+                value: 0.3,
+                mode: 1,
+            },
+            1.0
+        )
+    );
+    assert_eq!(
+        (0.3f64 * 1.8).cos(),
+        generated::integer_struct_member_1(
+            &MixedNumerics {
+                value: 0.3,
+                mode: 1,
+            },
+            1.8
+        )
+    );
+}
+
+#[test]
+fn test_integer_struct_member_2() {
+    let a = generated::integer_struct_member_2(6.1, 0.5);
+    assert_eq!((6.1 * 0.5) as i64, a.mode);
+    assert_eq!(6.1 - 0.5, a.value);
+
+    let b = generated::integer_struct_member_2(-1.3, 5.0);
+    assert_eq!((-1.3 * 5.0) as i64, b.mode);
+    assert_eq!(-1.3 - 5.0, b.value);
+}

--- a/components/core/tests/rust_generation_test/src/types.rs
+++ b/components/core/tests/rust_generation_test/src/types.rs
@@ -40,3 +40,9 @@ impl Circle {
         nalgebra::Vector3::new(self.center.x, self.center.y, self.radius)
     }
 }
+
+#[derive(Debug, Copy, Clone)]
+pub struct MixedNumerics {
+    pub value: f64,
+    pub mode: i64,
+}

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -252,4 +252,7 @@ inline auto external_function_call_6(scalar_expr x, scalar_expr y) {
   return external_function_4::call(p2);
 }
 
+// Accept an integer argument for `x`.
+inline auto integer_argument_test_1(ta::int_scalar_expr x, scalar_expr y) { return x * y; }
+
 }  // namespace wf

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -231,7 +231,7 @@ inline auto external_function_call_4(scalar_expr a, scalar_expr b) {
   return where(abs(p.x) > abs(p.y), p.x, p.y);
 }
 
-// A external function that accepts a nested custom type.
+// An external function that accepts a nested custom type.
 struct external_function_5
     : declare_external_function<external_function_5, scalar_expr,
                                 type_list<symbolic::Circle, symbolic::Circle>> {
@@ -253,6 +253,42 @@ inline auto external_function_call_6(scalar_expr x, scalar_expr y) {
 }
 
 // Accept an integer argument for `x`.
-inline auto integer_argument_test_1(ta::int_scalar_expr x, scalar_expr y) { return x * y; }
+inline auto integer_argument_1(ta::int_scalar_expr x, scalar_expr y) { return x * y; }
+
+// Return an integer value.
+inline auto integer_output_values_1(ta::int_scalar_expr x, scalar_expr y) {
+  return std::make_tuple(return_value(ta::int_scalar_expr(x * y)),
+                         output_arg<ta::int_scalar_expr>("baz", x - y));
+}
+
+namespace symbolic {
+// A custom type with variables of different numeric types.
+struct MixedNumerics {
+  scalar_expr value{0};
+  ta::int_scalar_expr mode{0};
+};
+}  // namespace symbolic
+
+template <>
+struct custom_type_registrant<symbolic::MixedNumerics> {
+  custom_type_builder<symbolic::MixedNumerics> operator()(custom_type_registry& registry) const {
+    return custom_type_builder<symbolic::MixedNumerics>(registry, "MixedNumerics")
+        .add_field("value", &symbolic::MixedNumerics::value)
+        .add_field("mode", &symbolic::MixedNumerics::mode);
+  }
+};
+
+// Accept a struct that uses an integer type.
+inline auto integer_struct_member_1(symbolic::MixedNumerics inputs, scalar_expr scale) {
+  return where(abs(inputs.mode) == 1, cos(inputs.value * scale), sin(inputs.value) * inputs.mode);
+}
+
+// Return a struct that uses an integer type.
+inline auto integer_struct_member_2(scalar_expr x, scalar_expr y) {
+  symbolic::MixedNumerics out{};
+  out.mode = x * y;
+  out.value = x - y;
+  return out;
+}
 
 }  // namespace wf

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -50,6 +50,7 @@ std::string generate_test_expressions(Generator gen) {
                 arg("x"), arg("y"));
   generate_func(gen, code, &external_function_call_6, "external_function_call_6", arg("x"),
                 arg("y"));
+  generate_func(gen, code, &integer_argument_test_1, "integer_argument_test_1", arg("x"), arg("y"));
   return code;
 }
 

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -50,7 +50,11 @@ std::string generate_test_expressions(Generator gen) {
                 arg("x"), arg("y"));
   generate_func(gen, code, &external_function_call_6, "external_function_call_6", arg("x"),
                 arg("y"));
-  generate_func(gen, code, &integer_argument_test_1, "integer_argument_test_1", arg("x"), arg("y"));
+  generate_func(gen, code, &integer_argument_1, "integer_argument_1", arg("x"), arg("y"));
+  generate_func(gen, code, &integer_output_values_1, "integer_output_values_1", arg("x"), arg("y"));
+  generate_func(gen, code, &integer_struct_member_1, "integer_struct_member_1", arg("inputs"),
+                arg("scale"));
+  generate_func(gen, code, &integer_struct_member_2, "integer_struct_member_2", arg("x"), arg("y"));
   return code;
 }
 

--- a/components/core/wf/code_generation/function_description.cc
+++ b/components/core/wf/code_generation/function_description.cc
@@ -5,8 +5,8 @@
 
 namespace wf {
 
-argument::argument(const std::string_view name, type_variant type, argument_direction direction,
-                   const std::size_t index)
+argument::argument(const std::string_view name, type_variant type,
+                   const argument_direction direction, const std::size_t index)
     : impl_(std::make_shared<const impl>(
           impl{std::string(name), std::move(type), direction, index})) {}
 

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -27,6 +27,29 @@ ir::value_ptr ir_form_visitor::operator()(const complex_infinity&) const {
   throw type_error("Cannot generate code for complex infinity.");
 }
 
+inline numeric_primitive_type determine_member_type(const custom_type& custom,
+                                                    const std::size_t index) {
+  const auto sequence = determine_access_sequence(custom, index);
+  WF_ASSERT(!sequence.empty());
+
+  const access_variant& last_element = sequence.back();
+  return overloaded_visit(
+      last_element,
+      // Matrices are always float for now:
+      [](const matrix_access&) constexpr { return numeric_primitive_type::floating_point; },
+      [&](const field_access& access) -> numeric_primitive_type {
+        // Retrieve the field from the type:
+        const auto accessed_field = access.get_field();
+        // Because this is a leaf, it must be a scalar. This assumption may eventually be relaxed.
+        const scalar_type* const scalar = std::get_if<scalar_type>(&accessed_field->type());
+        WF_ASSERT(
+            scalar != nullptr,
+            "Field `{}` on type `{}` is not a scalar (when accessing element {} of type `{}`)",
+            access.field_name(), access.type().name(), index, custom.name());
+        return scalar->numeric_type();
+      });
+}
+
 ir::value_ptr ir_form_visitor::operator()(const compound_expression_element& el) {
   const ir::value_ptr compound_val = operator()(el.provenance());
   return overloaded_visit(
@@ -36,9 +59,14 @@ ir::value_ptr ir_form_visitor::operator()(const compound_expression_element& el)
                          compound_val->name(), el.index());
       },
       [&](scalar_type) { return compound_val; },
-      [&](const auto&) {
+      [&](const matrix_type&) {
         return push_operation(ir::get{el.index()}, numeric_primitive_type::floating_point,
                               compound_val);
+      },
+      [&](const custom_type& custom) {
+        // Determine the numeric type of the member we are accessing:
+        const numeric_primitive_type type = determine_member_type(custom, el.index());
+        return push_operation(ir::get{el.index()}, type, compound_val);
       });
 }
 

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -384,8 +384,18 @@ ir::value_ptr ir_form_visitor::operator()(const undefined&) const {
   throw type_error("Cannot generate code with expressions containing: {}", undefined::name_str);
 }
 
+inline numeric_primitive_type get_variable_type(const variable& var) {
+  if (const function_argument_variable* arg =
+          std::get_if<function_argument_variable>(&var.identifier());
+      arg != nullptr) {
+    return arg->primitive_type();
+  } else {
+    return numeric_primitive_type::floating_point;
+  }
+}
+
 ir::value_ptr ir_form_visitor::operator()(const variable& var) {
-  return push_operation(ir::load{var}, numeric_primitive_type::floating_point);
+  return push_operation(ir::load{var}, get_variable_type(var));
 }
 
 template <typename T, typename>

--- a/components/core/wf/code_generation/type_registry.cc
+++ b/components/core/wf/code_generation/type_registry.cc
@@ -7,9 +7,8 @@
 
 namespace wf::detail {
 
-// TODO: Pass the numeric type information here.
-scalar_expr create_function_input(const scalar_type&, const std::size_t arg_index) {
-  return variable::create_function_argument(arg_index, 0);
+scalar_expr create_function_input(const scalar_type& scalar, const std::size_t arg_index) {
+  return variable::create_function_argument(arg_index, 0, scalar.numeric_type());
 }
 
 static std::vector<scalar_expr> create_function_args(const std::size_t arg_index,
@@ -17,7 +16,8 @@ static std::vector<scalar_expr> create_function_args(const std::size_t arg_index
   std::vector<scalar_expr> expressions{};
   expressions.reserve(size);
   for (const std::size_t index : make_range(size)) {
-    expressions.push_back(variable::create_function_argument(arg_index, index));
+    expressions.push_back(variable::create_function_argument(
+        arg_index, index, numeric_primitive_type::floating_point));
   }
   return expressions;
 }

--- a/components/core/wf/code_generation/type_registry.h
+++ b/components/core/wf/code_generation/type_registry.h
@@ -193,16 +193,27 @@ struct annotated_custom_type {
 
 namespace detail {
 
+// Non-annotated `scalar_expr` is always floating point.
 template <>
 struct record_type<scalar_expr> {
-  scalar_type operator()(const custom_type_registry&) const {
+  constexpr scalar_type operator()(const custom_type_registry&) const noexcept {
     return scalar_type(numeric_primitive_type::floating_point);
+  }
+};
+
+// Annotated `scalar_expr` may have a specific numerical type.
+template <numeric_primitive_type NumericType>
+struct record_type<type_annotations::annotated_scalar_expr<NumericType>> {
+  constexpr scalar_type operator()(const custom_type_registry&) const noexcept {
+    return scalar_type(NumericType);
   }
 };
 
 template <index_t Rows, index_t Cols>
 struct record_type<type_annotations::static_matrix<Rows, Cols>> {
-  matrix_type operator()(const custom_type_registry&) const { return matrix_type(Rows, Cols); }
+  constexpr matrix_type operator()(const custom_type_registry&) const noexcept {
+    return matrix_type(Rows, Cols);
+  }
 };
 
 // For custom types, we check add each type to the type registry.

--- a/components/core/wf/code_generation/types.cc
+++ b/components/core/wf/code_generation/types.cc
@@ -57,15 +57,14 @@ custom_type::custom_type(std::string name, std::vector<struct_field> fields,
   assert_field_names_are_unique(impl_->fields);
 }
 
-// TODO: Define a nullable_ptr and use it here?
-const struct_field* custom_type::field_by_name(std::string_view name) const noexcept {
+maybe_null<const struct_field*> custom_type::field_by_name(std::string_view name) const noexcept {
   // fields_ will typically be pretty small, so just do a linear search:
   const auto it = std::find_if(impl_->fields.begin(), impl_->fields.end(),
                                [&name](const struct_field& f) { return f.name() == name; });
   if (it == impl_->fields.end()) {
     return nullptr;
   }
-  return &(*it);
+  return &*it;
 }
 
 struct count_custom_type_size {

--- a/components/core/wf/compound_expression.h
+++ b/components/core/wf/compound_expression.h
@@ -20,8 +20,8 @@ struct type_list_trait<compound_meta_type> {
   // clang-format on
 };
 
-// An compound type expression is an expression whose value is an aggregate type,
-// like a user-provided custom struct.
+// A compound expression is an expression whose value is an aggregate type, like a user-provided
+// custom struct.
 class compound_expr final : public expression_base<compound_expr, compound_meta_type> {
  public:
   using expression_base::expression_base;

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -211,8 +211,8 @@ struct precedence_visitor {
 
 precedence get_precedence(const scalar_expr& expr) { return visit(expr, precedence_visitor{}); }
 
-scalar_expr make_unique_variable_symbol(number_set set) {
-  return make_expr<variable>(unique_variable(), set);
+scalar_expr make_unique_variable_symbol(const number_set set) {
+  return make_expr<variable>(unique_variable(set));
 }
 
 }  // namespace wf

--- a/components/core/wf/expressions/variable.cc
+++ b/components/core/wf/expressions/variable.cc
@@ -28,4 +28,10 @@ std::string variable::to_string() const {
   return std::visit(string_converter{}, identifier_);
 }
 
+scalar_expr variable::create_function_argument(const std::size_t arg_index,
+                                               const std::size_t element_index,
+                                               const numeric_primitive_type type) {
+  return make_expr<variable>(function_argument_variable(arg_index, element_index, type));
+}
+
 }  // namespace wf

--- a/components/core/wf/expressions/variable.h
+++ b/components/core/wf/expressions/variable.h
@@ -45,33 +45,51 @@ class function_argument_variable {
 class unique_variable {
  public:
   // Create a new variable w/ the next index.
-  unique_variable() : index_{next_unique_variable_index()} {}
+  explicit unique_variable(const number_set set)
+      : index_{next_unique_variable_index()}, set_(set) {}
 
-  bool operator<(const unique_variable& other) const noexcept { return index_ < other.index_; }
-  bool operator==(const unique_variable& other) const noexcept { return index_ == other.index_; }
+  constexpr bool operator<(const unique_variable& other) const noexcept {
+    return std::make_tuple(index_, set_) < std::make_tuple(other.index_, other.set_);
+  }
+  constexpr bool operator==(const unique_variable& other) const noexcept {
+    return std::make_tuple(index_, set_) == std::make_tuple(other.index_, other.set_);
+  }
 
   // Retrieve the underlying index.
   constexpr std::size_t index() const noexcept { return index_; }
+
+  // Numeric set the unique variable belongs to.
+  constexpr number_set set() const noexcept { return set_; }
 
  private:
   static std::size_t next_unique_variable_index();
 
   std::size_t index_;
+  number_set set_;
 };
 
 // A variable w/ a user-provided name.
 class named_variable {
  public:
-  explicit named_variable(std::string name) noexcept : name_{std::move(name)} {}
+  explicit named_variable(std::string name, const number_set set) noexcept
+      : name_{std::move(name)}, set_(set) {}
 
-  bool operator<(const named_variable& other) const noexcept { return name_ < other.name_; }
-  bool operator==(const named_variable& other) const noexcept { return name_ == other.name_; }
+  bool operator<(const named_variable& other) const noexcept {
+    return std::make_tuple(name_, set_) < std::make_tuple(other.name_, other.set_);
+  }
+  bool operator==(const named_variable& other) const noexcept {
+    return std::make_tuple(name_, set_) == std::make_tuple(other.name_, other.set_);
+  }
 
   // String name of the variable.
   constexpr const std::string& name() const noexcept { return name_; }
 
+  // Numeric set the variable belongs to.
+  constexpr number_set set() const noexcept { return set_; }
+
  private:
   std::string name_;
+  number_set set_;
 };
 
 // A named variable used in an expression.
@@ -88,16 +106,24 @@ class variable {
 
   // Construct variable from user-provided name.
   variable(std::string name, const number_set set)
-      : identifier_{std::in_place_type_t<named_variable>(), std::move(name)}, set_(set) {}
+      : identifier_{std::in_place_type_t<named_variable>(), std::move(name), set} {}
 
-  variable(identifier_type identifier, const number_set set) noexcept
-      : identifier_(std::move(identifier)), set_(set) {}
+  explicit variable(identifier_type identifier) noexcept : identifier_(std::move(identifier)) {}
 
   // Access the variant of different variable representations.
   constexpr const auto& identifier() const noexcept { return identifier_; }
 
   // The numeric set this variable belongs to.
-  constexpr number_set set() const noexcept { return set_; }
+  constexpr number_set set() const noexcept {
+    struct visitor {
+      constexpr number_set operator()(const named_variable& x) const { return x.set(); }
+      constexpr number_set operator()(const unique_variable& x) const { return x.set(); }
+      constexpr number_set operator()(const function_argument_variable&) const {
+        return number_set::real;
+      }
+    };
+    return std::visit(visitor{}, identifier_);
+  }
 
   // True if this variable is a `unique_variable`.
   constexpr bool is_unique_variable() const noexcept {
@@ -108,49 +134,46 @@ class variable {
   std::string to_string() const;
 
   // Create a function argument expression.
-  static scalar_expr create_function_argument(const std::size_t arg_index,
-                                              const std::size_t element_index,
-                                              const numeric_primitive_type type) {
-    // TODO: Support creating function arguments that are not real.
-    return make_expr<variable>(function_argument_variable(arg_index, element_index, type),
-                               number_set::real);
-  }
+  static scalar_expr create_function_argument(std::size_t arg_index, std::size_t element_index,
+                                              numeric_primitive_type type);
 
  private:
   identifier_type identifier_;
-  number_set set_;
 };
 
 template <>
 struct hash_struct<named_variable> {
   std::size_t operator()(const named_variable& v) const noexcept {
-    return hash_string_fnv(v.name());
+    return hash_combine(hash_string_fnv(v.name()), static_cast<std::size_t>(v.set()));
   }
 };
 
 template <>
 struct is_identical_struct<named_variable> {
   bool operator()(const named_variable& a, const named_variable& b) const noexcept {
-    return a.name() == b.name();
+    return a == b;
   }
 };
 
 template <>
 struct hash_struct<unique_variable> {
-  constexpr std::size_t operator()(const unique_variable& v) const noexcept { return v.index(); }
+  constexpr std::size_t operator()(const unique_variable& v) const noexcept {
+    return hash_combine(v.index(), static_cast<std::size_t>(v.set()));
+  }
 };
 
 template <>
 struct is_identical_struct<unique_variable> {
   constexpr bool operator()(const unique_variable& a, const unique_variable& b) const noexcept {
-    return a.index() == b.index();
+    return a == b;
   }
 };
 
 template <>
 struct hash_struct<function_argument_variable> {
   constexpr std::size_t operator()(const function_argument_variable& v) const noexcept {
-    return hash_combine(v.arg_index(), v.element_index());
+    return hash_combine(hash_combine(v.arg_index(), v.element_index()),
+                        static_cast<std::size_t>(v.primitive_type()));
   }
 };
 
@@ -158,21 +181,14 @@ template <>
 struct is_identical_struct<function_argument_variable> {
   constexpr bool operator()(const function_argument_variable& a,
                             const function_argument_variable& b) const noexcept {
-    return a.arg_index() == b.arg_index() && a.element_index() == b.element_index();
-  }
-};
-
-template <>
-struct hash_struct<number_set> {
-  constexpr std::size_t operator()(number_set set) const noexcept {
-    return static_cast<std::size_t>(set);
+    return a == b;
   }
 };
 
 template <>
 struct hash_struct<variable> {
   std::size_t operator()(const variable& v) const noexcept {
-    return hash_args(hash_variant<variable::identifier_type>{}(v.identifier()), v.set());
+    return hash_variant<variable::identifier_type>{}(v.identifier());
   }
 };
 
@@ -180,7 +196,7 @@ template <>
 struct is_identical_struct<variable> {
   bool operator()(const variable& a, const variable& b) const {
     // Comparing identifiers will use the std::variant::operator==.
-    return a.identifier() == b.identifier() && a.set() == b.set();
+    return a.identifier() == b.identifier();
   }
 };
 

--- a/components/core/wf/expressions/variable.h
+++ b/components/core/wf/expressions/variable.h
@@ -10,16 +10,17 @@ namespace wf {
 // Typically, the user does not create these directly.
 class function_argument_variable {
  public:
-  constexpr function_argument_variable(const std::size_t arg_index,
-                                       const std::size_t element_index) noexcept
-      : arg_index_(arg_index), element_index_(element_index) {}
+  constexpr function_argument_variable(const std::size_t arg_index, const std::size_t element_index,
+                                       const numeric_primitive_type primitive_type) noexcept
+      : arg_index_(arg_index), element_index_(element_index), primitive_type_(primitive_type) {}
 
   constexpr bool operator<(const function_argument_variable& other) const noexcept {
-    return std::make_pair(arg_index_, element_index_) <
-           std::make_pair(other.arg_index_, other.element_index_);
+    return std::make_tuple(arg_index_, element_index_, primitive_type_) <
+           std::make_tuple(other.arg_index_, other.element_index_, other.primitive_type_);
   }
   constexpr bool operator==(const function_argument_variable& other) const noexcept {
-    return arg_index_ == other.arg_index_ && element_index_ == other.element_index_;
+    return arg_index_ == other.arg_index_ && element_index_ == other.element_index_ &&
+           primitive_type_ == other.primitive_type_;
   }
 
   // Which function argument this refers to.
@@ -29,9 +30,15 @@ class function_argument_variable {
   // For a matrix arg, this is a flat index into the matrix.
   constexpr std::size_t element_index() const noexcept { return element_index_; }
 
+  // The numeric type of this variable.
+  constexpr numeric_primitive_type primitive_type() const noexcept { return primitive_type_; }
+
  private:
   std::size_t arg_index_;
   std::size_t element_index_;
+  // TODO: `numeric_primitive_type` is a bit too liberal, since it also incorporates boolean.
+  // But boolean can only be used in boolean_expr, not scalar_expr.
+  numeric_primitive_type primitive_type_;
 };
 
 // A variable designated by a unique integer index that is not reused.
@@ -102,9 +109,10 @@ class variable {
 
   // Create a function argument expression.
   static scalar_expr create_function_argument(const std::size_t arg_index,
-                                              const std::size_t element_index) {
+                                              const std::size_t element_index,
+                                              const numeric_primitive_type type) {
     // TODO: Support creating function arguments that are not real.
-    return make_expr<variable>(function_argument_variable(arg_index, element_index),
+    return make_expr<variable>(function_argument_variable(arg_index, element_index, type),
                                number_set::real);
   }
 

--- a/components/core/wf/type_annotations.h
+++ b/components/core/wf/type_annotations.h
@@ -85,5 +85,30 @@ struct is_static_matrix<static_matrix<Rows, Cols>> : std::true_type {};
 template <typename T>
 constexpr bool is_static_matrix_v = is_static_matrix<T>::value;
 
+// Annotate a `scalar_expr` with an expected numeric primitive type at compile time.
+template <numeric_primitive_type NumericType>
+class annotated_scalar_expr {
+ public:
+  static_assert(NumericType != numeric_primitive_type::boolean, "Type cannot be boolean");
+
+  // Implicitly construct from scalar expression.
+  annotated_scalar_expr(scalar_expr expr) noexcept : expr_(std::move(expr)) {}  // NOLINT
+
+  // Implicit conversion to scalar_expr.
+  constexpr operator const scalar_expr&() const noexcept { return expr_; }  // NOLINT
+
+ private:
+  scalar_expr expr_;
+};
+
+using int_scalar_expr = annotated_scalar_expr<numeric_primitive_type::integral>;
+
+template <typename>
+struct is_annotated_scalar_expr : std::false_type {};
+template <numeric_primitive_type NumericType>
+struct is_annotated_scalar_expr<annotated_scalar_expr<NumericType>> : std::true_type {};
+template <typename T>
+constexpr bool is_annotated_scalar_expr_v = is_annotated_scalar_expr<T>::value;
+
 }  // namespace type_annotations
 }  // namespace wf

--- a/components/core/wf/utility/checked_pointers.h
+++ b/components/core/wf/utility/checked_pointers.h
@@ -50,7 +50,7 @@ class non_null {
     WF_ASSERT(ptr_ != nullptr, "Cannot be constructed null");
   }
 
-  // Construct from a other `non_null` type that is convertible.
+  // Construct from another `non_null` type that is convertible.
   // We don't check here, because the constructor of `non_null<U>` already checked.
   template <typename U, typename = enable_if_convertible_t<U>>
   constexpr non_null(non_null<U> ptr) noexcept(std::is_nothrow_constructible_v<T, U&&>)  // NOLINT
@@ -174,8 +174,8 @@ class maybe_null {
     return ptr_;
   }
 
-  // Access the underlying object safely. Throws if the underlying ptr is null. Hence this is always
-  // noexcept(false), because we check at runtime for a valid access.
+  // Access the underlying object safely. Throws if the underlying ptr is null. Hence, this is
+  // always noexcept(false), because we check at runtime for a valid access.
   detail::value_or_reference_return_t<T> get() const noexcept(false) {
     WF_ASSERT(has_value(), "Accessing maybe_null that is null. T = {}", typeid(T).name());
     return ptr_;

--- a/components/python/wrenfold/custom_types.py
+++ b/components/python/wrenfold/custom_types.py
@@ -21,7 +21,11 @@ def convert_to_internal_type(
     OMIT_FROM_SPHINX
     """
     if issubclass(python_type, sym.Expr):
-        return type_info.ScalarType(type_info.NumericType.Float)
+        numeric_type = getattr(python_type, "NUMERIC_PRIMITIVE_TYPE")
+        if numeric_type is None:
+            raise TypeError(
+                f"Argument annotation {python_type} lacks the NUMERIC_PRIMITIVE_TYPE property")
+        return type_info.ScalarType(numeric_type=numeric_type)
     elif issubclass(python_type, sym.MatrixExpr):
         shape = _get_matrix_shape(matrix_type=python_type)
         return type_info.MatrixType(*shape)

--- a/components/python/wrenfold/custom_types.py
+++ b/components/python/wrenfold/custom_types.py
@@ -25,6 +25,10 @@ def convert_to_internal_type(
         if numeric_type is None:
             raise TypeError(
                 f"Argument annotation {python_type} lacks the NUMERIC_PRIMITIVE_TYPE property")
+        if numeric_type == type_info.NumericType.Bool:
+            raise TypeError(
+                "Boolean arguments and fields are not supported yet. https://github.com/wrenfold/wrenfold/issues/163"
+            )
         return type_info.ScalarType(numeric_type=numeric_type)
     elif issubclass(python_type, sym.MatrixExpr):
         shape = _get_matrix_shape(matrix_type=python_type)

--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -114,9 +114,13 @@ class Conversions:
             kwargs.update(complex=True)
 
         if expr.name.startswith('$arg_'):
+            if expr.is_integer:
+                numeric_type = type_info.NumericType.Integer
+            else:
+                assert expr.is_real, f"Function argument variables must be floats: {expr}"
+                numeric_type = type_info.NumericType.Float
             arg_index, element_index = [int(x) for x in expr.name.lstrip('$arg_').split('_')]
-            return function_argument_variable(
-                arg_index, element_index, type=type_info.NumericType.Float)
+            return function_argument_variable(arg_index, element_index, type=numeric_type)
 
         return sym.symbols(expr.name, **kwargs)
 

--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -7,7 +7,7 @@ import typing as T
 
 from pywrenfold.sympy_conversion import function_argument_variable, to_sympy
 
-from . import sym
+from . import sym, type_info
 
 
 class Conversions:
@@ -115,7 +115,8 @@ class Conversions:
 
         if expr.name.startswith('$arg_'):
             arg_index, element_index = [int(x) for x in expr.name.lstrip('$arg_').split('_')]
-            return function_argument_variable(arg_index, element_index)
+            return function_argument_variable(
+                arg_index, element_index, type=type_info.NumericType.Float)
 
         return sym.symbols(expr.name, **kwargs)
 

--- a/components/python/wrenfold/type_annotations.py
+++ b/components/python/wrenfold/type_annotations.py
@@ -7,11 +7,17 @@ expose the SHAPE tuple.
 """
 import typing as T
 
-from . import sym
+from . import sym, type_info
 
 
 class FloatScalar(sym.Expr):
     """Denote a floating-point scalar variable."""
+    NUMERIC_PRIMITIVE_TYPE = type_info.NumericType.Float
+
+
+class IntScalar(sym.Expr):
+    """Denote an integer valued scalar variable."""
+    NUMERIC_PRIMITIVE_TYPE = type_info.NumericType.Integer
 
 
 class Vector1(sym.MatrixExpr):

--- a/components/wrapper/pywrenfold/sympy_conversion.cc
+++ b/components/wrapper/pywrenfold/sympy_conversion.cc
@@ -248,11 +248,12 @@ void wrap_sympy_conversion(py::module_& m) {
 
   m.def(
       "function_argument_variable",
-      [](const std::size_t arg_index, const std::size_t element_index) {
-        return make_expr<variable>(function_argument_variable(arg_index, element_index),
+      [](const std::size_t arg_index, const std::size_t element_index,
+         const numeric_primitive_type type) {
+        return make_expr<variable>(function_argument_variable(arg_index, element_index, type),
                                    number_set::real);
       },
-      py::arg("arg_index"), py::arg("element_index"),
+      py::arg("arg_index"), py::arg("element_index"), py::arg("type"),
       py::doc("Create ``function_argument_variable``. OMIT_FROM_SPHINX"));
 }
 

--- a/components/wrapper/pywrenfold/sympy_conversion.cc
+++ b/components/wrapper/pywrenfold/sympy_conversion.cc
@@ -250,8 +250,7 @@ void wrap_sympy_conversion(py::module_& m) {
       "function_argument_variable",
       [](const std::size_t arg_index, const std::size_t element_index,
          const numeric_primitive_type type) {
-        return make_expr<variable>(function_argument_variable(arg_index, element_index, type),
-                                   number_set::real);
+        return make_expr<variable>(function_argument_variable(arg_index, element_index, type));
       },
       py::arg("arg_index"), py::arg("element_index"), py::arg("type"),
       py::doc("Create ``function_argument_variable``. OMIT_FROM_SPHINX"));

--- a/components/wrapper/pywrenfold/wrapper.cc
+++ b/components/wrapper/pywrenfold/wrapper.cc
@@ -83,15 +83,15 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
       m.def_submodule(PY_SUBMODULE_NAME_EXPRESSIONS, "Wrapped concrete expressions.");
   wrap_expressions(m_expressions);
 
-  auto m_sympy_conversion =
-      m.def_submodule(PY_SUBMODULE_NAME_SYMPY_CONVERSION, "Wrapped sympy conversion methods.");
-  wrap_sympy_conversion(m_sympy_conversion);
-
   auto m_geo = m.def_submodule(PY_SUBMODULE_NAME_GEOMETRY, "Wrapped geometry methods.");
   wrap_geometry_operations(m_geo);
 
   auto m_types = m.def_submodule(PY_SUBMODULE_NAME_TYPE_INFO, "Wrapped code-generation types.");
   wrap_types(m_types);
+
+  auto m_sympy_conversion =
+      m.def_submodule(PY_SUBMODULE_NAME_SYMPY_CONVERSION, "Wrapped sympy conversion methods.");
+  wrap_sympy_conversion(m_sympy_conversion);
 
   // We need to wrap `Argument` and `ArgumentDirection` first so they are available for `ast`.
   auto m_gen = m.def_submodule(PY_SUBMODULE_NAME_GEN, "Wrapped code-generation methods.");

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -258,6 +258,23 @@ class CodeGenerationWrapperTest(MathTestBase):
         self.assertEqual(5, ctype.total_size)
         self._run_generators(definition)
 
+    def test_boolean_args_disallowed(self):
+        """Test that boolean arguments are disallowed."""
+
+        class Boolean(sym.Expr):
+            # This is illegal.
+            NUMERIC_PRIMITIVE_TYPE = type_info.NumericType.Bool
+
+        def boolean_arg_func(x: Boolean, y: FloatScalar):
+            return [
+                code_generation.ReturnValue(5 + y * x),
+                code_generation.OutputArg(x, name="x_out")
+            ]
+
+        self.assertRaises(
+            TypeError, lambda: code_generation.generate_function(
+                func=boolean_arg_func, generator=code_generation.RustGenerator()))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -55,10 +55,10 @@ class OpaqueType(Opaque):
 
 
 external_func = external_functions.declare_external_function(
-    "external_func", arguments=[('foo', OpaqueType), ('bar', sym.Expr)], return_type=sym.Expr)
+    "external_func", arguments=[('foo', OpaqueType), ('bar', FloatScalar)], return_type=FloatScalar)
 
 
-def opaque_type_func(u: OpaqueType, x: sym.Expr, y: sym.Expr):
+def opaque_type_func(u: OpaqueType, x: FloatScalar, y: FloatScalar):
     """Use an opaque type as an argument to a generated function."""
     f = external_func(u, x * y + 3)
     return f + sym.cos(x * y)

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -53,7 +53,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(
             sym.symbols('z', real=True),
             expressions.Variable('z', number_set=enumerations.NumberSet.Real).to_expression())
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             [expressions.Variable('y'), expressions.Variable('x')],
             sym.get_variables(x + y * x - sym.cos(y)))
 
@@ -461,7 +461,8 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(0, f1.diff(z))
 
         f2 = f(sym.sin(x), x ** 2).diff(x)
-        u1, u2 = [v.to_expression() for v in sym.get_variables(f2) if v.is_unique_variable]
+        u1, u2 = sorted([v.to_expression() for v in sym.get_variables(f2) if v.is_unique_variable],
+                        key=functools.cmp_to_key(sym.compare))
 
         self.assertIdentical(
             sym.cos(x) * sym.substitution(f(u1, x ** 2).diff(u1), u1, sym.sin(x)) + \

--- a/components/wrapper/tests/external_function_wrapper_test.py
+++ b/components/wrapper/tests/external_function_wrapper_test.py
@@ -13,7 +13,7 @@ from wrenfold import (
     sym,
     type_info,
 )
-from wrenfold.type_annotations import Opaque, Vector2, Vector3
+from wrenfold.type_annotations import FloatScalar, Opaque, Vector2, Vector3
 
 
 class ExternalFunctionWrapperTest(MathTestBase):
@@ -21,7 +21,7 @@ class ExternalFunctionWrapperTest(MathTestBase):
     def test_scalars(self):
         """Define function that accepts and returns scalars."""
         func = external_functions.declare_external_function(
-            name="func", arguments=[("x", sym.Expr)], return_type=sym.Expr)
+            name="func", arguments=[("x", FloatScalar)], return_type=FloatScalar)
 
         self.assertEqual("func", func.name)
         self.assertEqual(1, func.num_arguments)
@@ -53,7 +53,7 @@ class ExternalFunctionWrapperTest(MathTestBase):
     def test_matrices(self):
         """Define a function that accepts and returns matrices."""
         func = external_functions.declare_external_function(
-            name="func", arguments=[("x", sym.Expr), ("v", Vector3)], return_type=Vector2)
+            name="func", arguments=[("x", FloatScalar), ("v", Vector3)], return_type=Vector2)
         self.assertEqual(2, func.num_arguments)
         self.assertEqual(type_info.MatrixType(2, 1), func.return_type)
 
@@ -77,11 +77,11 @@ class ExternalFunctionWrapperTest(MathTestBase):
         @dataclasses.dataclass
         class TestType:
             """A dummy type we use for this test."""
-            a: sym.Expr
+            a: FloatScalar
             b: Vector2
 
         func = external_functions.declare_external_function(
-            name="func", arguments=[("foo", TestType), ("bar", sym.Expr)], return_type=TestType)
+            name="func", arguments=[("foo", TestType), ("bar", FloatScalar)], return_type=TestType)
         self.assertEqual(2, func.num_arguments)
         self.assertIsInstance(func.return_type, type_info.CustomType)
 
@@ -106,9 +106,9 @@ class ExternalFunctionWrapperTest(MathTestBase):
 
         # Define two functions - one that returns the type, and another accepts it.
         func_1 = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", sym.Expr)], return_type=TestType)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=TestType)
         func_2 = external_functions.declare_external_function(
-            name="func_2", arguments=[("q", TestType), ("w", sym.Expr)], return_type=sym.Expr)
+            name="func_2", arguments=[("q", TestType), ("w", FloatScalar)], return_type=FloatScalar)
         self.assertEqual(1, func_1.num_arguments)
         self.assertIsInstance(func_1.return_type, type_info.CustomType)
 
@@ -131,13 +131,13 @@ class ExternalFunctionWrapperTest(MathTestBase):
     def test_comparisons(self):
         """Check that we can test external functions for equality."""
         func_1 = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", sym.Expr)], return_type=Vector2)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2)
         func_1_dup = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", sym.Expr)], return_type=Vector2)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2)
         self.assertEqual(func_1, func_1_dup)
 
         func_2 = external_functions.declare_external_function(
-            name="func_2", arguments=[("x", sym.Expr)], return_type=Vector2)
+            name="func_2", arguments=[("x", FloatScalar)], return_type=Vector2)
         self.assertNotEqual(func_1, func_2)
 
         func_3 = external_functions.declare_external_function(

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -36,6 +36,9 @@ class SympyConversionTest(MathTestBase):
         self.assertEqualSp(
             sp.symbols('$arg_2_3', real=True),
             sympy_conversion.function_argument_variable(2, 3, type_info.NumericType.Float))
+        self.assertEqualSp(
+            sp.symbols('$arg_2_4', integer=True),
+            sympy_conversion.function_argument_variable(2, 4, type_info.NumericType.Integer))
 
         # sympy --> wf
         self.assertIdenticalFromSp(sym.symbols('x'), sp.symbols('x'))
@@ -47,6 +50,9 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(
             sympy_conversion.function_argument_variable(2, 3, type_info.NumericType.Float),
             sp.symbols('$arg_2_3', real=True))
+        self.assertIdenticalFromSp(
+            sympy_conversion.function_argument_variable(3, 4, type_info.NumericType.Integer),
+            sp.symbols('$arg_3_4', integer=True))
 
     def test_numeric_constants(self):
         self.assertEqualSp(sp.Integer(0), sym.zero)

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -8,7 +8,7 @@ import unittest
 import sympy as sp
 from test_base import MathTestBase
 
-from wrenfold import sym, sympy_conversion
+from wrenfold import sym, sympy_conversion, type_info
 
 # Some shorthand for the purpose of this test:
 spy = sympy_conversion.to_sympy
@@ -34,7 +34,8 @@ class SympyConversionTest(MathTestBase):
         self.assertEqualSp(sp.symbols('x', nonnegative=True), sym.symbols('x', nonnegative=True))
         self.assertEqualSp(sp.symbols('x', complex=True), sym.symbols('x', complex=True))
         self.assertEqualSp(
-            sp.symbols('$arg_2_3', real=True), sympy_conversion.function_argument_variable(2, 3))
+            sp.symbols('$arg_2_3', real=True),
+            sympy_conversion.function_argument_variable(2, 3, type_info.NumericType.Float))
 
         # sympy --> wf
         self.assertIdenticalFromSp(sym.symbols('x'), sp.symbols('x'))
@@ -44,7 +45,8 @@ class SympyConversionTest(MathTestBase):
             sym.symbols('x', nonnegative=True), sp.symbols('x', nonnegative=True))
         self.assertIdenticalFromSp(sym.symbols('x', complex=True), sp.symbols('x', complex=True))
         self.assertIdenticalFromSp(
-            sympy_conversion.function_argument_variable(2, 3), sp.symbols('$arg_2_3', real=True))
+            sympy_conversion.function_argument_variable(2, 3, type_info.NumericType.Float),
+            sp.symbols('$arg_2_3', real=True))
 
     def test_numeric_constants(self):
         self.assertEqualSp(sp.Integer(0), sym.zero)

--- a/examples/custom_types/custom_types_test.cc
+++ b/examples/custom_types/custom_types_test.cc
@@ -21,7 +21,7 @@ struct Point3d {
 };
 
 // A simple 3D pose. We implement accessors and constructors for this type, to demonstrate that the
-// code generator can be cutomized to use these.
+// code generator can be customized to use these.
 class Pose3d {
  public:
   Pose3d(const Quaterniond& rotation, const Vector3d& translation) noexcept

--- a/examples/python_generation/python_generation.py
+++ b/examples/python_generation/python_generation.py
@@ -28,9 +28,9 @@ class SimParamsSymbolic:
     A sample struct with some parameters of a simulation. This is the symbolic version.
     We use this to test code-generation of custom types.
     """
-    mass: sym.Expr
-    drag_coefficient: sym.Expr
-    gravity: sym.Expr
+    mass: type_annotations.FloatScalar
+    drag_coefficient: type_annotations.FloatScalar
+    gravity: type_annotations.FloatScalar
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Adds support for functions accepting integer arguments, and partially addresses https://github.com/wrenfold/wrenfold/issues/163. This is a **breaking change** because all values that were previously annotated as `sym.Expr` must now be annotated as `type_annotations.FloatScalar` or `type_annotations.IntScalar`.

Type annotations can now be specified as:

```python
from wrenfold import sym, type_annotations, code_generation

def func(x: type_annotations.FloatScalar, mode: type_annotations.IntScalar):
  return sym.where(sym.eq(mode, 1), sym.cos(x), sym.sin(x) + 2)

print(code_generation.generate_function(func, generator=code_generation.CppGenerator()))
```
Produces:
```cpp
template <typename Scalar>
Scalar func(const Scalar x, const std::int64_t mode)
{
 // ...
  const std::int64_t v001 = mode;
  const Scalar v003 = x;
  Scalar v009;
  if (1 == v001) {
    v009 = std::cos(v003);
  } else {
    v009 = std::sin(v003) + static_cast<Scalar>(2);
  }
  return v009;
}
```
Not a very realistic example, but it illustrates the point. Integers type annotations can also be used on custom types, which may be passed as arguments or returned as return values.