### PR TITLE
`sym.derivative` simplifies to zero when argument is not relevant to the differentiand

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -258,6 +258,11 @@ TEST(DerivativesTest, TestDerivativeExpression) {
   ASSERT_IDENTICAL(derivative::create(abs(x + y), x, 2), f.diff(x));
   ASSERT_IDENTICAL(derivative::create(f, y, 1), f.diff(y));
   ASSERT_IDENTICAL(0, f.diff(z));
+
+  // Test that `derivative::create` simplifies automatically:
+  ASSERT_IDENTICAL(0, derivative::create(x, y, 1));
+  ASSERT_IDENTICAL(0, derivative::create(cos(x) + 5 * y, z, 2));
+  ASSERT_IDENTICAL(0, derivative::create(symbolic_function("f")(y * y, z), x, 1));
 }
 
 TEST(DerivativesTest, TestUnevaluated) {

--- a/components/core/wf/expressions/derivative_expression.cc
+++ b/components/core/wf/expressions/derivative_expression.cc
@@ -4,6 +4,7 @@
 #include "wf/expressions/derivative_expression.h"
 
 #include "wf/constants.h"
+#include "wf/utility_visitors.h"
 
 namespace wf {
 
@@ -15,6 +16,13 @@ scalar_expr derivative::create(scalar_expr function, scalar_expr arg, int order)
   if (!arg.is_type<variable>()) {
     throw type_error("Derivatives can only be taken with respect to variables. Arg = {}",
                      arg.to_string());
+  }
+
+  // Inspect `derivative` to see if it is not a function of its own argument:
+  //  diff(f(y), x) --> 0, since f(y) is not a function of `x`.
+  // TODO: This operation should really memoize as it searches `function`.
+  if (!is_function_of(function, arg)) {
+    return constants::zero;
   }
 
   if (const derivative* d = get_if<const derivative>(function);


### PR DESCRIPTION
This change will cause `sym.derivative(f, x)` to simplify to zero automatically when `f` is not a function of `x`.

This mirrors the behavior in SymPy: `sp.Derivative(f, x).doit()` or `sp.Derivative(f, x).simplify()`.

Previously this could be a little annoying as a default, since you might wish to express the derivative of some abstract function with respect to, say, time. However, as of https://github.com/wrenfold/wrenfold/pull/254 there is an official faculty for expressing such functions.