### PR TITLE
Add standalone versions of the sym.subs and sym.distribute functions

### DIFF
--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -14,9 +14,9 @@ struct collect_visitor {
   explicit collect_visitor(const absl::Span<const scalar_expr> terms) : collected_terms_(terms) {}
 
   scalar_expr operator()(const scalar_expr& x) { return visit(x, *this); }
-  compound_expr operator()(const compound_expr& x) { return map_compound_expressions(x, *this); }
+  compound_expr operator()(const compound_expr& x) { return visit(x, *this); }
   boolean_expr operator()(const boolean_expr& x) { return visit(x, *this); }
-  matrix_expr operator()(const matrix_expr& x) { return map_matrix_expression(x, *this); }
+  matrix_expr operator()(const matrix_expr& x) { return visit(x, *this); }
 
   scalar_expr collect_addition_terms(addition::container_type&& container) const {
     // iterate over the terms we want to search for:

--- a/components/core/wf/distribute.cc
+++ b/components/core/wf/distribute.cc
@@ -16,8 +16,7 @@ scalar_expr distribute_visitor::operator()(const scalar_expr& input) {
 }
 
 compound_expr distribute_visitor::operator()(const compound_expr& input) {
-  return cache_.get_or_insert(
-      input, [this](const compound_expr& x) { return map_compound_expressions(x, *this); });
+  return cache_.get_or_insert(input, [this](const compound_expr& x) { return visit(x, *this); });
 }
 
 boolean_expr distribute_visitor::operator()(const boolean_expr& input) {
@@ -25,8 +24,7 @@ boolean_expr distribute_visitor::operator()(const boolean_expr& input) {
 }
 
 matrix_expr distribute_visitor::operator()(const matrix_expr& input) {
-  return cache_.get_or_insert(
-      input, [this](const matrix_expr& m) { return map_matrix_expression(m, *this); });
+  return cache_.get_or_insert(input, [this](const matrix_expr& m) { return visit(m, *this); });
 }
 
 scalar_expr distribute_visitor::operator()(const multiplication& mul) {

--- a/components/core/wf/evaluate.cc
+++ b/components/core/wf/evaluate.cc
@@ -36,8 +36,7 @@ scalar_expr evaluate_visitor::operator()(const scalar_expr& input) {
 }
 
 compound_expr evaluate_visitor::operator()(const compound_expr& input) {
-  return cache_.get_or_insert(
-      input, [this](const compound_expr& x) { return map_compound_expressions(x, *this); });
+  return cache_.get_or_insert(input, [this](const compound_expr& x) { return visit(x, *this); });
 }
 
 boolean_expr evaluate_visitor::operator()(const boolean_expr& input) {
@@ -45,8 +44,7 @@ boolean_expr evaluate_visitor::operator()(const boolean_expr& input) {
 }
 
 matrix_expr evaluate_visitor::operator()(const matrix_expr& input) {
-  return cache_.get_or_insert(
-      input, [this](const matrix_expr& x) { return map_matrix_expression(x, *this); });
+  return cache_.get_or_insert(input, [this](const matrix_expr& x) { return visit(x, *this); });
 }
 
 scalar_expr evaluate(const scalar_expr& arg) { return evaluate_visitor{}(arg); }

--- a/components/core/wf/expression_visitor.h
+++ b/components/core/wf/expression_visitor.h
@@ -74,30 +74,4 @@ auto visit_binary(const U& u, const V& v, VisitorType&& handler) {
   });
 }
 
-// Expand a matrix expression, and apply `f` to every `scalar_expr` it contains.
-template <typename F>
-matrix_expr map_matrix_expression(const matrix_expr& expr, F&& f) {
-  return visit(expr, [&](const auto& mat) { return mat.map_children(std::forward<F>(f)); });
-}
-
-// Expand a compound expression, and visit all the sub-expressions that make it up with the provided
-// object `f`. Type `F` will be invoked with expression types like `scalar_expr`, `boolean_expr`,
-// etc.
-template <typename F>
-compound_expr map_compound_expressions(const compound_expr& expr, F&& f) {
-  return visit(expr, make_overloaded(
-                         [&](const external_function_invocation& invocation) {
-                           return invocation.map_children([&](const any_expression& arg) {
-                             // Visit the `any_expression` variant. `f()` is invoked with all
-                             // the possible expression types.
-                             return std::visit(
-                                 [&f](const auto& x) -> any_expression { return f(x); }, arg);
-                           });
-                         },
-                         [&](const custom_type_argument&) { return expr; },
-                         [&](const custom_type_construction& construct) {
-                           return construct.map_children(std::forward<F>(f));
-                         }));
-}
-
 }  // namespace wf

--- a/components/core/wf/matrix_expression.cc
+++ b/components/core/wf/matrix_expression.cc
@@ -84,6 +84,12 @@ std::vector<scalar_expr> matrix_expr::to_vector() const { return as_matrix().chi
 
 matrix_expr matrix_expr::operator-() const { return operator*(*this, constants::negative_one); }
 
+// Expand a matrix expression, and apply `f` to every `scalar_expr` it contains.
+template <typename F>
+static matrix_expr map_matrix_expression(const matrix_expr& expr, F&& f) {
+  return visit(expr, [&](const auto& mat) { return mat.map_children(std::forward<F>(f)); });
+}
+
 matrix_expr matrix_expr::diff(const scalar_expr& var, const int reps,
                               const non_differentiable_behavior behavior) const {
   derivative_visitor visitor{var, behavior};

--- a/components/core/wf/substitute.h
+++ b/components/core/wf/substitute.h
@@ -60,11 +60,13 @@ class substitute_variables_visitor {
 };
 
 // Replace all [target, replacement] pairs in the input expression.
-scalar_expr substitute(const scalar_expr& input, absl::Span<const scalar_or_boolean_pair> pairs,
-                       bool force_unordered_execution = false);
-boolean_expr substitute(const boolean_expr& input, absl::Span<const scalar_or_boolean_pair> pairs,
-                        bool force_unordered_execution = false);
-matrix_expr substitute(const matrix_expr& input, absl::Span<const scalar_or_boolean_pair> pairs,
-                       bool force_unordered_execution = false);
+any_expression substitute_any(any_expression input, absl::Span<const scalar_or_boolean_pair> pairs,
+                              bool force_unordered_execution = false);
+
+template <typename X, typename = enable_if_inherits_expression_base_t<X>>
+X substitute(const X& input, absl::Span<const scalar_or_boolean_pair> pairs,
+             bool force_unordered_execution = false) {
+  return std::get<X>(substitute_any(input, pairs, force_unordered_execution));
+}
 
 }  // namespace wf

--- a/components/wrapper/CMakeLists.txt
+++ b/components/wrapper/CMakeLists.txt
@@ -121,6 +121,7 @@ add_wrapper_module(
   pywrenfold/docs/geometry_wrapper.h
   pywrenfold/docs/matrix_wrapper.h
   pywrenfold/docs/scalar_wrapper.h
+  pywrenfold/docs/symbolic_functions_wrapper.h
   pywrenfold/docs/sympy_conversion.h
   pywrenfold/enums_wrapper.cc
   pywrenfold/exceptions_wrapper.cc
@@ -128,8 +129,10 @@ add_wrapper_module(
   pywrenfold/geometry_wrapper.cc
   pywrenfold/matrix_wrapper.cc
   pywrenfold/scalar_wrapper.cc
+  pywrenfold/symbolic_functions_wrapper.cc
   pywrenfold/sympy_conversion.cc
   pywrenfold/types_wrapper.cc
+  pywrenfold/visitor_wrappers.h
   pywrenfold/wrapper.cc
   pywrenfold/wrapper_utils.h
   SUB_MODULE_NAMES

--- a/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
+++ b/components/wrapper/pywrenfold/boolean_expression_wrapper.cc
@@ -11,6 +11,7 @@
 #include "wf/expressions/special_constants.h"
 
 #include "args_visitor.h"
+#include "visitor_wrappers.h"
 #include "wrapper_utils.h"
 
 namespace py = pybind11;
@@ -43,11 +44,11 @@ void wrap_boolean_expression(py::module_& m) {
           "args", [](const boolean_expr& self) { return args_visitor{}(self); },
           "Arguments of ``self`` as a tuple.")
       .def("subs", &substitute_wrapper_single<boolean_expr, scalar_expr>, py::arg("target"),
-           py::arg("substitute"), "See :func:`wrenfold.sym.Expr.subs`")
+           py::arg("substitute"), "See :func:`wrenfold.sym.subs`")
       .def("subs", &substitute_wrapper_single<boolean_expr, boolean_expr>, py::arg("target"),
-           py::arg("substitute"), "See :func:`wrenfold.sym.Expr.subs`")
+           py::arg("substitute"), "See :func:`wrenfold.sym.subs`")
       .def("subs", &substitute_wrapper<boolean_expr>, py::arg("pairs"),
-           "See :func:`wrenfold.sym.Expr.subs`")
+           "See :func:`wrenfold.sym.subs`")
       .def("__bool__", &coerce_to_bool, py::doc("Coerce expression to boolean."))
       .doc() = "A boolean-valued symbolic expression.";
 

--- a/components/wrapper/pywrenfold/docs/scalar_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/scalar_wrapper.h
@@ -70,53 +70,6 @@ Examples:
   x**2*cos(x*y)
 )doc";
 
-inline constexpr std::string_view scalar_expr_distribute = R"doc(
-Expand the mathematical expression. ``distribute`` will recursively traverse the expression tree and
-multiply out any product of additions and subtractions. For example:
-
-.. math::
-  \left(x + y\right)\cdot(4 - y) \rightarrow 4 \cdot x + 4  \cdot y - x  \cdot y - y^{2}
-
-Powers of the form :math:`f\left(x\right)^{\frac{n}{2}}` where :math:`n` is an integer are also
-expanded:
-
-.. math::
-  \left(x + 2\right)^{\frac{3}{2}} \rightarrow x \cdot \left(x + 2\right)^{\frac{1}{2}} +
-  2 \cdot \left(x + 2\right)^{\frac{1}{2}}
-
-Returns:
-  The input expression after expansion.
-
-Examples:
-  >>> x, y = sym.symbols('x, y')
-  >>> f = (x - 2) * (y + x) * (y - 3)
-  >>> f.distribute()
-  6*x + 6*y - 5*x*y + x**2*y + x*y**2 - 3*x**2 - 2*y**2
-)doc";
-
-inline constexpr std::string_view subs = R"doc(
-Traverse the expression tree and replace target expressions with corresponding substitutions. The
-list of replacements is executed *in order*, such that substitutions that appear later in the list
-of ``(target, replacement)`` pairs may leverage the result of earlier ones.
-
-Args:
-  pairs: A list of tuples. Each tuple contains a ``(target, replacement)`` pair, where the *target*
-    is the expression to find and the *replacement* is the expression to substitute in its place.
-    The pairs may be scalar-valued or boolean-valued expressions.
-
-Returns:
-  The input expression after performing replacements.
-
-Examples:
-  >>> x, y = sym.symbols('x, y')
-  >>> sym.cos(x).subs([(x, y*2), (y, sym.pi)])
-  1
-  >>> (sym.pow(x, 2) * y).subs(x * y, 3)
-  3*x
-  >>> (x + 2*y - 5).subs(x + 2*y, y)
-  -5 + y
-)doc";
-
 inline constexpr std::string_view scalar_expr_eval = R"doc(
 Evaluate the mathematical expression into a numeric value. Traverses the expression tree, converting
 every numeric literal and constant into a double precision float. Operations are recursively

