### PR TITLE
Enable c++20

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -6,6 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
       - 'test-release-tag'
+      - 'test-build-wheels-tag'
 
 jobs:
   # Run the CI jobs first.
@@ -113,7 +114,7 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/test-build-wheels-tag') }}
         with:
           files: |
             wheels/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
       - id: yapf
         additional_dependencies: [toml]
         exclude: '^dependencies/'
+        require_serial: true
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -136,8 +136,8 @@ add_library(
   wf/utility/visit_switch.h
   wf/utility/zip_tuples.h)
 
-# Turn on C++17
-target_compile_features(wf_core PUBLIC cxx_std_17)
+# Turn on C++20
+target_compile_features(wf_core PUBLIC cxx_std_20)
 
 # Set -fPIC since we will need to build shared libraries for python.
 set_target_properties(wf_core PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/components/core/test_support/wf_test_support/eigen_test_macros.h
+++ b/components/core/test_support/wf_test_support/eigen_test_macros.h
@@ -5,16 +5,23 @@
 #include <gtest/gtest.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <type_traits>
 
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/matrix_expression.h"
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 #define EXPECT_EIGEN_NEAR(a, b, tol) EXPECT_PRED_FORMAT3(wf::expect_eigen_near, a, b, tol)
 #define ASSERT_EIGEN_NEAR(a, b, tol) ASSERT_PRED_FORMAT3(wf::expect_eigen_near, a, b, tol)
+
+// https://github.com/fmtlib/fmt/issues/4123
+template <typename T>
+struct fmt::is_range<T, std::enable_if_t<std::is_base_of_v<Eigen::MatrixBase<T>, T>, char>>
+    : std::false_type {};
 
 // Allow formatting of Eigen matrices.
 template <typename T>

--- a/components/core/tests/cse_visitor_test.cc
+++ b/components/core/tests/cse_visitor_test.cc
@@ -9,6 +9,10 @@
 
 #include "wf_test_support/test_macros.h"
 
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ranges.h>
+WF_END_THIRD_PARTY_INCLUDES
+
 // Tests for the cse_visitor.
 namespace wf {
 using namespace wf::custom_literals;

--- a/components/core/tests/integer_utils_test.cc
+++ b/components/core/tests/integer_utils_test.cc
@@ -3,14 +3,14 @@
 // For license information refer to accompanying LICENSE file.
 #include <numeric>
 
-#include "wf/expressions/numeric_expressions.h"
+#include "wf/expression.h"
 #include "wf/integer_utils.h"
 #include "wf/utility/index_range.h"
 
-#include "wf_test_support/test_macros.h"
-
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <gtest/gtest.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 // Format prime_factor

--- a/components/core/tests/static_vector_test.cc
+++ b/components/core/tests/static_vector_test.cc
@@ -4,6 +4,11 @@
 #include <gtest/gtest.h>
 
 #include "wf/utility/static_vector.h"
+#include "wf/utility/third_party_imports.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ranges.h>
+WF_END_THIRD_PARTY_INCLUDES
 
 // Tests for the static_vector type.
 namespace wf {

--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -21,9 +21,8 @@ namespace wf::ast {
 // Add two values together.
 struct add {
   static constexpr std::string_view snake_case_name_str = "add";
-  using container_type = absl::InlinedVector<ast_element, 2>;
-
-  container_type args{};
+  using storage_type = absl::InlinedVector<ast_element, 2>;
+  storage_type args{};
 };
 
 // Assign a value to a temporary variable.
@@ -204,12 +203,11 @@ struct integer_literal {
   std::int64_t value;
 };
 
-// Multiply two operands together.
+// Multiply two (or more) operands together.
 struct multiply {
   static constexpr std::string_view snake_case_name_str = "multiply";
-  using container_type = absl::InlinedVector<ast_element, 2>;
-
-  container_type args{};
+  using storage_type = absl::InlinedVector<ast_element, 2>;
+  storage_type args{};
 };
 
 // Negate an operand.

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -3,6 +3,7 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/code_generation/ast_conversion.h"
 
+#include "wf/code_generation/ast.h"
 #include "wf/code_generation/ast_formatters.h"
 #include "wf/code_generation/control_flow_graph.h"
 #include "wf/code_generation/ir_block.h"
@@ -373,7 +374,7 @@ std::vector<ast::ast_element> ast_form_visitor::transform_operands(
 
 ast::ast_element ast_form_visitor::operator()(const ir::value& val, const ir::add&) {
   auto args =
-      transform_map<ast::add::container_type>(val.operands(), [this](const ir::const_value_ptr v) {
+      transform_map<ast::add::storage_type>(val.operands(), [this](const ir::const_value_ptr v) {
         return visit_operation_argument(v, precedence::addition);
       });
   return ast::ast_element{std::in_place_type_t<ast::add>{}, std::move(args)};
@@ -474,8 +475,8 @@ ast::ast_element ast_form_visitor::operator()(const ir::value&, const ir::load& 
 
 ast::ast_element ast_form_visitor::operator()(const ir::value& val, const ir::mul&) {
   WF_ASSERT_GE(val.num_operands(), 2);
-  auto args =
-      transform_map<ast::add::container_type>(val.operands(), [this](const ir::const_value_ptr v) {
+  auto args = transform_map<ast::multiply::storage_type>(
+      val.operands(), [this](const ir::const_value_ptr v) {
         return visit_operation_argument(v, precedence::multiplication);
       });
   return ast::ast_element{std::in_place_type_t<ast::multiply>{}, std::move(args)};

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -5,6 +5,11 @@
 #include "wf/code_generation/ast.h"
 #include "wf/code_generation/ast_visitor.h"
 #include "wf/utility/strings.h"
+#include "wf/utility/third_party_imports.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ranges.h>
+WF_END_THIRD_PARTY_INCLUDES
 
 // Formatters for the ast types. These are defined primarily so that we can implement repr() in
 // python + generate prettier assertions when throwing from C++.

--- a/components/core/wf/code_generation/binarizer.cc
+++ b/components/core/wf/code_generation/binarizer.cc
@@ -3,11 +3,9 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/code_generation/binarizer.h"
 
-#include <queue>
-#include <type_traits>
-
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <absl/container/flat_hash_set.h>
+#include <fmt/ranges.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 #include "wf/utility/scoped_trace.h"

--- a/components/core/wf/code_generation/types.cc
+++ b/components/core/wf/code_generation/types.cc
@@ -81,6 +81,8 @@ struct count_custom_type_size {
   }
 };
 
+std::size_t custom_type::size() const noexcept { return impl_->fields.size(); }
+
 std::size_t custom_type::total_size() const noexcept { return count_custom_type_size{}(*this); }
 
 bool is_identical_struct<custom_type>::operator()(const custom_type& a,

--- a/components/core/wf/code_generation/types.h
+++ b/components/core/wf/code_generation/types.h
@@ -153,7 +153,7 @@ class custom_type {
   }
 
   // Number of fields.
-  std::size_t size() const noexcept { return impl_->fields.size(); }
+  std::size_t size() const noexcept;
 
   // The total size (including all sub-structs).
   std::size_t total_size() const noexcept;

--- a/components/core/wf/expressions/power.cc
+++ b/components/core/wf/expressions/power.cc
@@ -212,7 +212,7 @@ struct power_numerics_visitor {
       }
     }
 
-    for (const auto [exponent_denominator, base_and_exp] : exp_to_base) {
+    for (const auto& [exponent_denominator, base_and_exp] : exp_to_base) {
       operands.emplace_back(
           std::in_place_type_t<power>(), scalar_expr(base_and_exp.base),
           scalar_expr(rational_constant{base_and_exp.exponent, exponent_denominator}));

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -181,7 +181,7 @@ void tree_formatter_visitor::apply_indentation() {
 template <typename... Args>
 void tree_formatter_visitor::format_append(const std::string_view fmt_str, Args&&... args) {
   apply_indentation();
-  fmt::format_to(std::back_inserter(output_), fmt_str, std::forward<Args>(args)...);
+  fmt::vformat_to(std::back_inserter(output_), fmt_str, fmt::make_format_args(args...));
   output_ += "\n";
 }
 

--- a/components/core/wf/utility/assertions.h
+++ b/components/core/wf/utility/assertions.h
@@ -6,6 +6,7 @@
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 namespace wf {
@@ -13,30 +14,30 @@ namespace detail {
 
 // Generates an exception w/ a formatted string.
 template <typename... Ts>
-std::string format_assert(const char* const condition, const char* const file, const int line,
-                          const char* const reason_fmt = nullptr, Ts&&... args) {
+std::string format_assert(const std::string_view condition, const std::string_view file,
+                          const int line, const std::string_view reason_fmt = {}, Ts&&... args) {
   std::string err = fmt::format("Assertion failed: {}\nFile: {}\nLine: {}", condition, file, line);
-  if (reason_fmt != nullptr) {
+  if (!reason_fmt.empty()) {
     err.append("\nDetails: ");
-    fmt::format_to(std::back_inserter(err), reason_fmt, std::forward<Ts>(args)...);
+    fmt::vformat_to(std::back_inserter(err), reason_fmt, fmt::make_format_args(args...));
   }
   return err;
 }
 
 // Version that prints args A & B as well. For binary comparisons.
 template <typename A, typename B, typename... Ts>
-std::string format_assert_binary(const char* const condition, const char* const file,
-                                 const int line, const char* const a_name, A&& a,
-                                 const char* const b_name, B&& b,
-                                 const char* const reason_fmt = nullptr, Ts&&... args) {
+std::string format_assert_binary(const std::string_view condition, const std::string_view file,
+                                 const int line, const std::string_view a_name, A&& a,
+                                 const std::string_view b_name, B&& b,
+                                 const std::string_view reason_fmt = {}, Ts&&... args) {
   std::string err = fmt::format(
       "Assertion failed: {}\n"
       "Operands are: `{}` = {}, `{}` = {}\n"
       "File: {}\nLine: {}",
       condition, a_name, std::forward<A>(a), b_name, std::forward<B>(b), file, line);
-  if (reason_fmt != nullptr) {
+  if (!reason_fmt.empty()) {
     err.append("\nDetails: ");
-    fmt::format_to(std::back_inserter(err), reason_fmt, std::forward<Ts>(args)...);
+    fmt::vformat_to(std::back_inserter(err), reason_fmt, fmt::make_format_args(args...));
   }
   return err;
 }

--- a/components/core/wf/utility/bitset_range.h
+++ b/components/core/wf/utility/bitset_range.h
@@ -79,15 +79,3 @@ template <std::size_t N>
 bitset_range(std::bitset<N>) -> bitset_range<N>;
 
 }  // namespace wf
-
-// template <std::size_t N>
-// struct fmt::formatter<wf::bitset_range<N>, char> {
-//   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin();
-//   }
-
-//   template <typename FormatContext>
-//   auto format(const wf::bitset_range<N>& range, FormatContext& ctx) const -> decltype(ctx.out())
-//   {
-//     return fmt::format_to(ctx.out(), "[{}]", fmt::join(range, ", "));
-//   }
-// };

--- a/components/core/wf/utility/bitset_range.h
+++ b/components/core/wf/utility/bitset_range.h
@@ -8,6 +8,7 @@
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 namespace wf {
@@ -79,12 +80,14 @@ bitset_range(std::bitset<N>) -> bitset_range<N>;
 
 }  // namespace wf
 
-template <std::size_t N>
-struct fmt::formatter<wf::bitset_range<N>, char> {
-  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+// template <std::size_t N>
+// struct fmt::formatter<wf::bitset_range<N>, char> {
+//   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin();
+//   }
 
-  template <typename FormatContext>
-  auto format(const wf::bitset_range<N>& range, FormatContext& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "[{}]", fmt::join(range, ", "));
-  }
-};
+//   template <typename FormatContext>
+//   auto format(const wf::bitset_range<N>& range, FormatContext& ctx) const -> decltype(ctx.out())
+//   {
+//     return fmt::format_to(ctx.out(), "[{}]", fmt::join(range, ", "));
+//   }
+// };

--- a/components/core/wf/utility/error_types.h
+++ b/components/core/wf/utility/error_types.h
@@ -21,7 +21,7 @@ struct exception_base : std::exception {
   // Construct with format specifier and arguments.
   template <typename... Ts>
   explicit exception_base(std::string_view fmt, Ts&&... args)
-      : exception_base(fmt::format(fmt, std::forward<Ts>(args)...)) {}
+      : exception_base(fmt::vformat(fmt, fmt::make_format_args(args...))) {}
 
   // Retrieve error message as a string view.
   [[nodiscard]] std::string_view message() const noexcept { return message_; }

--- a/components/core/wf/utility/scoped_trace.cc
+++ b/components/core/wf/utility/scoped_trace.cc
@@ -27,6 +27,7 @@
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 // Format wf::trace_event to JSON.

--- a/components/wrapper/pywrenfold/visitor_wrappers.h
+++ b/components/wrapper/pywrenfold/visitor_wrappers.h
@@ -9,8 +9,6 @@
 #include "wf/substitute.h"
 #include "wf/utility/algorithms.h"
 
-// #include "wrapper_utils.h"
-
 // This file is mostly a gross nuisance to handle the fact that we cannot pass std::variant
 // directly to pybind methods (because it cannot be default initialized). So instead we have to
 // write some adapter code so those methods can be wrapped - typically by passing a variant of

--- a/components/wrapper/pywrenfold/visitor_wrappers.h
+++ b/components/wrapper/pywrenfold/visitor_wrappers.h
@@ -7,8 +7,9 @@
 
 #include "wf/any_expression.h"
 #include "wf/substitute.h"
+#include "wf/utility/algorithms.h"
 
-#include "wrapper_utils.h"
+// #include "wrapper_utils.h"
 
 // This file is mostly a gross nuisance to handle the fact that we cannot pass std::variant
 // directly to pybind methods (because it cannot be default initialized). So instead we have to

--- a/components/wrapper/pywrenfold/wrapper_utils.h
+++ b/components/wrapper/pywrenfold/wrapper_utils.h
@@ -3,12 +3,16 @@
 // For license information refer to accompanying LICENSE file.
 #pragma once
 #include <algorithm>
-#include <variant>
 
 #include <pybind11/pybind11.h>
 
 #include "wf/expression.h"
-#include "wf/utility/algorithms.h"
+#include "wf/utility/third_party_imports.h"
+#include "wf/utility/type_list.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ranges.h>
+WF_END_THIRD_PARTY_INCLUDES
 
 // Shared utilities for writing wrappers.
 namespace wf {


### PR DESCRIPTION
Testing what will be required to enable c++20 for the pywrenfold library (not the runtime library, which will remain c++17).

This change does not leverage any modern features yet, it only converts code that would not compile and tests that the CI/build-wheel processes work.