### PR TITLE
Update version number to 0.1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: gareth-cross
 
 **Configuration:**
 - OS: [e.g. OSX14, Ubuntu 22.04]
-- wrenfold version [e.g. 0.1.0]
+- wrenfold version [e.g. 0.1.1]
 - python version [e.g. 3.10]
 
 **Describe the bug**

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,7 @@ jobs:
 
       # https://github.com/pypa/cibuildwheel
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.17.0
+        run: python -m pip install cibuildwheel==v2.21.3
 
       - if: runner.os == 'Windows'
         name: Enable developer command prompt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bspline_demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrayvec",
  "bspline_rust_test",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "bspline_rust_test"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",
@@ -637,7 +637,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "custom_types_rust_test"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "motion_planning"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -2144,7 +2144,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_generation_test"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "rust_generation_test_2"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "wrenfold-test-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-package.version = "0.1.0"
+package.version = "0.1.1"
 package.license = "MIT"
 package.edition = "2021"
 package.authors = ["Gareth <gcross.code@icloud.com>"]
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.dependencies]
-wrenfold-test-utils = { path = "components/rust/wrenfold-test-utils", version = "0.1.0" }
+wrenfold-test-utils = { path = "components/rust/wrenfold-test-utils", version = "0.1.1" }
 wrenfold-traits = { path = "components/rust/wrenfold-traits", version = "0.1.0", features = ["nalgebra"] }
 bspline_rust_test = { path = "examples/bspline/bspline_rust_test" }
 

--- a/components/core/tests/rust_generation_test/Cargo.toml
+++ b/components/core/tests/rust_generation_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_generation_test"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/components/core/tests/rust_generation_test_2/Cargo.toml
+++ b/components/core/tests/rust_generation_test_2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_generation_test_2"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -20,11 +20,11 @@ wrenfold is also available as a `conda-forge <https://anaconda.org/conda-forge/w
 **Alternatively**, python wheels may also be obtained from the
 `GitHub Releases Page <https://github.com/wrenfold/wrenfold/releases>`_. Select the ``whl`` file
 appropriate to your OS and python version. For example, for python 3.10 on arm64 OSX you would
-download and install ``wrenfold-0.1.0-cp310-cp310-macosx_11_0_arm64.whl``:
+download and install ``wrenfold-0.1.1-cp310-cp310-macosx_11_0_arm64.whl``:
 
 .. code:: bash
 
-   pip install wrenfold-0.1.0-cp310-cp310-macosx_11_0_arm64.whl
+   pip install wrenfold-0.1.1-cp310-cp310-macosx_11_0_arm64.whl
 
 Validating the install
 ----------------------
@@ -34,7 +34,7 @@ After installation, open a python REPL and test that wrenfold can be imported:
 .. code:: python
 
    import wrenfold
-   print(wrenfold.__version__)  # prints: 0.1.0
+   print(wrenfold.__version__)  # prints: 0.1.1
 
    from wrenfold import sym
 

--- a/docs/source/quick_start_files/rosenbrock_crate/Cargo.toml
+++ b/docs/source/quick_start_files/rosenbrock_crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosenbrock_test"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/examples/bspline/bspline_rust_test/Cargo.toml
+++ b/examples/bspline/bspline_rust_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bspline_rust_test"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/examples/custom_types/custom_types_rust_test/Cargo.toml
+++ b/examples/custom_types/custom_types_rust_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_types_rust_test"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/examples/motion_planning/motion_planning_test/Cargo.toml
+++ b/examples/motion_planning/motion_planning_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion_planning"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/python_generation/python_generation.py
+++ b/examples/python_generation/python_generation.py
@@ -339,8 +339,10 @@ def generate_and_import(func: T.Callable) -> T.Callable:
     # Execute the generated code and return the specified function. This is a fair bit easier
     # than writing it out and using importlib, which fails anyway on windows when we write
     # the file to /tmp: https://stackoverflow.com/questions/66884520/
-    exec(code)
-    return locals()[func.__name__]
+    # We pass the function out via a dict: https://github.com/python/cpython/issues/118888
+    locals_out = dict()
+    exec(code, globals(), locals_out)
+    return locals_out[func.__name__]
 
 
 # noinspection PyMethodMayBeStatic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wrenfold"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.9"
 authors = [
     { name = "Gareth Cross", email = "gcross.code@icloud.com" },

--- a/support/conda/wrenfold/meta.yaml
+++ b/support/conda/wrenfold/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: wrenfold
@@ -14,6 +14,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
   host:
     - python >=3.9
     - scikit-build-core ==0.9.8
@@ -22,7 +23,7 @@ requirements:
     - mypy ==1.9.0
     - pip
   run:
-    - python >=3.9
+    - python
 
 test:
   imports:
@@ -41,6 +42,7 @@ test:
     - python support/test_wheel.py
 
 about:
+  home: https://github.com/wrenfold/wrenfold
   summary: Toolkit for generating code from symbolic math expressions.
   license: MIT
   license_file:
@@ -48,7 +50,6 @@ about:
     - dependencies/abseil-cpp/LICENSE
     - dependencies/fmt/LICENSE
     - dependencies/pybind11/LICENSE
-  dev_url: https://github.com/wrenfold/wrenfold
   doc_url: https://wrenfold.org
 
 extra:


### PR DESCRIPTION
The version number is updated to 0.1.1.

This is the first release that will include python 3.13 - correspondingly I also updated cibuildwheel to `v2.21.3` to enable building wheels for 3.13.

Going forward the rust-crate version will be decoupled from the python package (so that it can be updated separately), hence I have not updated the `wrenfold-traits` version.