--- a/components/wrapper/pywrenfold/docs/symbolic_functions_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/symbolic_functions_wrapper.h
@@ -1,0 +1,56 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+#include <string_view>
+
+namespace wf::docstrings {
+
+inline constexpr std::string_view distribute = R"doc(
+Expand the mathematical expression. ``distribute`` will recursively traverse the expression tree and
+multiply out any product of additions and subtractions. For example:
+
+.. math::
+  \left(x + y\right)\cdot(4 - y) \rightarrow 4 \cdot x + 4  \cdot y - x  \cdot y - y^{2}
+
+Powers of the form :math:`f\left(x\right)^{\frac{n}{2}}` where :math:`n` is an integer are also
+expanded:
+
+.. math::
+  \left(x + 2\right)^{\frac{3}{2}} \rightarrow x \cdot \left(x + 2\right)^{\frac{1}{2}} +
+  2 \cdot \left(x + 2\right)^{\frac{1}{2}}
+
+Returns:
+  The input expression after expansion.
+
+Examples:
+  >>> x, y = sym.symbols('x, y')
+  >>> f = (x - 2) * (y + x) * (y - 3)
+  >>> f.distribute()
+  6*x + 6*y - 5*x*y + x**2*y + x*y**2 - 3*x**2 - 2*y**2
+)doc";
+
+inline constexpr std::string_view subs = R"doc(
+Traverse the expression tree and replace target expressions with corresponding substitutions. The
+list of replacements is executed *in order*, such that substitutions that appear later in the list
+of ``(target, replacement)`` pairs may leverage the result of earlier ones.
+
+Args:
+  pairs: A list of tuples. Each tuple contains a ``(target, replacement)`` pair, where the *target*
+    is the expression to find and the *replacement* is the expression to substitute in its place.
+    The pairs may be scalar-valued or boolean-valued expressions.
+
+Returns:
+  The input expression after performing replacements.
+
+Examples:
+  >>> x, y = sym.symbols('x, y')
+  >>> sym.cos(x).subs([(x, y*2), (y, sym.pi)])
+  1
+  >>> (sym.pow(x, 2) * y).subs(x * y, 3)
+  3*x
+  >>> (x + 2*y - 5).subs(x + 2*y, y)
+  -5 + y
+)doc";
+
+}  // namespace wf::docstrings

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -18,6 +18,7 @@
 #include "wf/numerical_casts.h"
 
 #include "docs/matrix_wrapper.h"
