### PR TITLE
Cleanup CMake + fix brittleness with docs build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(MSVC)
   # incorrectly.
   set(WF_SHARED_WARNING_FLAGS /W4 /WX /wd4702)
 else()
-  set(WF_SHARED_WARNING_FLAGS -Wall -Wextra -pedantic -Werror -Wno-sign-compare)
+  set(WF_SHARED_WARNING_FLAGS -Wall -Wextra -pedantic -Werror)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,14 @@ if(DEFINED SKBUILD_PROJECT_NAME AND DEFINED SKBUILD_PROJECT_VERSION)
     DESCRIPTION "Tools for generating code from symbolic math."
     LANGUAGES CXX)
   message(STATUS "Building project version: ${SKBUILD_PROJECT_VERSION}")
-  set(BUILD_EXTRAS_DEFAULT OFF)
+  set(WF_BUILD_EXTRAS_DEFAULT OFF)
 else()
   project(wrenfold CXX)
-  set(BUILD_EXTRAS_DEFAULT ON)
+  set(WF_BUILD_EXTRAS_DEFAULT ON)
 endif()
 
 enable_testing()
 include(GNUInstallDirs)
-set(CMAKE_COLOR_MAKEFILE ON)
 
 # Find python (for pybind11)
 find_package(
@@ -26,7 +25,7 @@ message(STATUS "Python_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}")
 message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")
 
 option(WF_BUILD_EXTRAS "Build tests, benchmarks, examples, and docs."
-       ${BUILD_EXTRAS_DEFAULT})
+       ${WF_BUILD_EXTRAS_DEFAULT})
 
 # Add third party code
 add_subdirectory(dependencies)
@@ -41,21 +40,21 @@ set_python_env_variables()
 if(MSVC)
   # We turn off C4702 (unreachable code) because constexpr blocks trigger it
   # incorrectly.
-  set(SHARED_WARNING_FLAGS /W4 /WX /wd4244 /wd4702)
+  set(WF_SHARED_WARNING_FLAGS /W4 /WX /wd4702)
 else()
-  set(SHARED_WARNING_FLAGS -Wall -Wextra -pedantic -Werror -Wno-sign-compare)
+  set(WF_SHARED_WARNING_FLAGS -Wall -Wextra -pedantic -Werror -Wno-sign-compare)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # Disable unused parameter warning (triggered by if constexpr)
-  list(APPEND SHARED_WARNING_FLAGS -Wno-unused-parameter
+  list(APPEND WF_SHARED_WARNING_FLAGS -Wno-unused-parameter
        -Wno-unused-but-set-parameter)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL
                                              "AppleClang")
   # Disable unused local typedef on Clang:
-  list(APPEND SHARED_WARNING_FLAGS -Wno-unused-local-typedef)
+  list(APPEND WF_SHARED_WARNING_FLAGS -Wno-unused-local-typedef)
 endif()
 
 # Custom target that groups together all the rust code-generation.

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -6,11 +6,11 @@ define_property(
   BRIEF_DOCS ${GENERATED_SOURCE_FILE_DOCS}
   FULL_DOCS ${GENERATED_SOURCE_FILE_DOCS})
 
