### PR TITLE
Support taking derivative wrt the derivative of a symbolic function

### DIFF
--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -346,6 +346,23 @@ TEST(DerivativesTest, TestWrtSymbolicFunction) {
                    signum(f(x)).diff(f(x), 1, non_differentiable_behavior::abstract));
 }
 
+TEST(DerivativeTest, TestWrtDerivativeOfSymbolicFunction) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+  const auto f = symbolic_function("f");
+  const auto g = symbolic_function("g");
+
+  ASSERT_IDENTICAL(0, f(x).diff(g(x).diff(x)));
+  ASSERT_IDENTICAL(0, f(x).diff(g(x).diff(x, 2)));
+  ASSERT_IDENTICAL(0, f(y).diff(x).diff(f(y).diff(y)));
+
+  ASSERT_IDENTICAL(1, f(x).diff(x).diff(f(x).diff(x)));
+  ASSERT_IDENTICAL(2 * f(x, y).diff(x), pow(f(x, y).diff(x), 2).diff(f(x, y).diff(x)));
+
+  // Derivative of anything else is invalid.
+  ASSERT_THROW(f(x).diff(derivative::create(x * y * 3, y, 1)), wf::type_error);
+  ASSERT_THROW(f(x, cos(y)).diff(derivative::create(cos(y), y, 1)), wf::type_error);
+}
+
 TEST(DerivativesTest, TestSubstitution) {
   const scalar_expr x{"x", number_set::real};
   const auto [y, z] = make_symbols("y", "z");

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -302,6 +302,16 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertIdentical(-y / (x ** 2 + y ** 2), sym.atan2(y, x).diff(x))
         self.assertIdentical(2 * x / (x ** 2 + 4 * y ** 2), sym.atan2(2 * y, x).diff(y))
 
+        # Derivatives wrt symbolic function invocations.
+        f = sym.Function('f')
+        g = f(x).diff(x)
+        q = f(x, y).diff(y)
+        p = g.diff(x)
+        self.assertIdentical(1, g.diff(g))
+        self.assertIdentical(2 * g * sym.cos(g ** 2), sym.sin(g ** 2).diff(g))
+        self.assertIdentical(0, g.diff(q))
+        self.assertIdentical(3, (3 * p + y * g).diff(p))
+
         # Differentiate conditionals:
         self.assertIdentical(
             sym.where(x > 0, 5 * sym.cos(5 * x), 0),
@@ -309,6 +319,14 @@ class ExpressionWrapperTest(MathTestBase):
 
         # Diffing a polynomial too many times can trigger arithmetic error (factorial overflow)
         self.assertRaises(exceptions.ArithmeticError, lambda: (x ** 100).diff(x, 20))
+
+        # Certain types cannot be passed to `diff`:
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(1))
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(sym.pi))
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(x + y))
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(-z))
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(sym.sin(z)))
+        self.assertRaises(exceptions.TypeError, lambda: x.diff(sym.derivative(x * 2, x, 2)))
 
     def test_relational(self):
         """Test creating relational expressions."""


### PR DESCRIPTION
It is useful when doing dynamical derivations to be able to take the derivative wrt the time-derivative of a symbolic function. For example when calculating the Euler-Lagrange equations, we take derivatives wrt to `d(q_i)/dt` when computing the generalized momenta.

There was nothing fundamental blocking this capability, other than adjusting the type-checking logic in `derivative.cc`. This change turns on support for this feature and adds some tests.