+#include "visitor_wrappers.h"
 #include "wrapper_utils.h"
 
 namespace py = pybind11;
@@ -353,7 +354,7 @@ void wrap_matrix_operations(py::module_& m) {
           "vars"_a, py::arg("use_abstract") = false,
           "See :func:`wrenfold.sym.jacobian`. Equivalent to ``sym.jacobian(self, vars)``.")
       .def("distribute", &matrix_expr::distribute,
-           "Invoke :func:`wrenfold.sym.Expr.distribute` on every element of the matrix.")
+           "Invoke :func:`wrenfold.sym.distribute` on every element of the matrix.")
       .def("subs", &substitute_wrapper_single<matrix_expr, scalar_expr>, py::arg("target"),
            py::arg("substitute"),
            "Overload of ``subs`` that performs a single scalar-valued substitution.")
@@ -361,7 +362,7 @@ void wrap_matrix_operations(py::module_& m) {
            py::arg("substitute"),
            "Overload of ``subs`` that performs a single boolean-valued substitution.")
       .def("subs", &substitute_wrapper<matrix_expr>, py::arg("pairs"),
-           "Invoke :func:`wrenfold.sym.Expr.subs` on every element of the matrix.")
+           "Invoke :func:`wrenfold.sym.subs` on every element of the matrix.")
       .def(
           "eval",
           [](const matrix_expr& self) {

--- a/components/wrapper/pywrenfold/scalar_wrapper.cc
+++ b/components/wrapper/pywrenfold/scalar_wrapper.cc
@@ -27,6 +27,7 @@
 
 #include "args_visitor.h"
 #include "docs/scalar_wrapper.h"
+#include "visitor_wrappers.h"
 #include "wrapper_utils.h"
 
 namespace py = pybind11;
@@ -154,8 +155,9 @@ void wrap_scalar_operations(py::module_& m) {
           },
           "var"_a, py::arg("order") = 1, py::arg("use_abstract") = false,
           docstrings::scalar_expr_diff.data())
-      .def("distribute", &scalar_expr::distribute, docstrings::scalar_expr_distribute.data())
-      .def("subs", &substitute_wrapper<scalar_expr>, py::arg("pairs"), docstrings::subs.data())
+      .def("distribute", &scalar_expr::distribute, "See :func:`wrenfold.sym.distribute`.")
+      .def("subs", &substitute_wrapper<scalar_expr>, py::arg("pairs"),
+           "See :func:`wrenfold.sym.subs`.")
       .def("subs", &substitute_wrapper_single<scalar_expr, scalar_expr>, py::arg("target"),
            py::arg("substitute"),
            "Overload of ``subs`` that performs a single scalar-valued substitution.")

--- a/components/wrapper/pywrenfold/symbolic_functions_wrapper.cc
+++ b/components/wrapper/pywrenfold/symbolic_functions_wrapper.cc
@@ -1,0 +1,39 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#define PYBIND11_DETAILED_ERROR_MESSAGES
+#include <pybind11/pybind11.h>
+
+#include "wf/distribute.h"  //  distribute_visitor
+
+#include "docs/symbolic_functions_wrapper.h"
+#include "visitor_wrappers.h"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace wf {
+
+template <typename Visitor>
+auto wrap_visitor_with_any_expression_arg() {
+  return [](const any_const_ptr_to_expression& expr) {
+    Visitor visitor{};
+    return std::visit([&visitor](const auto& x) -> any_expression { return visitor(*x); }, expr);
+  };
+}
+
+void wrap_symbolic_functions(py::module_& m) {
+  m.def("distribute", wrap_visitor_with_any_expression_arg<distribute_visitor>(), py::arg("expr"),
+        wf::docstrings::distribute.data());
+
+  m.def("subs", &substitute_wrapper<any_const_ptr_to_expression>, py::arg("expr"), py::arg("pairs"),
+        wf::docstrings::subs.data());
+  m.def("subs", &substitute_wrapper_single<any_const_ptr_to_expression, scalar_expr>,
+        py::arg("expr"), py::arg("target"), py::arg("replacement"),
+        "Overload of ``subs`` that performs a single scalar-valued substitution.");
+  m.def("subs", &substitute_wrapper_single<any_const_ptr_to_expression, boolean_expr>,
+        py::arg("expr"), py::arg("target"), py::arg("replacement"),
+        "Overload of ``subs`` that performs a single boolean-valued substitution.");
+}
+
+}  // namespace wf

