### PR TITLE
Update yapf pre-commit version to v0.40.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
     hooks:
       - id: cmake-format
 
-  - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.32.0'
+  - repo: https://github.com/google/yapf
+    rev: 'v0.40.2'
     hooks:
       - id: yapf
         additional_dependencies: [toml]

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -85,7 +85,10 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertEqual(hash(x), hash(x))
         self.assertNotEqual(hash(x), hash(y))  # Not impossible, but very unlikely.
         # use expressions as keys in a dict:
-        storage = {x: 10, y: -13}
+        storage = {
+            x: 10,
+            y: -13
+        }
         self.assertEqual(10, storage[x])
         self.assertEqual(-13, storage[y])
 

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -117,7 +117,10 @@ class MatrixWrapperTest(MathTestBase):
         u = sym.vector(x * y, sym.cos(x), 0)
         self.assertNotEqual(hash(v), hash(u))  # Not likely.
         # Use matrix expressions as keys in a dict:
-        storage = {v: 1939, u: 1984}
+        storage = {
+            v: 1939,
+            u: 1984
+        }
         self.assertEqual(1939, storage[v])
         self.assertEqual(1984, storage[u])
 

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -216,7 +216,9 @@ class CustomCppGenerator(code_generation.CppGenerator):
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
         if element.type.python_type == EigenQuaternion:
             # Eigen quaternion expects constructor args in order (w, x, y, z)
-            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
+            arg_dict = {
+                f.name: element.get_field_value(f.name) for f in element.type.fields
+            }
             formatted_args = ", ".join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
             # We normalize numerically on construction, rather than symbolically. This avoids introducing
             # superfluous operations into the symbolic math tree, which saves on generated operations.
@@ -262,7 +264,9 @@ class CustomRustGenerator(code_generation.RustGenerator):
             return f"crate::geo::Pose3d::new(\n  {r},\n  {t}\n)"
         elif element.type.python_type == EigenQuaternion:
             # Order for nalgebra is [w, x, y, z]
-            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
+            arg_dict = {
+                f.name: element.get_field_value(f.name) for f in element.type.fields
+            }
             formatted_args = ", ".join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
             return f"nalgebra::Unit::new_normalize(nalgebra::Quaternion::<f64>::new({formatted_args}))"
         return self.super_format(element)


### PR DESCRIPTION
The current `yapf` mirror was deprecated and several versions behind. This change updates the pre-commit config to the latest version of yapf.