-# Set the `PYTHON_COMMAND_ENV_VARIABLES` variable with environment variables
-# that can be be passed to `cmake -E env` when running python scripts. This
-# places both the python library, and pywrenfold (pybind11 wrapper) on the
-# PYTHONPATH. Ideally we would get these paths from the targets themselves, but
-# the order in which targets are added makes that tricky.
+# Set the `WF_PYTHON_ENV_VARIABLES` variable with environment variables that can
+# be be passed to `cmake -E env` when running python scripts. This places both
+# the python library, and pywrenfold (pybind11 wrapper) on the PYTHONPATH.
+# Ideally we would get these paths from the targets themselves, but the order in
+# which targets are added makes that tricky.
 function(set_python_env_variables)
   set(COMPONENTS_BINARY_DIR "${CMAKE_BINARY_DIR}/components")
   set(COMPONENTS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/components")
@@ -21,7 +21,7 @@ function(set_python_env_variables)
   else()
     set(PATH_SEP ":")
   endif()
-  set(PYTHON_COMMAND_ENV_VARIABLES
+  set(WF_PYTHON_ENV_VARIABLES
       "PYTHONPATH=${COMPONENTS_BINARY_DIR}/wrapper${PATH_SEP}${COMPONENTS_SOURCE_DIR}/python"
       PARENT_SCOPE)
 endfunction()
@@ -54,7 +54,7 @@ function(add_compiled_code_generator NAME)
   target_compile_definitions(
     ${generate_target}
     PRIVATE "-DGENERATOR_OUTPUT_FILE=\"${GENERATOR_OUTPUT_FILE}\"")
-  target_compile_options(${generate_target} PRIVATE ${SHARED_WARNING_FLAGS})
+  target_compile_options(${generate_target} PRIVATE ${WF_SHARED_WARNING_FLAGS})
   add_dependencies(${generate_target} ${generate_target}_mkdir)
 
   # Record the output file as a custom property on the target:
@@ -117,7 +117,7 @@ function(add_cpp_test NAME)
     gtest
     eigen
     fmt::fmt-header-only)
-  target_compile_options(${NAME} PRIVATE ${SHARED_WARNING_FLAGS})
+  target_compile_options(${NAME} PRIVATE ${WF_SHARED_WARNING_FLAGS})
   if(NOT MSVC)
     target_compile_options(${NAME} PRIVATE -Wno-unused-comparison)
   endif()
@@ -170,8 +170,8 @@ function(add_py_code_generator NAME MAIN_SCRIPT_FILE)
   add_custom_command(
     OUTPUT ${GENERATOR_OUTPUT_FILE}
     COMMAND
-      ${CMAKE_COMMAND} -E env ${PYTHON_COMMAND_ENV_VARIABLES}
-      ${Python_EXECUTABLE} -B "${CMAKE_CURRENT_SOURCE_DIR}/${MAIN_SCRIPT_FILE}"
+      ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES} ${Python_EXECUTABLE} -B
+      "${CMAKE_CURRENT_SOURCE_DIR}/${MAIN_SCRIPT_FILE}"
       "${GENERATOR_OUTPUT_FILE}" ${ARGS_SCRIPT_ARGUMENTS}
     WORKING_DIRECTORY ${GENERATOR_OUTPUT_DIR}
     COMMENT "Run python code-generator: ${NAME}"
@@ -237,8 +237,8 @@ function(add_python_test PYTHON_SOURCE_FILE)
   if(NOT DEFINED Python_EXECUTABLE)
     message(FATAL_ERROR "The Python executable could not be located.")
   endif()
-  if(NOT DEFINED PYTHON_COMMAND_ENV_VARIABLES)
-    message(FATAL_ERROR "PYTHON_COMMAND_ENV_VARIABLES should be defined")
+  if(NOT DEFINED WF_PYTHON_ENV_VARIABLES)
+    message(FATAL_ERROR "WF_PYTHON_ENV_VARIABLES should be defined")
   endif()
 
   # In order for `PYTHONPATH` to be set correctly, we need to pass the
@@ -247,8 +247,8 @@ function(add_python_test PYTHON_SOURCE_FILE)
   add_test(
     NAME ${TEST_NAME}
     COMMAND
-      ${CMAKE_COMMAND} -E env ${PYTHON_COMMAND_ENV_VARIABLES}
-      ${Python_EXECUTABLE} -B ${CMAKE_CURRENT_SOURCE_DIR}/${PYTHON_SOURCE_FILE}
+      ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES} ${Python_EXECUTABLE}
+      -B ${CMAKE_CURRENT_SOURCE_DIR}/${PYTHON_SOURCE_FILE}
       ${ARGS_SCRIPT_ARGUMENTS})
   message(STATUS "Added python test: ${TEST_NAME}")
 endfunction()

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -142,20 +142,14 @@ target_compile_features(wf_core PUBLIC cxx_std_17)
 # Set -fPIC since we will need to build shared libraries for python.
 set_target_properties(wf_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# Append our shared warning flags.
+message(STATUS "Warning flags set to: ${WF_SHARED_WARNING_FLAGS}")
+target_compile_options(wf_core PRIVATE ${WF_SHARED_WARNING_FLAGS})
+
 if(MSVC)
-  set(LIB_COMPILATION_FLAGS_PRIVATE /bigobj /EHs)
-  set(LIB_COMPILATION_FLAGS_PUBLIC /Zc:__cplusplus)
-else()
-  set(LIB_COMPILATION_FLAGS_PRIVATE "")
-  set(LIB_COMPILATION_FLAGS_PUBLIC "")
+  target_compile_options(wf_core PRIVATE /bigobj /EHs)
 endif()
 
-# Append our shared warning flags.
-list(APPEND LIB_COMPILATION_FLAGS_PRIVATE ${SHARED_WARNING_FLAGS})
-message(STATUS "Warning flags set to: ${SHARED_WARNING_FLAGS}")
-
-target_compile_options(wf_core PRIVATE ${LIB_COMPILATION_FLAGS_PRIVATE})
-target_compile_options(wf_core PUBLIC ${LIB_COMPILATION_FLAGS_PUBLIC})
 target_link_libraries(wf_core wf_runtime fmt::fmt-header-only
                       absl::inlined_vector absl::span absl::flat_hash_set)
 if(WIN32)

--- a/components/core/benchmarks/CMakeLists.txt
+++ b/components/core/benchmarks/CMakeLists.txt
@@ -7,7 +7,7 @@ function(add_benchmark SOURCE_FILE)
   message(STATUS "Adding benchmark: ${BENCH_NAME}")
   add_executable(${BENCH_NAME} ${SOURCE_FILE})
   target_link_libraries(${BENCH_NAME} wf_core benchmark::benchmark)
-  target_compile_options(${BENCH_NAME} PRIVATE ${SHARED_WARNING_FLAGS})
+  target_compile_options(${BENCH_NAME} PRIVATE ${WF_SHARED_WARNING_FLAGS})
 endfunction()
 
 # Add all of our benchmarks:

--- a/components/core/test_support/CMakeLists.txt
+++ b/components/core/test_support/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(wf_test_support INTERFACE wf_runtime gtest eigen
 add_library(wf_custom_main OBJECT custom_main.cc)
 target_link_libraries(wf_custom_main gtest)
 target_compile_features(wf_custom_main PRIVATE cxx_std_17)
-target_compile_options(wf_custom_main PRIVATE ${SHARED_WARNING_FLAGS})
+target_compile_options(wf_custom_main PRIVATE ${WF_SHARED_WARNING_FLAGS})

--- a/components/core/tests/factorizer_test.cc
+++ b/components/core/tests/factorizer_test.cc
@@ -5,16 +5,16 @@
 
 #include <random>
 
-#include "wf/utility/algorithms.h"
+#include <gtest/gtest.h>
+
 #include "wf/utility/bitset_range.h"
-#include "wf_test_support/test_macros.h"
 
 namespace wf {
 
 inline factor_bits fill_bits(const std::initializer_list<int> indices) {
   factor_bits b{};
   for (auto index : indices) {
-    WF_ASSERT_LT(index, b.size());
+    WF_ASSERT_LT(static_cast<std::size_t>(index), b.size());
     b.set(index);
   }
   return b;
@@ -36,9 +36,9 @@ std::ostream& operator<<(std::ostream& s, const factorization& f) {
   return s;
 }
 
-void check_factorizations(const std::vector<factorization>& facs,
+void check_factorizations(const std::vector<factorization>& factorizations,
                           const absl::Span<const factor_bits> input_terms) {
-  for (const factorization& fac : facs) {
+  for (const factorization& fac : factorizations) {
     // Check that all the factors aren't trampling on each other:
     for (std::size_t i = 0; i < fac.size(); ++i) {
       const auto [vi, ti] = fac[i];

--- a/components/core/tests/quaternion_test.cc
+++ b/components/core/tests/quaternion_test.cc
@@ -621,7 +621,8 @@ TEST(QuaternionTest, TestFromRotationMatrix) {
     // Compute the sign flip so that signs match:
     Eigen::Index max_index{};
     q_num.coeffs().cwiseAbs().maxCoeff(&max_index);
-    const double sign = q_num.coeffs()[max_index] / cast_to_float(q.to_vector_xyzw()[max_index]);
+    const double sign = q_num.coeffs()[max_index] /
+                        cast_to_float(q.to_vector_xyzw()[static_cast<wf::index_t>(max_index)]);
 
     ASSERT_NEAR(q_num.w(), sign * cast_to_float(q.w()), 1.0e-15)
         << fmt::format("q_num = [{}, {}, {}, {}]\nq = {}\nR:\n{}", q_num.w(), q_num.x(), q_num.y(),

--- a/components/core/wf/matrix_functions.cc
+++ b/components/core/wf/matrix_functions.cc
@@ -360,7 +360,7 @@ static matrix_expr create_matrix_from_permutations(const permutation_matrix& P) 
   const auto span = make_span(data.data(), make_value_pack(P.rows(), P.rows()),
                               make_value_pack(P.rows(), constant<1>{}));
 
-  for (index_t row = 0; row < P.rows(); ++row) {
+  for (index_t row = 0; row < static_cast<index_t>(P.rows()); ++row) {
     span(row, P.permuted_row(row)) = constants::one;
   }
   return matrix_expr::create(static_cast<index_t>(P.rows()), static_cast<index_t>(P.rows()),

--- a/components/runtime/CMakeLists.txt
+++ b/components/runtime/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Create a target for the runtime library (a header only target).
-set(RUNTIME_INTERFACE_NAME wf_runtime)
 set(RUNTIME_SOURCES wrenfold/span.h wrenfold/span_detail.h)
-add_library(${RUNTIME_INTERFACE_NAME} INTERFACE ${RUNTIME_SOURCES})
+add_library(wf_runtime INTERFACE ${RUNTIME_SOURCES})
 target_include_directories(
-  ${RUNTIME_INTERFACE_NAME}
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-            $<INSTALL_INTERFACE:include>)
+  wf_runtime INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                       $<INSTALL_INTERFACE:include>)
 
 if(WF_BUILD_EXTRAS)
   add_subdirectory(tests)

--- a/components/runtime/tests/CMakeLists.txt
+++ b/components/runtime/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(span_test span_test.cc)
 target_link_libraries(span_test gtest_main)
 target_link_libraries(span_test wf_runtime eigen fmt::fmt-header-only)
 target_compile_features(span_test PRIVATE cxx_std_17)
-target_compile_options(span_test PRIVATE ${SHARED_WARNING_FLAGS})
+target_compile_options(span_test PRIVATE ${WF_SHARED_WARNING_FLAGS})
 
 # Enable support for Eigen --> span conversion so we can test it.
 target_compile_definitions(span_test PRIVATE -DWF_SPAN_EIGEN_SUPPORT)

--- a/components/runtime/tests/span_test.cc
+++ b/components/runtime/tests/span_test.cc
@@ -230,7 +230,7 @@ TEST(SpanTest, TestMakeArraySpan) {
   EXPECT_EQ(5, span.rows());
   EXPECT_EQ(5, span.dimension<0>());
   EXPECT_EQ(1, span.stride<0>());
-  for (int i = 0; i < data.size(); ++i) {
+  for (std::size_t i = 0; i < data.size(); ++i) {
     EXPECT_EQ(i + 1, span[i]);
   }
 }
@@ -431,8 +431,8 @@ TEST(SpanTest, TestEigenMap) {
 // Then we check that our span does not include any zero elements.
 template <typename Dimensions, typename Strides>
 void check_non_zero(const wf::span<const int, Dimensions, Strides>& span) {
-  for (int i = 0; i < span.rows(); ++i) {
-    for (int j = 0; j < span.cols(); ++j) {
+  for (std::size_t i = 0; i < span.rows(); ++i) {
+    for (std::size_t j = 0; j < span.cols(); ++j) {
       ASSERT_NE(0, span(i, j));
     }
   }

--- a/components/wrapper/CMakeLists.txt
+++ b/components/wrapper/CMakeLists.txt
@@ -21,7 +21,7 @@ function(add_wrapper_module)
 
   # Depend on the static library
   target_link_libraries(${MODULE_NAME} PRIVATE wf_core)
-  target_compile_options(${MODULE_NAME} PRIVATE ${SHARED_WARNING_FLAGS})
+  target_compile_options(${MODULE_NAME} PRIVATE ${WF_SHARED_WARNING_FLAGS})
   target_compile_definitions(${MODULE_NAME}
                              PRIVATE PY_MODULE_NAME=${MODULE_NAME})
   if(DEFINED SKBUILD_PROJECT_VERSION)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -2,7 +2,9 @@ function(add_libfmt)
   set(FMT_TEST
       OFF
       CACHE BOOL "" FORCE) # Turn off libfmt tests
-  add_subdirectory(fmt EXCLUDE_FROM_ALL) # Don't need to install.
+  if(NOT TARGET fmt::fmt-header-only)
+    add_subdirectory(fmt EXCLUDE_FROM_ALL) # Don't need to install.
+  endif()
 endfunction()
 add_libfmt()
 
@@ -13,7 +15,9 @@ function(add_gtest)
   set(INSTALL_GTEST
       OFF
       CACHE BOOL "" FORCE)
-  add_subdirectory(gtest)
+  if(NOT TARGET gtest)
+    add_subdirectory(gtest)
+  endif()
 endfunction()
 
 if(WF_BUILD_EXTRAS)
@@ -32,7 +36,9 @@ function(add_google_benchmark)
     # Turn off warning about failure to specify /EHs
     add_compile_options(/wd4530)
   endif()
-  add_subdirectory(benchmark)
+  if(NOT TARGET benchmark::benchmark)
+    add_subdirectory(benchmark)
+  endif()
 endfunction()
 
 if(WF_BUILD_EXTRAS)
@@ -57,13 +63,17 @@ function(add_abseil)
   set(ABSL_PROPAGATE_CXX_STD
       ON
       CACHE BOOL "" FORCE)
-  add_subdirectory(abseil-cpp EXCLUDE_FROM_ALL)
+  if(NOT TARGET absl::span)
+    add_subdirectory(abseil-cpp EXCLUDE_FROM_ALL)
+  endif()
 endfunction()
 add_abseil()
 
 # Add pybind:
 function(add_pybind)
-  add_subdirectory(pybind11)
+  if(NOT TARGET pybind11::module)
+    add_subdirectory(pybind11)
+  endif()
 endfunction()
 add_pybind()
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -57,24 +57,19 @@ if(${SPHINX_FOUND})
   # Get a list of python sources in `wf_python`.
   get_python_library_sources(PYTHON_LIB_SOURCES)
 
-  # The python script we use to generate RST files, and the list of output
-  # files:
-  set(DOC_GENERATION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/generate_api_rst.py")
-  set(GENERATED_RST_FILES
-      source/python_api/ast.rst
-      source/python_api/code_generation.rst
-      source/python_api/enumerations.rst
-      source/python_api/exceptions.rst
-      source/python_api/expressions.rst
-      source/python_api/geometry.rst
-      source/python_api/sym.rst
-      source/python_api/sympy_conversion.rst
-      source/python_api/type_annotations.rst
-      source/python_api/type_info.rst)
-
-  set(HANDWRITTEN_RST_FILES
+  set(DOCUMENTATION_INPUT_FILES
       "${CMAKE_SOURCE_DIR}/README.md"
       "${CMAKE_SOURCE_DIR}/LICENSE"
+      source/_static/arch_dark.png
+      source/_static/arch_light.png
+      source/_static/benchmark_plots/ImuIntegration-clang.html
+      source/_static/benchmark_plots/ImuIntegration-gcc.html
+      source/_static/benchmark_plots/QuatInterpolation-clang.html
+      source/_static/benchmark_plots/QuatInterpolation-gcc.html
+      source/_static/benchmark_plots/QuatLocalCoords-clang.html
+      source/_static/benchmark_plots/QuatLocalCoords-gcc.html
+      source/_static/benchmark_plots/RollingShutterCamera-clang.html
+      source/_static/benchmark_plots/RollingShutterCamera-gcc.html
       source/building.rst
       source/conf.py
       source/cpp_api/index.rst
@@ -83,13 +78,23 @@ if(${SPHINX_FOUND})
       source/index.rst
       source/license.rst
       source/performance.rst
+      source/python_api/ast.rst
+      source/python_api/code_generation.rst
+      source/python_api/enumerations.rst
+      source/python_api/exceptions.rst
+      source/python_api/expressions.rst
+      source/python_api/geometry.rst
       source/python_api/index.rst
+      source/python_api/sym.rst
+      source/python_api/sympy_conversion.rst
+      source/python_api/type_annotations.rst
+      source/python_api/type_info.rst
       source/quick_start_files/main.cpp
       source/quick_start_files/quick_start_script.py
-      source/quick_start_files/rosenbrock.h
       source/quick_start_files/rosenbrock_crate/Cargo.toml
       source/quick_start_files/rosenbrock_crate/src/generated.rs
       source/quick_start_files/rosenbrock_crate/src/lib.rs
+      source/quick_start_files/rosenbrock.h
       source/quick_start.rst
       source/reference/conditionals.rst
       source/reference/custom_types_script.py
@@ -102,33 +107,12 @@ if(${SPHINX_FOUND})
       source/reference/introduction.rst
       source/reference/new_language.rst
       source/reference/symbolic_manipulation.rst
-      source/reference/sympy_interop.rst
-      source/_static/arch_dark.png
-      source/_static/arch_light.png
-      source/_static/benchmark_plots/ImuIntegration-gcc.html
-      source/_static/benchmark_plots/ImuIntegration-clang.html
-      source/_static/benchmark_plots/QuatInterpolation-gcc.html
-      source/_static/benchmark_plots/QuatInterpolation-clang.html
-      source/_static/benchmark_plots/QuatLocalCoords-gcc.html
-      source/_static/benchmark_plots/QuatLocalCoords-clang.html
-      source/_static/benchmark_plots/RollingShutterCamera-gcc.html
-      source/_static/benchmark_plots/RollingShutterCamera-clang.html)
-
-  # Invoke `generate_api_rst.py` to generate RST files for our python modules.
-  add_custom_command(
-    OUTPUT ${GENERATED_RST_FILES}
-    COMMAND
-      ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES} ${Python_EXECUTABLE} -B
-      ${DOC_GENERATION_SCRIPT} "${CMAKE_CURRENT_SOURCE_DIR}/source/python_api"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Generate RST for python API."
-    DEPENDS wf_core wf_wrapper wf_python ${PYTHON_LIB_SOURCES}
-            ${DOC_GENERATION_SCRIPT} ${HANDWRITTEN_RST_FILES})
+      source/reference/sympy_interop.rst)
 
   # Add command that runs sphinx-build. This depends explicitly on wf_stubs so
   # that the wrapper and stubs are up to date when docs are generated. Specify
   # `-E -a` so that this runs irrespective of whether `.rst` files have changed.
-  set(SPHINX_ARGS -E -a source build)
+  set(SPHINX_ARGS -E -a "${CMAKE_CURRENT_SOURCE_DIR}/source" build)
 
   if(DEFINED DOXYGEN_OUTPUT_DIR)
     message(STATUS "Configuring sphinx to ingest doxygen output.")
@@ -140,13 +124,13 @@ if(${SPHINX_FOUND})
 
   # Run sphinx through cmake so we can specify the python path correctly.
   add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/build/index.html"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/build/index.html"
     COMMAND ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES}
             ${SPHINX_BUILD_PATH} ${SPHINX_ARGS}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generate documentation with sphinx."
-    DEPENDS wf_stubs source/conf.py ${GENERATED_RST_FILES}
-            ${HANDWRITTEN_RST_FILES} ${DOXYGEN_INDEX_FILE})
+    DEPENDS wf_stubs source/conf.py ${DOCUMENTATION_INPUT_FILES}
+            ${PYTHON_LIB_SOURCES} ${DOXYGEN_INDEX_FILE})
   add_custom_target(wf_docs
-                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/build/index.html")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/build/index.html")
 endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -50,9 +50,8 @@ if(${SPHINX_FOUND})
   if(NOT DEFINED Python_EXECUTABLE)
     message(FATAL_ERROR "The Python executable could not be located.")
   endif()
-  if(NOT DEFINED PYTHON_COMMAND_ENV_VARIABLES)
-    message(
-      FATAL_ERROR "Variable PYTHON_COMMAND_ENV_VARIABLES must be defined.")
+  if(NOT DEFINED WF_PYTHON_ENV_VARIABLES)
+    message(FATAL_ERROR "Variable WF_PYTHON_ENV_VARIABLES must be defined.")
   endif()
 
   # Get a list of python sources in `wf_python`.
@@ -119,9 +118,8 @@ if(${SPHINX_FOUND})
   add_custom_command(
     OUTPUT ${GENERATED_RST_FILES}
     COMMAND
-      ${CMAKE_COMMAND} -E env ${PYTHON_COMMAND_ENV_VARIABLES}
-      ${Python_EXECUTABLE} -B ${DOC_GENERATION_SCRIPT}
-      "${CMAKE_CURRENT_SOURCE_DIR}/source/python_api"
+      ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES} ${Python_EXECUTABLE} -B
+      ${DOC_GENERATION_SCRIPT} "${CMAKE_CURRENT_SOURCE_DIR}/source/python_api"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generate RST for python API."
     DEPENDS wf_core wf_wrapper wf_python ${PYTHON_LIB_SOURCES}
@@ -143,7 +141,7 @@ if(${SPHINX_FOUND})
   # Run sphinx through cmake so we can specify the python path correctly.
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/build/index.html"
-    COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_COMMAND_ENV_VARIABLES}
+    COMMAND ${CMAKE_COMMAND} -E env ${WF_PYTHON_ENV_VARIABLES}
             ${SPHINX_BUILD_PATH} ${SPHINX_ARGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Generate documentation with sphinx."


### PR DESCRIPTION
- Prefix some global variables that were missing `WF_` prefix. (In service of making this work better as a sub-project).
- Remove some unnecessary compiler flags (warning suppressions that were neither required or advisable).
- Dependencies are only added to the build if they were not specified elsewhere.
- The python build previously ran `generate_api_docs.py` automatically. This was brittle and sometimes the build had to be invoked twice in a row to get the right result. Also the output files from this step then had to be committed. After this change, the user runs this step manually and cmake just pipes the result through sphinx.
- Documentation build writes output to `build` instead of into the source tree.