--- a/components/wrapper/pywrenfold/visitor_wrappers.h
+++ b/components/wrapper/pywrenfold/visitor_wrappers.h
@@ -1,0 +1,78 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>  // Required to pass std::vector.
+
+#include "wf/any_expression.h"
+#include "wf/substitute.h"
+
+#include "wrapper_utils.h"
+
+// This file is mostly a gross nuisance to handle the fact that we cannot pass std::variant
+// directly to pybind methods (because it cannot be default initialized). So instead we have to
+// write some adapter code so those methods can be wrapped - typically by passing a variant of
+// const-pointers (which will at least produce correct type annotations). I'd like to be able
+// to delete all of this.
+namespace wf {
+
+// Create a std::variant of const pointers to the types in `any_expression`:
+template <typename T>
+using add_const_ptr = std::add_pointer_t<std::add_const_t<T>>;
+using any_expression_types = type_list_from_variant_t<any_expression>;
+using any_const_ptr_to_expression =
+    variant_from_type_list_t<type_list_map_t<add_const_ptr, any_expression_types>>;
+
+// Accept variant of any_expression types const-ptr, and de-reference (copying in the process).
+inline any_expression deref_any_ptr_to_expression(const any_const_ptr_to_expression& ptrs) {
+  return std::visit(
+      [](const auto ptr) -> any_expression {
+        WF_ASSERT(ptr);
+        return *ptr;
+      },
+      ptrs);
+}
+
+using scalar_ptr_pair = std::tuple<const scalar_expr*, const scalar_expr*>;
+using boolean_ptr_pair = std::tuple<const boolean_expr*, const boolean_expr*>;
+using scalar_ptr_or_boolean_ptr_pair = std::variant<scalar_ptr_pair, boolean_ptr_pair>;
+
+// Wrapper for substitute() method that accepts a list of tuples.
+template <typename X>
+auto substitute_wrapper(const X& self, const std::vector<scalar_ptr_or_boolean_ptr_pair>& pairs) {
+  // TODO: This conversion is a bit annoying, but it allows us to have correct type annotations.
+  // We can probably avoid this by switching to nanobind.
+  // See: https://github.com/wrenfold/wrenfold/issues/198
+  const auto pairs_copied = transform_map<std::vector>(pairs, [](const auto& pair) {
+    return std::visit(
+        [](const auto& p) -> scalar_or_boolean_pair {
+          return std::apply(
+              [](auto... ptrs) {
+                WF_ASSERT((static_cast<bool>(ptrs) && ...));
+                return std::make_tuple(*ptrs...);
+              },
+              p);
+        },
+        pair);
+  });
+
+  if constexpr (std::is_same_v<X, any_const_ptr_to_expression>) {
+    return substitute_any(deref_any_ptr_to_expression(self), pairs_copied);
+  } else {
+    return substitute(self, pairs_copied);
+  }
+}
+
+// Wrapper for the single-replacement version of `substitute`.
+template <typename X1, typename X2>
+auto substitute_wrapper_single(const X1& self, const X2& target, const X2& replacement) {
+  const std::array<scalar_or_boolean_pair, 1> pairs = {std::make_tuple(target, replacement)};
+  if constexpr (std::is_same_v<X1, any_const_ptr_to_expression>) {
+    return substitute_any(deref_any_ptr_to_expression(self), pairs);
+  } else {
+    return substitute(self, pairs);
+  }
+}
+
+}  // namespace wf

