### PR TITLE
Enable taking derivatives wrt symbolic function invocations

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -321,7 +321,32 @@ TEST(DerivativesTest, TestSymbolicFunction) {
   }
 }
 
-TEST(DerivativeTest, TestSubstitution) {
+TEST(DerivativesTest, TestWrtSymbolicFunction) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+  const auto f = symbolic_function("f");
+  const auto g = symbolic_function("g");
+
+  // A symbolic function wrt itself:
+  ASSERT_IDENTICAL(1, f(x).diff(f(x)));
+  ASSERT_IDENTICAL(1, f(x, y + z).diff(f(x, y + z)));
+
+  // Symbolic function wrt other symbolic function is zero (this matches SymPy).
+  ASSERT_IDENTICAL(0, f(x).diff(g(x)));
+  ASSERT_IDENTICAL(0, f(x).diff(g(f(x))));
+
+  // Other expressions wrt symbolic function:
+  ASSERT_IDENTICAL(-sin(f(x) * 2) * 2, cos(f(x) * 2).diff(f(x)));
+  ASSERT_IDENTICAL(2 * f(x), (f(x) * f(x) + 2).diff(f(x)));
+
+  // Check that: d( df(x, y)/dx ) / df(x, y) --> 0 (this also matches SymPy).
+  ASSERT_IDENTICAL(0, derivative::create(f(x, y), x, 1).diff(f(x, y)));
+
+  // Create a derivative wrt a symbolic function invocation:
+  ASSERT_IDENTICAL(derivative::create(signum(f(x)), f(x), 1),
+                   signum(f(x)).diff(f(x), 1, non_differentiable_behavior::abstract));
+}
+
+TEST(DerivativesTest, TestSubstitution) {
   const scalar_expr x{"x", number_set::real};
   const auto [y, z] = make_symbols("y", "z");
   const auto f = symbolic_function("f");

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -4,7 +4,6 @@
 #pragma once
 #include <unordered_map>
 
-#include "wf/compound_expression.h"
 #include "wf/enumerations.h"
 #include "wf/expression.h"
 #include "wf/matrix_expression.h"

--- a/components/core/wf/expressions/derivative_expression.cc
+++ b/components/core/wf/expressions/derivative_expression.cc
@@ -3,8 +3,6 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/expressions/derivative_expression.h"
 
-#include "wf/constants.h"
-
 namespace wf {
 
 scalar_expr derivative::create(scalar_expr function, scalar_expr arg, int order) {
@@ -12,9 +10,11 @@ scalar_expr derivative::create(scalar_expr function, scalar_expr arg, int order)
     throw invalid_argument_error("Order of the derivative must be >= 1");
   }
 
-  if (!arg.is_type<variable>()) {
-    throw type_error("Derivatives can only be taken with respect to variables. Arg = {}",
-                     arg.to_string());
+  if (!arg.is_type<variable, symbolic_function_invocation>()) {
+    throw type_error(
+        "Derivatives can only be taken with respect to variables and other symbolic functions. Arg "
+        "= {}",
+        arg.to_string());
   }
 
   if (const derivative* d = get_if<const derivative>(function);


### PR DESCRIPTION
The title of the PR more or less says it all. This change enables taking derivatives (using `diff` or `jacobian`) with respect to symbolic function invocations (added in https://github.com/wrenfold/wrenfold/pull/254). Previously derivatives could only be taken wrt variables.

For example, you can do:

```python
>>> f = sym.Function('f')
>>> t = sym.symbols('t')
>>> g =  f(t).diff(t) * -0.3 + (f(t) ** 2) * sym.pi
>>> g.diff(f(t))
2*pi*f(t)
```

This behavior matches that of SymPy. Notably: 
```python
>>> f(t).diff(t).diff(f(t))
0
```
`f(t)` (for the purpose of differentiation) is treated as a variable, such that `d[Derivative(f(t), t)] / df(t) --> Derivative(1, t) --> 0`