### PR TITLE
Improve performance of multiplications

### DIFF
--- a/components/core/benchmarks/bench_jacobian.cc
+++ b/components/core/benchmarks/bench_jacobian.cc
@@ -24,7 +24,7 @@ static void BM_QuaternionInterpolateJacobian(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_QuaternionInterpolateJacobian)->Iterations(2000)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_QuaternionInterpolateJacobian)->Iterations(30000)->Unit(benchmark::kMillisecond);
 
 }  // namespace wf
 

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -309,9 +309,7 @@ TEST(ScalarOperationsTest, TestDivision) {
 }
 
 TEST(ScalarOperationsTest, TestAsCoeffAndMultiplicand) {
-  const scalar_expr x{"x"};
-  const scalar_expr y{"y"};
-  const scalar_expr z{"z"};
+  const auto [x, y, z] = make_symbols("x", "y", "z");
 
   ASSERT_IDENTICAL(constants::zero, as_coeff_and_mul(0).first);
   ASSERT_IDENTICAL(constants::one, as_coeff_and_mul(0).second);
@@ -335,6 +333,31 @@ TEST(ScalarOperationsTest, TestAsCoeffAndMultiplicand) {
   // Include some functions:
   ASSERT_IDENTICAL(1.22_s, as_coeff_and_mul(1.22 * sin(x) * cos(y)).first);
   ASSERT_IDENTICAL(cos(y) * sin(x), as_coeff_and_mul(1.22 * sin(x) * cos(y)).second);
+
+  // More complex numerics (like powers of integers) are not split out:
+  {
+    const auto [coeff, mul] = as_coeff_and_mul(pow(3, 1_s / 5) * x);
+    ASSERT_IDENTICAL(1, coeff);
+    ASSERT_IDENTICAL(pow(3, 1_s / 5) * x, mul);
+  }
+  {
+    const auto [coeff, mul] = as_coeff_and_mul(pow(3, 1_s / 5) * sin(x) * pow(1_s / 2, 3_s / 8));
+    ASSERT_IDENTICAL(1, coeff);
+    ASSERT_IDENTICAL(pow(3, 1_s / 5) * pow(1_s / 2, 3_s / 8) * sin(x), mul);
+  }
+}
+
+TEST(ScalarOperationsTest, TestHasNumericCoefficient) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_FALSE(has_numeric_coefficient(x));
+  ASSERT_FALSE(has_numeric_coefficient(x * y));
+  ASSERT_FALSE(has_numeric_coefficient(x * constants::pi));
+  ASSERT_TRUE(has_numeric_coefficient(2));
+  ASSERT_TRUE(has_numeric_coefficient(2_s / 7));
+  ASSERT_TRUE(has_numeric_coefficient(-3.12));
+  ASSERT_TRUE(has_numeric_coefficient(2.2 * cos(x) / y));
+  ASSERT_TRUE(has_numeric_coefficient(-3 / 5_s * y));
+  ASSERT_TRUE(has_numeric_coefficient(-2.1 * pow(y, 2)));
 }
 
 TEST(ScalarOperationsTest, TestPower) {

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -224,18 +224,22 @@ TEST(ScalarOperationsTest, TestMultiplicationImaginaryUnit) {
 TEST(ScalarOperationsTest, TestMultiplicationNumericalConstants) {
   ASSERT_IDENTICAL(6, 2_s * 3_s);
   ASSERT_IDENTICAL(0, 0_s * 1_s);
-  ASSERT_IDENTICAL(-1_s, multiplication::from_operands({-1_s, -1_s, 1_s, -1_s}));
+  ASSERT_IDENTICAL(-1_s, multiplication::from_operands(
+                             std::initializer_list<scalar_expr>{-1_s, -1_s, 1_s, -1_s}));
   // int times rational
   ASSERT_IDENTICAL(8_s / 3, 2_s / 3 * 4);
   ASSERT_IDENTICAL(-24_s / 13, -3_s * (8_s / 13));
-  ASSERT_IDENTICAL(14_s / 3, multiplication::from_operands({7_s, 2_s / 3, 1_s}));
+  ASSERT_IDENTICAL(14_s / 3, multiplication::from_operands(
+                                 std::initializer_list<scalar_expr>{7_s, 2_s / 3, 1_s}));
   // int times float:
   ASSERT_IDENTICAL(0.84, 4_s * 0.21);
   ASSERT_IDENTICAL(-0.76, -0.38_s * 2);
   ASSERT_IDENTICAL(0, 4_s * 0.0);
   ASSERT_IDENTICAL(0, 0.0_s * 9);
-  ASSERT_IDENTICAL(-24.0_s, multiplication::from_operands({4_s, -12_s, 0.5_s}));
-  ASSERT_IDENTICAL(0, multiplication::from_operands({0.0_s, 17_s, -0.0_s, 1.4_s}));
+  ASSERT_IDENTICAL(-24.0_s, multiplication::from_operands(
+                                std::initializer_list<scalar_expr>{4_s, -12_s, 0.5_s}));
+  ASSERT_IDENTICAL(0, multiplication::from_operands(
+                          std::initializer_list<scalar_expr>{0.0_s, 17_s, -0.0_s, 1.4_s}));
   // rational times float:
   ASSERT_IDENTICAL(0.8, 4.0_s * (1_s / 5));
   ASSERT_IDENTICAL(-1.0, (-1_s / 2) * 2.0);
@@ -261,7 +265,8 @@ TEST(ScalarOperationsTest, TestMultiplicationInfinities) {
   ASSERT_IDENTICAL(0, constants::pi / z_inf);
   ASSERT_IDENTICAL(0, (y * x) / z_inf);
 
-  ASSERT_IDENTICAL(z_inf, multiplication::from_operands({z_inf, z_inf, 22, -1.02}));
+  ASSERT_IDENTICAL(z_inf, multiplication::from_operands(
+                              std::initializer_list<scalar_expr>{z_inf, z_inf, 22, -1.02}));
 }
 
 TEST(ScalarOperationsTest, TestMultiplicationUndefined) {

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -4,6 +4,7 @@
 #include "wf/code_generation/ir_form_visitor.h"
 
 #include "wf/expression_visitor.h"
+#include "wf/utility/overloaded_visit.h"
 #include "wf/utility/scoped_trace.h"
 #include "wf/utility_visitors.h"
 

--- a/components/core/wf/collect.cc
+++ b/components/core/wf/collect.cc
@@ -4,7 +4,6 @@
 #include <algorithm>
 
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
 
 namespace wf {
 
@@ -89,19 +88,18 @@ struct collect_visitor {
     // Now we're done with the first term, we recurse for the remaining terms.
     for (auto it = exponents_to_mul.begin(); it != exponents_to_mul.end(); ++it) {
       // The term we are collecting, e.g. x, x**2, x**3, etc...
-      scalar_expr collected_pow = power::create(collected_term, it->first);
+      const scalar_expr collected_pow = power::create(collected_term, it->first);
 
       // Check if we need to collect remaining terms of our coefficient, otherwise just turn it into
       // an addition. In some cases, the addition might just reduce to a single expression.
-      scalar_expr term_coefficient =
+      const scalar_expr term_coefficient =
           collected_terms_.size() > 1
               ? collect_visitor{collected_terms_.subspan(1)}.collect_addition_terms(
                     std::move(it->second))
               : addition::from_operands(it->second);
 
       // Multiply the power by the collected terms: x**2 * (y + pi - 3)
-      scalar_expr mul =
-          multiplication::from_operands({std::move(collected_pow), std::move(term_coefficient)});
+      scalar_expr mul = multiplication::from_two_operands(collected_pow, term_coefficient);
       container.push_back(std::move(mul));
     }
     return addition::from_operands(container);  //  TODO: should be a move

--- a/components/core/wf/constants.cc
+++ b/components/core/wf/constants.cc
@@ -20,6 +20,9 @@ const scalar_expr constants::complex_infinity{std::in_place_type_t<wf::complex_i
 const scalar_expr constants::undefined{std::in_place_type_t<wf::undefined>{}};
 const scalar_expr constants::imaginary_unit{std::in_place_type_t<wf::imaginary_unit>{}};
 
+const scalar_expr constants::two{std::in_place_type_t<wf::integer_constant>{}, 2};
+const scalar_expr constants::negative_two{std::in_place_type_t<wf::integer_constant>{}, -2};
+
 const boolean_expr constants::boolean_true{std::in_place_type_t<boolean_constant>{}, true};
 const boolean_expr constants::boolean_false{std::in_place_type_t<boolean_constant>{}, false};
 

--- a/components/core/wf/constants.h
+++ b/components/core/wf/constants.h
@@ -17,6 +17,10 @@ class constants {
   static const scalar_expr undefined;
   static const scalar_expr imaginary_unit;
 
+  // Additional integers we declare for reuse:
+  static const scalar_expr two;
+  static const scalar_expr negative_two;
+
   static const boolean_expr boolean_true;
   static const boolean_expr boolean_false;
 };

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -9,11 +9,9 @@
 #include "wf/distribute.h"
 #include "wf/evaluate.h"
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
 #include "wf/plain_formatter.h"
 #include "wf/substitute.h"
 #include "wf/tree_formatter.h"
-#include "wf/utility/assertions.h"
 
 namespace wf {
 

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -75,7 +75,7 @@ std::string scalar_expr::to_expression_tree_string() const {
 }
 
 scalar_expr scalar_expr::operator-() const {
-  return multiplication::from_operands({constants::negative_one, *this});
+  return multiplication::from_two_operands(constants::negative_one, *this);
 }
 
 scalar_expr scalar_expr::diff(const scalar_expr& var, const int reps,
@@ -105,16 +105,16 @@ scalar_expr operator+(const scalar_expr& a, const scalar_expr& b) {
 }
 
 scalar_expr operator-(const scalar_expr& a, const scalar_expr& b) {
-  return a + multiplication::from_operands({constants::negative_one, b});
+  return a + multiplication::from_two_operands(constants::negative_one, b);
 }
 
 scalar_expr operator*(const scalar_expr& a, const scalar_expr& b) {
-  return multiplication::from_operands({a, b});
+  return multiplication::from_two_operands(a, b);
 }
 
 scalar_expr operator/(const scalar_expr& a, const scalar_expr& b) {
   auto one_over_b = power::create(b, constants::negative_one);
-  return multiplication::from_operands({a, one_over_b});
+  return multiplication::from_two_operands(a, one_over_b);
 }
 
 boolean_expr operator<(const scalar_expr& a, const scalar_expr& b) {

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -60,6 +60,10 @@ scalar_expr scalar_expr::from_int(const checked_int x) {
     return constants::one;
   } else if (x == -1) {
     return constants::negative_one;
+  } else if (x == 2) {
+    return constants::two;
+  } else if (x == -2) {
+    return constants::negative_two;
   }
   return make_expr<integer_constant>(x);
 }

--- a/components/core/wf/expression_visitor.h
+++ b/components/core/wf/expression_visitor.h
@@ -3,7 +3,6 @@
 // For license information refer to accompanying LICENSE file.
 #pragma once
 #include "wf/expression_variant.h"
-#include "wf/utility/overloaded_visit.h"
 #include "wf/utility/visit_switch.h"
 
 // All expression definitions need to be available to static_cast.

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -164,8 +164,7 @@ void addition_parts::normalize_coefficients() {
 scalar_expr addition_parts::create_addition() const {
   addition::container_type args{};
 
-  scalar_expr constant_coeff_expr =
-      overloaded_visit(coeff, [](const auto x) { return scalar_expr(x); });
+  scalar_expr constant_coeff_expr = std::visit([](const auto x) { return scalar_expr(x); }, coeff);
 
   if (is_undefined(constant_coeff_expr)) {
     return constants::undefined;

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -7,6 +7,7 @@
 #include "wf/expressions/multiplication.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/special_constants.h"
+#include "wf/utility/overloaded_visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -183,7 +183,7 @@ scalar_expr addition_parts::create_addition() const {
       // expression and `coeff` is a numerical coefficient.
       args.emplace_back(std::in_place_type_t<multiplication>{}, term_coeff, multiplicand);
     } else {
-      args.push_back(multiplication::from_operands({multiplicand, term_coeff}));
+      args.push_back(multiplication::from_two_operands(multiplicand, term_coeff));
     }
   }
 

--- a/components/core/wf/expressions/custom_type_expressions.cc
+++ b/components/core/wf/expressions/custom_type_expressions.cc
@@ -4,6 +4,7 @@
 #include "wf/expressions/custom_type_expressions.h"
 
 #include "wf/expression_visitor.h"
+#include "wf/utility/overloaded_visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -119,7 +119,7 @@ scalar_expr multiplication::from_operands(const absl::Span<const scalar_expr> ar
     parts.multiply_term(term);
   }
   parts.normalize_coefficients();
-  return parts.create_multiplication();
+  return std::move(parts).create_multiplication();
 }
 
 void multiplication::sort_terms() {
@@ -217,13 +217,13 @@ void multiplication_parts::normalize_coefficients() {
   map_erase_if(terms_, [](const auto& pair) { return is_zero(pair.second); });
 }
 
-scalar_expr multiplication_parts::create_multiplication() const {
+scalar_expr multiplication_parts::create_multiplication() && {
   multiplication::container_type args{};
   multiplication_parts::constant_coeff constant_coefficient = coeff_;
 
   // Convert into a vector of powers, and sort into canonical order:
-  for (const auto& [base, exp] : terms_) {
-    auto pow = power::create(base, exp);
+  for (auto& [base, exp] : terms_) {
+    auto pow = power::create(base, std::move(exp));
 
     // The power may have produced a numerical coefficient:
     auto [pow_coeff, mul] = as_coeff_and_mul(pow);

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -7,8 +7,8 @@
 
 #include "wf/expression.h"
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
 #include "wf/integer_utils.h"
+#include "wf/utility/overloaded_visit.h"
 #include "wf/utility_visitors.h"
 
 namespace wf {

--- a/components/core/wf/expressions/multiplication.cc
+++ b/components/core/wf/expressions/multiplication.cc
@@ -249,7 +249,7 @@ static std::pair<scalar_expr, scalar_expr> split_multiplication(const multiplica
   multiplication::container_type numerics{};
   multiplication::container_type remainder{};
   for (const scalar_expr& expr : mul) {
-    if (is_numeric(expr)) {  // TODO: This is inconsistent with `has_numeric_coefficient`.
+    if (expr.is_type<integer_constant, rational_constant, float_constant>()) {
       numerics.push_back(expr);
     } else {
       remainder.push_back(expr);

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -128,7 +128,8 @@ struct multiplication_parts {
   void normalize_coefficients();
 
   // Create the resulting multiplication.
-  scalar_expr create_multiplication() const;
+  // This is ref-qualified because we move expressions out of the map.
+  scalar_expr create_multiplication() &&;
 
   // Visitor operations.
   void operator()(const multiplication& mul);

--- a/components/core/wf/expressions/multiplication.h
+++ b/components/core/wf/expressions/multiplication.h
@@ -98,6 +98,10 @@ struct order_struct<multiplication> {
   }
 };
 
+// Returns true if the expression has a numerical coefficient (an integer, rational, or float).
+// If this function returns true, then `as_coeff_and_mul` will return a non-unit coefficient.
+bool has_numeric_coefficient(const scalar_expr& expr);
+
 // Convert an expression into a coefficient and a multiplicand. This operation checks if
 // expr is a multiplication. If it is, we extract all numeric constants and return them
 // as the first value. The remaining terms form a new multiplication, which is returned as

--- a/components/core/wf/external_function.cc
+++ b/components/core/wf/external_function.cc
@@ -5,6 +5,7 @@
 
 #include "wf/code_generation/ast_formatters.h"
 #include "wf/expression_visitor.h"
+#include "wf/utility/overloaded_visit.h"
 
 namespace wf {
 

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -5,7 +5,7 @@
 
 #include "wf/enumerations.h"
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
+#include "wf/utility/overloaded_visit.h"
 
 namespace wf {
 

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -5,6 +5,7 @@
 
 #include "wf/expression_visitor.h"
 #include "wf/utility/assertions.h"
+#include "wf/utility/overloaded_visit.h"
 #include "wf/utility/third_party_imports.h"
 #include "wf/utility_visitors.h"
 

--- a/components/core/wf/substitute.cc
+++ b/components/core/wf/substitute.cc
@@ -219,7 +219,7 @@ struct substitute_mul_visitor
     }
 
     input_parts.normalize_coefficients();
-    return input_parts.create_multiplication();
+    return std::move(input_parts).create_multiplication();
   }
 
  protected:

--- a/components/wrapper/pywrenfold/sympy_conversion.cc
+++ b/components/wrapper/pywrenfold/sympy_conversion.cc
@@ -9,6 +9,7 @@
 #include "wf/expression.h"
 #include "wf/expression_visitor.h"
 #include "wf/matrix_expression.h"
+#include "wf/utility/overloaded_visit.h"
 
 #include "docs/sympy_conversion.h"
 #include "wrapper_utils.h"


### PR DESCRIPTION
This change implements a moderate performance improvement to symbolic multiplication. The techniques user were:
- Ensure more expressions are moved instead of copied when building multiplications.
- Cache the common integers +2 and -2, which occur frequently in powers.
- Create a slightly simpler code-path for binary multiplications.
- Skip some needless copies of `scalar_exprs` for expressions with no numeric coefficients.

I think more can be done here, but these relatively simple changes produced an improvement of:
- `14.02%` on `bench_jacobian`.
- `18.6%` on `bench_add_mul`.