--- a/components/wrapper/pywrenfold/wrapper.cc
+++ b/components/wrapper/pywrenfold/wrapper.cc
@@ -36,6 +36,9 @@ void wrap_compound_expression(py::module_& m);
 // Defined in boolean_expression_wrapper.cc
 void wrap_boolean_expression(py::module_& m);
 
+// Defined in symbolic_functions_wrapper.cc
+void wrap_symbolic_functions(py::module_& m);
+
 // Defined in geometry_wrapper.cc
 void wrap_geometry_operations(py::module_& m);
 
@@ -74,6 +77,7 @@ PYBIND11_MODULE(PY_MODULE_NAME, m) {
   wrap_scalar_operations(m_sym);
   wrap_matrix_operations(m_sym);
   wrap_compound_expression(m_sym);
+  wrap_symbolic_functions(m_sym);
 
   auto m_expressions =
       m.def_submodule(PY_SUBMODULE_NAME_EXPRESSIONS, "Wrapped concrete expressions.");

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -276,6 +276,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(
             a * c * e + a * c * f + a * d * e + a * d * f + b * c * e + b * c * f + b * d * e +
             b * d * f, expr.distribute())
+        self.assertIdentical(expr.distribute(), sym.distribute(expr))
 
     def test_diff(self):
         """Test calling diff on scalar expressions."""
@@ -347,9 +348,9 @@ class ExpressionWrapperTest(MathTestBase):
         x, y, z = sym.symbols('x, y, z')
         self.assertIdentical(x, x.subs(x, x))
         self.assertIdentical(y, x.subs(x, y))
-        self.assertIdentical(2.5, x.subs(x, 2.5))
+        self.assertIdentical(2.5, sym.subs(x, x, 2.5))
         self.assertIdentical(0, (x - y).subs(y, x))
-        self.assertIdentical(1, (x / z).subs(z, x))
+        self.assertIdentical(1, sym.subs(x / z, z, x))
         self.assertIdentical(z ** 2 * x, (x ** 3 * y ** 2).subs(x * y, z))
         self.assertIdentical(2 * z, (x + 2 * z - (y * 3) / 2).subs(x - (y * 3) / 2, 0))
         self.assertIdentical(sym.cos(y + 1), sym.cos(x).subs(x, y + 1))
@@ -361,7 +362,7 @@ class ExpressionWrapperTest(MathTestBase):
         # Boolean substitution:
         f = sym.where(x > y, sym.cos(x), sym.abs(y))
         self.assertIdentical(sym.cos(x), f.subs(x > y, sym.true))
-        self.assertIdentical(sym.abs(y), f.subs(x > y, sym.false))
+        self.assertIdentical(sym.abs(y), sym.subs(f, x > y, sym.false))
 
     def test_collect(self):
         """Test calling collect() on expressions."""

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -389,6 +389,7 @@ class MatrixWrapperTest(MathTestBase):
                        sym.sin(x) * y + sym.sin(x) * 2),
             m.distribute(),
         )
+        self.assertIdentical(m.distribute(), sym.distribute(m))
 
     def test_collect(self):
         """Test calling collect on a matrix."""
@@ -430,6 +431,7 @@ class MatrixWrapperTest(MathTestBase):
             sym.matrix([(0, b - c), (c - sym.sin(y), z)]),
             m1.subs(a, -x * 2).subs(d + sym.log(d), z),
         )
+        self.assertIdentical(m1.subs(a, -x * 2), sym.subs(m1, a, -x * 2))
         self.assertIdentical(
             sym.matrix([(3 * x, b - 4), (4 - sym.sin(x), d + sym.log(d))]),
             m1.subs([(a, x), (c, 4), (y, x)]))
@@ -438,6 +440,7 @@ class MatrixWrapperTest(MathTestBase):
         m2 = sym.where(a > d, sym.vector(a, b, c), sym.vector(x, y, z))
         self.assertIdentical(sym.vector(a, b, c), m2.subs(a > d, sym.true))
         self.assertIdentical(sym.vector(x, y, z), m2.subs(a > d, sym.false))
+        self.assertIdentical(m2.subs(a > d, sym.false), sym.subs(m2, a > d, sym.false))
 
     def test_matrix_conditional(self):
         """Test creating a matrix conditional."""

--- a/docs/source/python_api/sym.rst
+++ b/docs/source/python_api/sym.rst
@@ -19,6 +19,8 @@ sym
 
 .. autofunction:: wrenfold.sym.atanh
 
+.. autofunction:: wrenfold.sym.compare
+
 .. autofunction:: wrenfold.sym.cos
 
 .. autofunction:: wrenfold.sym.cosh
@@ -28,6 +30,8 @@ sym
 .. autofunction:: wrenfold.sym.det
 
 .. autofunction:: wrenfold.sym.diag
+
+.. autofunction:: wrenfold.sym.distribute
 
 .. autofunction:: wrenfold.sym.eliminate_subexpressions
 
@@ -84,6 +88,8 @@ sym
 .. autofunction:: wrenfold.sym.sinh
 
 .. autofunction:: wrenfold.sym.sqrt
+
+.. autofunction:: wrenfold.sym.subs
 
 .. autofunction:: wrenfold.sym.substitution
 


### PR DESCRIPTION
Having `subs`, `distribute` (and eventually other visitor methods) be free functions is more scalable because then they can accept `any_expression` and work with any expression type. This is easier to maintain than adding member functions for every expression type, and having to do `def("blah", &blah, ...)` on every class wrapper.

Now the user can do:
```python
>>> from wrenfold import sym
>>> x, y = sym.symbols('x, y')
>>> sym.subs(x + 3, x, y)
y + 3
```

Additional changes:
- Delete superfluous `map_matrix_expression` and `map_compound_expressions` methods from `expression_visitor.h`