### PR TITLE
Add `convert_ternaries` option to allow conditionals to remain in ternary form

### DIFF
--- a/components/core/benchmarks/bench_code_generation.cc
+++ b/components/core/benchmarks/bench_code_generation.cc
@@ -72,7 +72,7 @@ void BM_ConvertIr(benchmark::State& state) {
     control_flow_graph flat_ir{description, optimization_params{}};
     state.ResumeTiming();
     // Convert to the non-flat IR.
-    control_flow_graph output_ir = std::move(flat_ir).convert_conditionals_to_control_flow();
+    control_flow_graph output_ir = std::move(flat_ir).convert_conditionals_to_control_flow(true);
     benchmark::DoNotOptimize(output_ir);
   }
 }
@@ -84,7 +84,8 @@ void BM_GenerateCpp(benchmark::State& state) {
       &quaternion_interpolation, "quaternion_interpolation", arg("q0"), arg("q1"), arg("alpha"));
 
   const control_flow_graph output_cfg =
-      control_flow_graph{description, optimization_params()}.convert_conditionals_to_control_flow();
+      control_flow_graph{description, optimization_params()}.convert_conditionals_to_control_flow(
+          true);
 
   for (auto _ : state) {
     ast::function_definition definition = ast::create_ast(output_cfg, description);

--- a/components/core/test_support/wf_test_support/code_gen_helpers.h
+++ b/components/core/test_support/wf_test_support/code_gen_helpers.h
@@ -14,12 +14,13 @@ namespace wf {
 
 template <typename CodeGenerator, typename Func, typename... Args>
 void generate_func(CodeGenerator&& generator, std::string& output, Func&& func,
-                   const std::string_view name, Args&&... args) {
+                   const bool convert_ternaries, const std::string_view name, Args&&... args) {
   const function_description description =
       build_function_description(std::forward<Func>(func), name, std::forward<Args>(args)...);
 
   const control_flow_graph output_cfg =
-      control_flow_graph{description, optimization_params()}.convert_conditionals_to_control_flow();
+      control_flow_graph{description, optimization_params()}.convert_conditionals_to_control_flow(
+          convert_ternaries);
 
   // Generate syntax tree:
   const ast::function_definition definition = ast::create_ast(output_cfg, description);
@@ -27,6 +28,13 @@ void generate_func(CodeGenerator&& generator, std::string& output, Func&& func,
   // Convert to output code:
   const std::string code = generator(definition);
   fmt::format_to(std::back_inserter(output), "{}\n\n", code);
+}
+
+template <typename CodeGenerator, typename Func, typename... Args>
+void generate_func(CodeGenerator&& generator, std::string& output, Func&& func,
+                   const std::string_view name, Args&&... args) {
+  generate_func(std::forward<CodeGenerator>(generator), output, std::forward<Func>(func), true,
+                name, std::forward<Args>(args)...);
 }
 
 }  // namespace wf

--- a/components/core/tests/cpp_generation_gen.cc
+++ b/components/core/tests/cpp_generation_gen.cc
@@ -1,11 +1,9 @@
 // wrenfold symbolic code generator.
 // Copyright (c) 2024 Gareth Cross
 // For license information refer to accompanying LICENSE file.
-#include <filesystem>
 #include <fstream>
 
 #include "wf/code_generation/cpp_code_generator.h"
-#include "wf_test_support/code_gen_helpers.h"
 
 #include "test_expressions_codegen.h"
 

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -1,11 +1,8 @@
 // wrenfold symbolic code generator.
 // Copyright (c) 2024 Gareth Cross
 // For license information refer to accompanying LICENSE file.
-#include "wf/type_annotations.h"
-
 #include "wf_test_support/eigen_test_macros.h"
 #include "wf_test_support/numeric_testing.h"
-#include "wf_test_support/test_macros.h"
 
 #include "test_expressions.h"  //  Symbolic test functions.
 
@@ -248,6 +245,42 @@ TEST(CppGenerationTest, TestNestedConditionals2) {
   EXPECT_EQ(evaluator(-1.7, -2.0), gen::nested_conditionals_2(-1.7, -2.0));
 }
 
+TEST(CppGenerationTest, TestNestedConditionals1WithTernaries) {
+  auto evaluator = create_evaluator(&nested_conditionals_1);
+  // Exercise all the different control paths.
+  // x > 0, y > 0, |x| > |y|
+  EXPECT_NEAR(evaluator(0.5, 0.2), gen::nested_conditionals_1_with_ternaries(0.5, 0.2), 1.0e-15);
+  // x > 0, y > 0, |x| <= |y|
+  EXPECT_NEAR(evaluator(0.1, 0.3), gen::nested_conditionals_1_with_ternaries(0.1, 0.3), 1.0e-15);
+  // x > 0, y <= 0, |x| > |y|
+  EXPECT_NEAR(evaluator(2.4, -0.11), gen::nested_conditionals_1_with_ternaries(2.4, -0.11),
+              1.0e-15);
+  // x > 0, y <= 0, |x| <= |y|
+  EXPECT_NEAR(evaluator(1.3, -3.0), gen::nested_conditionals_1_with_ternaries(1.3, -3.0), 1.0e-15);
+  // x <= 0, y > 0, |x| > |y|
+  EXPECT_NEAR(evaluator(-0.8, 0.66), gen::nested_conditionals_1_with_ternaries(-0.8, 0.66),
+              1.0e-15);
+  // x <= 0, y <= 0, |x| <= |y|
+  EXPECT_NEAR(evaluator(-0.123, -0.5), gen::nested_conditionals_1_with_ternaries(-0.123, -0.5),
+              1.0e-15);
+}
+
+TEST(CppGenerationTest, TestNestedConditionals2WithTernaries) {
+  auto evaluator = create_evaluator(&nested_conditionals_2);
+  // x > 0, y > 0, |x| > |y|
+  EXPECT_EQ(evaluator(0.73, 0.02), gen::nested_conditionals_2_with_ternaries(0.73, 0.02));
+  // x > 0, y > 0, |x| <= |y|
+  EXPECT_EQ(evaluator(1.32, 1.32), gen::nested_conditionals_2_with_ternaries(1.32, 1.32));
+  // x > 0, y <= 0, |x| > |y|
+  EXPECT_EQ(evaluator(7.2, -7.0), gen::nested_conditionals_2_with_ternaries(7.2, -7.0));
+  // x > 0, y <= 0, |x| <= |y|
+  EXPECT_EQ(evaluator(5.6, -6.3), gen::nested_conditionals_2_with_ternaries(5.6, -6.3));
+  // x <= 0, y > 0, |x| > |y|
+  EXPECT_EQ(evaluator(-1.0, 0.95), gen::nested_conditionals_2_with_ternaries(-1.0, 0.95));
+  // x <= 0, y <= 0, |x| <= |y|
+  EXPECT_EQ(evaluator(-1.7, -2.0), gen::nested_conditionals_2_with_ternaries(-1.7, -2.0));
+}
+
 TEST(CppGenerationTest, TestQuaternionFromMatrix) {
   const double sqrt2inv = 1.0 / std::sqrt(2.0);
   const std::vector<Eigen::Quaterniond> qs = {
@@ -337,9 +370,17 @@ TEST(CppGenerationTest, TestCreateRotationMatrix) {
   EXPECT_EIGEN_NEAR(R_num, R_gen, 1.0e-15);
   EXPECT_EIGEN_NEAR(D_num, D_gen, 1.0e-15);
 
+  gen::create_rotation_matrix_with_ternaries<double>(w2, R_gen, D_gen);
+  EXPECT_EIGEN_NEAR(R_num, R_gen, 1.0e-15);
+  EXPECT_EIGEN_NEAR(D_num, D_gen, 1.0e-15);
+
   const Eigen::Vector3d w3{5.0, -4.0, 2.1};
   evaluator(w3, R_num, D_num);
   gen::create_rotation_matrix<double>(w3, R_gen, D_gen);
+  EXPECT_EIGEN_NEAR(R_num, R_gen, 1.0e-15);
+  EXPECT_EIGEN_NEAR(D_num, D_gen, 1.0e-15);
+
+  gen::create_rotation_matrix_with_ternaries<double>(w3, R_gen, D_gen);
   EXPECT_EIGEN_NEAR(R_num, R_gen, 1.0e-15);
   EXPECT_EIGEN_NEAR(D_num, D_gen, 1.0e-15);
 }

--- a/components/core/tests/rust_generation_gen.cc
+++ b/components/core/tests/rust_generation_gen.cc
@@ -6,7 +6,6 @@
 #include "wf/code_generation/rust_code_generator.h"
 
 #include "test_expressions_codegen.h"
-#include "wf_test_support/code_gen_helpers.h"
 
 namespace wf {
 

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn simple_multiply_add<>(x: f64, y: f64, z: f64) -> f64
 {
   // Operation counts:
@@ -17,7 +17,7 @@ pub fn simple_multiply_add<>(x: f64, y: f64, z: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn vector_rotation_2d<T1, T2, T3, >(theta: f64, v: &T1, v_rot: &mut T2, D_theta: Option<&mut T3>) -> ()
 where
   T1: wrenfold_traits::Span2D<2, 1, ValueType = f64>,
@@ -48,7 +48,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn vector_norm_3d<T0, T1, >(v: &T0, D_v: &mut T1) -> f64
 where
   T0: wrenfold_traits::Span2D<3, 1, ValueType = f64>,
@@ -73,7 +73,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn heaviside<>(x: f64) -> f64
 {
   // Operation counts:
@@ -92,7 +92,7 @@ pub fn heaviside<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn exclusive_or<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
@@ -121,7 +121,7 @@ pub fn exclusive_or<>(x: f64, y: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn signum_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -133,7 +133,7 @@ pub fn signum_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn abs_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -145,7 +145,7 @@ pub fn abs_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn floor_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -157,7 +157,7 @@ pub fn floor_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn cosh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -169,7 +169,7 @@ pub fn cosh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn sinh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -181,7 +181,7 @@ pub fn sinh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn tanh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -193,7 +193,7 @@ pub fn tanh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn acosh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -205,7 +205,7 @@ pub fn acosh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn asinh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -217,7 +217,7 @@ pub fn asinh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn atanh_test<>(x: f64) -> f64
 {
   // Operation counts:
@@ -229,7 +229,7 @@ pub fn atanh_test<>(x: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn atan2_with_derivatives<>(y: f64, x: f64, D_y: &mut f64, D_x: &mut f64) -> f64
 {
   // Operation counts:
@@ -249,7 +249,7 @@ pub fn atan2_with_derivatives<>(y: f64, x: f64, D_y: &mut f64, D_x: &mut f64) ->
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn nested_conditionals_1<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
@@ -286,7 +286,7 @@ pub fn nested_conditionals_1<>(x: f64, y: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn nested_conditionals_2<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
@@ -319,7 +319,44 @@ pub fn nested_conditionals_2<>(x: f64, y: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn nested_conditionals_1_with_ternaries<>(x: f64, y: f64) -> f64
+{
+  // Operation counts:
+  // add: 2
+  // call: 10
+  // compare: 3
+  // multiply: 4
+  // negate: 1
+  // total: 20
+  
+  let v002: f64 = x;
+  let v000: f64 = y;
+  let v001: f64 = (v000).abs();
+  let v015: f64 = if (((0i64) as f64) < (v000)) { (v000 * v002).cos() } else { ((v002).cos() + (2i64) as f64) };
+  if ((v001) < ((v002).abs())) { (v015 * (3i64) as f64 + -((v015).abs()).sqrt()) } else { (0.2f64 * ((if (((0i64) as f64) < (v002)) { (v001).ln() } else { ((3i64) as f64 * (v000).atan2(v002)) }).abs()).powf(0.3333333333333333f64)) }
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn nested_conditionals_2_with_ternaries<>(x: f64, y: f64) -> f64
+{
+  // Operation counts:
+  // add: 3
+  // call: 7
+  // compare: 3
+  // divide: 1
+  // multiply: 8
+  // negate: 2
+  // total: 24
+  
+  let v000: f64 = y;
+  let v002: f64 = x;
+  if (((v000).abs()) < ((v002).abs())) { (if (((0i64) as f64) < (v002)) { (if (((0i64) as f64) < (v000)) { (v000 * v002 * std::f64::consts::PI).cos() } else { ((((1i64) as f64 / v000) * (22i64) as f64).sin() + -(v002 * (3i64) as f64)) }) } else { ((v000 * 0.4f64).atan2(v002 * 0.1f64) * (19i64) as f64 + -v000) }) } else { ((v002 * (v000 + (2i64) as f64)).abs()).sqrt() }
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn create_rotation_matrix<T0, T1, T2, >(w: &T0, R: &mut T1, R_D_w: Option<&mut T2>) -> ()
 where
   T0: wrenfold_traits::Span2D<3, 1, ValueType = f64>,
@@ -490,7 +527,146 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn create_rotation_matrix_with_ternaries<T0, T1, T2, >(w: &T0, R: &mut T1, R_D_w: Option<&mut T2>) -> ()
+where
+  T0: wrenfold_traits::Span2D<3, 1, ValueType = f64>,
+  T1: wrenfold_traits::OutputSpan2D<3, 3, ValueType = f64>,
+  T2: wrenfold_traits::OutputSpan2D<9, 3, ValueType = f64>,
+{
+  // Operation counts:
+  // add: 68
+  // branch: 1
+  // call: 4
+  // compare: 1
+  // divide: 5
+  // multiply: 131
+  // negate: 13
+  // total: 223
+  
+  let v0007: f64 = w.get(2, 0);
+  let v0003: f64 = w.get(0, 0);
+  let v0005: f64 = w.get(1, 0);
+  let v0483: f64 = v0007 * v0007;
+  let v0479: f64 = v0003 * v0003;
+  let v0475: f64 = v0005 * v0005;
+  let v0009: f64 = v0475 + v0479 + v0483;
+  let v0014: f64 = 0.5f64;
+  let v0010: f64 = (v0009).sqrt();
+  let v0024: f64 = ((1i64) as f64 + v0009 * 0.25f64).sqrt();
+  let v0016: f64 = v0010 * v0014;
+  let v0025: f64 = (1i64) as f64 / v0024;
+  let v0017: f64 = (v0016).sin();
+  let v0013: f64 = (1i64) as f64 / v0010;
+  let v0478: f64 = v0014 * v0025;
+  let v0472: f64 = v0013 * v0017;
+  let v0011: bool = (1e-16f64) < (v0010);
+  let v0037: f64 = (v0016).cos();
+  let v0042: f64 = if v0011 { (v0003 * v0472) } else { (v0003 * v0478) };
+  let v0038: f64 = if v0011 { v0037 } else { v0025 };
+  let v0034: f64 = if v0011 { (v0007 * v0472) } else { (v0007 * v0478) };
+  let v0027: f64 = if v0011 { (v0005 * v0472) } else { (v0005 * v0478) };
+  if let Some(R_D_w) = R_D_w {
+    let v0535: f64 = -((1i64) as f64 / (v0010 * v0010 * v0010));
+    let v0513: f64 = ((1i64) as f64 / v0009) * (v0014 * v0037);
+    let v0075: f64 = (1i64) as f64 / (v0024 * v0024 * v0024);
+    let v0250: f64 = v0017 * v0535 + v0513;
+    let v0473: f64 = (-0.125f64) * v0075;
+    let v0114: f64 = -0.25f64;
+    let v0509: f64 = (-0.5f64) * v0472;
+    let v0481: f64 = v0003 * v0250;
+    let v0138: f64 = if v0011 { (v0007 * v0509) } else { (v0114 * (v0007 * v0075)) };
+    let v0084: f64 = if v0011 { (v0007 * v0481) } else { (v0473 * (v0003 * v0007)) };
+    let v0077: f64 = if v0011 { (v0005 * v0481) } else { (v0473 * (v0003 * v0005)) };
+    let v0130: f64 = if v0011 { (v0005 * v0509) } else { (v0114 * (v0005 * v0075)) };
+    let v0124: f64 = if v0011 { (v0250 * v0479 + v0472) } else { (v0473 * v0479 + v0478) };
+    let v0116: f64 = if v0011 { (v0003 * v0509) } else { (v0114 * (v0003 * v0075)) };
+    let v0109: f64 = if v0011 { (v0250 * v0483 + v0472) } else { (v0473 * v0483 + v0478) };
+    let v0100: f64 = if v0011 { (v0005 * (v0007 * v0250)) } else { (v0473 * (v0005 * v0007)) };
+    let v0094: f64 = if v0011 { (v0475 * v0513 + v0017 * (v0013 + v0475 * v0535)) } else { (v0473 * v0475 + v0478) };
+    let v0289: f64 = v0038 * v0084;
+    let v0361: f64 = v0038 * v0077;
+    let v0295: f64 = v0038 * v0100;
+    let v0520: f64 = v0289 + v0042 * v0138;
+    let v0269: f64 = v0034 * v0100;
+    let v0529: f64 = v0042 * v0130 + v0361;
+    let v0277: f64 = v0027 * v0100;
+    let v0528: f64 = v0042 * v0116 + v0038 * v0124;
+    let v0313: f64 = v0034 * v0077;
+    let v0300: f64 = v0027 * v0084;
+    let v0257: f64 = v0034 * v0084;
+    let v0299: f64 = v0042 * v0100;
+    let v0306: f64 = v0042 * v0084;
+    let v0523: f64 = v0034 * v0138 + v0038 * v0109;
+    let v0521: f64 = v0034 * v0130 + v0295;
+    let v0256: f64 = v0027 * v0077;
+    let v0518: f64 = v0034 * v0116 + v0289;
+    let v0287: f64 = v0042 * v0077;
+    let v0522: f64 = v0295 + v0027 * v0138;
+    let v0531: f64 = v0027 * v0130 + v0038 * v0094;
+    let v0530: f64 = v0361 + v0027 * v0116;
+    let v0268: f64 = v0027 * v0094;
+    let v0341: f64 = v0042 * v0124;
+    let v0516: f64 = v0269 + v0027 * v0109;
+    let v0517: f64 = v0277 + v0034 * v0094;
+    let v0526: f64 = v0300 + v0313;
+    let v0515: f64 = v0257 + v0042 * v0109;
+    let v0525: f64 = v0299 + v0313;
+    let v0527: f64 = v0306 + v0034 * v0124;
+    let v0278: f64 = v0034 * v0109;
+    let v0524: f64 = v0299 + v0300;
+    let v0514: f64 = v0256 + v0042 * v0094;
+    let v0519: f64 = v0287 + v0027 * v0124;
+    let v0532: f64 = -(4i64) as f64;
+    R_D_w.set(0, 0, (v0256 + v0257) * v0532);
+    R_D_w.set(0, 1, (v0268 + v0269) * v0532);
+    R_D_w.set(0, 2, (v0277 + v0278) * v0532);
+    R_D_w.set(1, 0, (2i64) as f64 * (v0518 + v0519));
+    R_D_w.set(1, 1, (2i64) as f64 * (v0514 + v0521));
+    R_D_w.set(1, 2, (2i64) as f64 * (v0523 + v0524));
+    R_D_w.set(2, 0, (2i64) as f64 * (v0527 + -v0530));
+    R_D_w.set(2, 1, (2i64) as f64 * (v0525 + -v0531));
+    R_D_w.set(2, 2, (2i64) as f64 * (v0515 + -v0522));
+    R_D_w.set(3, 0, (2i64) as f64 * (v0519 + -v0518));
+    R_D_w.set(3, 1, (2i64) as f64 * (v0514 + -v0521));
+    R_D_w.set(3, 2, (2i64) as f64 * (v0524 + -v0523));
+    R_D_w.set(4, 0, (v0257 + v0341) * v0532);
+    R_D_w.set(4, 1, (v0269 + v0287) * v0532);
+    R_D_w.set(4, 2, (v0278 + v0306) * v0532);
+    R_D_w.set(5, 0, (2i64) as f64 * (v0526 + v0528));
+    R_D_w.set(5, 1, (2i64) as f64 * (v0517 + v0529));
+    R_D_w.set(5, 2, (2i64) as f64 * (v0516 + v0520));
+    R_D_w.set(6, 0, (2i64) as f64 * (v0527 + v0530));
+    R_D_w.set(6, 1, (2i64) as f64 * (v0525 + v0531));
+    R_D_w.set(6, 2, (2i64) as f64 * (v0515 + v0522));
+    R_D_w.set(7, 0, (2i64) as f64 * (v0526 + -v0528));
+    R_D_w.set(7, 1, (2i64) as f64 * (v0517 + -v0529));
+    R_D_w.set(7, 2, (2i64) as f64 * (v0516 + -v0520));
+    R_D_w.set(8, 0, (v0256 + v0341) * v0532);
+    R_D_w.set(8, 1, (v0268 + v0287) * v0532);
+    R_D_w.set(8, 2, (v0277 + v0306) * v0532);
+  }
+  let v0227: f64 = v0042 * v0042;
+  let v0209: f64 = v0027 * v0027;
+  let v0534: f64 = -v0038;
+  let v0210: f64 = v0034 * v0034;
+  let v0533: f64 = -(2i64) as f64;
+  let v0232: f64 = v0027 * v0034;
+  let v0218: f64 = v0034 * v0042;
+  let v0215: f64 = v0027 * v0042;
+  R.set(0, 0, (1i64) as f64 + (v0209 + v0210) * v0533);
+  R.set(0, 1, (2i64) as f64 * (v0034 * v0534 + v0215));
+  R.set(0, 2, (2i64) as f64 * (v0218 + v0027 * v0038));
+  R.set(1, 0, (2i64) as f64 * (v0215 + v0034 * v0038));
+  R.set(1, 1, (1i64) as f64 + (v0210 + v0227) * v0533);
+  R.set(1, 2, (2i64) as f64 * (v0042 * v0534 + v0232));
+  R.set(2, 0, (2i64) as f64 * (v0218 + v0027 * v0534));
+  R.set(2, 1, (2i64) as f64 * (v0232 + v0038 * v0042));
+  R.set(2, 2, (1i64) as f64 + (v0209 + v0227) * v0533);
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn quaternion_from_matrix<T0, T1, >(R: &T0, q_xyzw: &mut T1) -> ()
 where
   T0: wrenfold_traits::Span2D<3, 3, ValueType = f64>,
@@ -579,7 +755,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn rotation_vector_from_matrix<T0, T1, >(R: &T0, w: &mut T1) -> ()
 where
   T0: wrenfold_traits::Span2D<3, 3, ValueType = f64>,
@@ -696,7 +872,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn no_required_outputs<>(x: f64, out1: Option<&mut f64>, out2: Option<&mut f64>) -> ()
 {
   // Operation counts:
@@ -716,7 +892,7 @@ pub fn no_required_outputs<>(x: f64, out1: Option<&mut f64>, out2: Option<&mut f
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn custom_type_1<>(p: &crate::types::Point2d) -> crate::types::Point2d
 {
   // Operation counts:
@@ -745,7 +921,7 @@ pub fn custom_type_1<>(p: &crate::types::Point2d) -> crate::types::Point2d
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn custom_type_2<T3, >(theta: f64, radius: f64, out: Option<&mut crate::types::Point2d>, D_inputs: Option<&mut T3>) -> ()
 where
   T3: wrenfold_traits::OutputSpan2D<2, 2, ValueType = f64>,
@@ -775,7 +951,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn custom_type_3<>(out: &mut crate::types::Point2d) -> ()
 {
   // Operation counts:
@@ -786,7 +962,7 @@ pub fn custom_type_3<>(out: &mut crate::types::Point2d) -> ()
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn nested_custom_type_1<>(c: &crate::types::Circle, p: &crate::types::Point2d) -> crate::types::Circle
 {
   // Operation counts:
@@ -817,7 +993,7 @@ pub fn nested_custom_type_1<>(c: &crate::types::Circle, p: &crate::types::Point2
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_1<>(x: f64, y: f64) -> f64
 {
   // Operation counts:
@@ -832,7 +1008,7 @@ pub fn external_function_call_1<>(x: f64, y: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_2<T0, T1, >(u: &T0, v: &T1) -> f64
 where
   T0: wrenfold_traits::Span2D<2, 1, ValueType = f64>,
@@ -853,7 +1029,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_3<T1, >(x: f64, v: &T1) -> nalgebra::SMatrix<f64, 2, 2>
 where
   T1: wrenfold_traits::Span2D<2, 1, ValueType = f64>,
@@ -871,7 +1047,7 @@ where
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_4<>(a: f64, b: f64) -> f64
 {
   // Operation counts:
@@ -898,7 +1074,7 @@ pub fn external_function_call_4<>(a: f64, b: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_5<>(c: &crate::types::Circle, x: f64, y: f64) -> f64
 {
   // Operation counts:
@@ -916,7 +1092,7 @@ pub fn external_function_call_5<>(c: &crate::types::Circle, x: f64, y: f64) -> f
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
 {
   // Operation counts:
@@ -941,7 +1117,7 @@ pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn integer_argument_1<>(x: i64, y: f64) -> f64
 {
   // Operation counts:
@@ -954,7 +1130,7 @@ pub fn integer_argument_1<>(x: i64, y: f64) -> f64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn integer_output_values_1<>(x: i64, y: f64, baz: &mut i64) -> i64
 {
   // Operation counts:
@@ -971,7 +1147,7 @@ pub fn integer_output_values_1<>(x: i64, y: f64, baz: &mut i64) -> i64
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn integer_struct_member_1<>(inputs: &crate::types::MixedNumerics, scale: f64) -> f64
 {
   // Operation counts:
@@ -994,7 +1170,7 @@ pub fn integer_struct_member_1<>(inputs: &crate::types::MixedNumerics, scale: f6
 }
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn integer_struct_member_2<>(x: f64, y: f64) -> crate::types::MixedNumerics
 {
   // Operation counts:

--- a/components/core/tests/rust_generation_test/src/lib.rs
+++ b/components/core/tests/rust_generation_test/src/lib.rs
@@ -245,6 +245,62 @@ fn test_nested_conditionals_2() {
 }
 
 #[test]
+fn test_nested_conditionals_1_with_ternaries() {
+    assert_eq!(
+        1.9875135408080455,
+        generated::nested_conditionals_1_with_ternaries(0.5, 0.2)
+    );
+    assert_eq!(
+        0.2127659962913584,
+        generated::nested_conditionals_1_with_ternaries(0.1, 0.3)
+    );
+    assert_eq!(
+        2.664161305696031,
+        generated::nested_conditionals_1_with_ternaries(2.4, -0.11)
+    );
+    assert_eq!(
+        0.20636916796204946,
+        generated::nested_conditionals_1_with_ternaries(1.3, -3.0)
+    );
+    assert_eq!(
+        1.6620319900924367,
+        generated::nested_conditionals_1_with_ternaries(-0.8, 0.66)
+    );
+    assert_eq!(
+        0.35166057729244216,
+        generated::nested_conditionals_1_with_ternaries(-0.123, -0.5)
+    );
+}
+
+#[test]
+fn test_nested_conditionals_2_with_ternaries() {
+    assert_eq!(
+        0.998948281966456,
+        generated::nested_conditionals_2_with_ternaries(0.73, 0.02)
+    );
+    assert_eq!(
+        2.093418257300724,
+        generated::nested_conditionals_2_with_ternaries(1.32, 1.32)
+    );
+    assert_eq!(
+        -21.598735511069624,
+        generated::nested_conditionals_2_with_ternaries(7.2, -7.0)
+    );
+    assert_eq!(
+        4.907137658554118,
+        generated::nested_conditionals_2_with_ternaries(5.6, -6.3)
+    );
+    assert_eq!(
+        33.78428079355372,
+        generated::nested_conditionals_2_with_ternaries(-1.0, 0.95)
+    );
+    assert_eq!(
+        0.0,
+        generated::nested_conditionals_2_with_ternaries(-1.7, -2.0)
+    );
+}
+
+#[test]
 fn test_no_required_outputs() {
     let x: f64 = -1.142;
 

--- a/components/core/tests/rust_generation_test_2/src/generated.rs
+++ b/components/core/tests/rust_generation_test_2/src/generated.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[inline]
-#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables)]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn lookup_and_compute_inner_product<>(vec: &std::vec::Vec<crate::types::StructType>, a: f64, b: f64) -> f64
 {
   // Operation counts:

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -30,7 +30,13 @@ std::string generate_test_expressions(Generator gen) {
   generate_func(gen, code, &atan2_with_derivatives, "atan2_with_derivatives", arg("y"), arg("x"));
   generate_func(gen, code, &nested_conditionals_1, "nested_conditionals_1", arg("x"), arg("y"));
   generate_func(gen, code, &nested_conditionals_2, "nested_conditionals_2", arg("x"), arg("y"));
+  generate_func(gen, code, &nested_conditionals_1, false, "nested_conditionals_1_with_ternaries",
+                arg("x"), arg("y"));
+  generate_func(gen, code, &nested_conditionals_2, false, "nested_conditionals_2_with_ternaries",
+                arg("x"), arg("y"));
   generate_func(gen, code, &create_rotation_matrix, "create_rotation_matrix", arg("w"));
+  generate_func(gen, code, &create_rotation_matrix, false, "create_rotation_matrix_with_ternaries",
+                arg("w"));
   generate_func(gen, code, &quaternion_from_matrix, "quaternion_from_matrix", arg("R"));
   generate_func(gen, code, &rotation_vector_from_matrix, "rotation_vector_from_matrix", arg("R"));
   generate_func(gen, code, &no_required_outputs, "no_required_outputs", arg("x"));

--- a/components/core/wf/code_generation/ast.h
+++ b/components/core/wf/code_generation/ast.h
@@ -251,6 +251,15 @@ struct return_object {
   ast_element value;
 };
 
+// A ternary conditional statement: condition ? if_branch : else_branch;
+struct ternary {
+  static constexpr std::string_view snake_case_name_str = "ternary";
+
+  ast_element condition;
+  ast_element left;
+  ast_element right;
+};
+
 // Usage of a variable.
 struct variable_ref {
   static constexpr std::string_view snake_case_name_str = "variable_ref";

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -342,7 +342,7 @@ ast::ast_element ast_form_visitor::visit_value(const ir::value& value) {
         // These types are placeholders, and don't directly appear in the ast output:
         using T = std::decay_t<decltype(op)>;
         using excluded_types =
-            type_list<ir::jump_condition, ir::save, ir::cond, ir::phi, ir::output_required>;
+            type_list<ir::jump_condition, ir::save, ir::phi, ir::output_required>;
         if constexpr (type_list_contains_v<T, excluded_types>) {
           throw type_error("Type cannot be converted to AST: {}", typeid(T).name());
         } else {
@@ -409,6 +409,13 @@ ast::ast_element ast_form_visitor::operator()(const ir::value& val,
   type_constructor constructor{transform_operands(val, std::nullopt)};
   return std::visit([&](const auto& x) { return ast::ast_element(constructor(x)); },
                     construct.type());
+}
+
+ast::ast_element ast_form_visitor::operator()(const ir::value& val, const ir::cond&) {
+  return ast::ast_element{std::in_place_type_t<ast::ternary>{},
+                          visit_operation_argument(val[0], precedence::ternary),
+                          visit_operation_argument(val[1], precedence::ternary),
+                          visit_operation_argument(val[2], precedence::ternary)};
 }
 
 ast::ast_element ast_form_visitor::operator()(const ir::value& val, const ir::copy&) {

--- a/components/core/wf/code_generation/ast_conversion.h
+++ b/components/core/wf/code_generation/ast_conversion.h
@@ -91,6 +91,7 @@ class ast_form_visitor {
   ast::ast_element operator()(const ir::value& val, const ir::cast& cast);
   ast::ast_element operator()(const ir::value& val, const ir::compare& compare);
   ast::ast_element operator()(const ir::value& val, const ir::construct& construct);
+  ast::ast_element operator()(const ir::value& val, const ir::cond&);
   ast::ast_element operator()(const ir::value& val, const ir::copy&);
   ast::ast_element operator()(const ir::value& val, const ir::div&);
   ast::ast_element operator()(const ir::value& val, const ir::get& get);

--- a/components/core/wf/code_generation/ast_element.h
+++ b/components/core/wf/code_generation/ast_element.h
@@ -45,6 +45,7 @@ using ast_element_types = type_list<
     struct parenthetical,
     struct special_constant,
     struct return_object,
+    struct ternary,
     struct variable_ref
     >;
 // clang-format on

--- a/components/core/wf/code_generation/ast_formatters.h
+++ b/components/core/wf/code_generation/ast_formatters.h
@@ -186,6 +186,11 @@ auto format_ast(Iterator it, const wf::ast::return_object& r) {
 }
 
 template <typename Iterator>
+auto format_ast(Iterator it, const wf::ast::ternary& t) {
+  return fmt::format_to(it, "({} ? {} : {})", t.condition, t.left, t.right);
+}
+
+template <typename Iterator>
 auto format_ast(Iterator it, const wf::ast::special_constant& c) {
   return fmt::format_to(it, "({})", string_from_symbolic_constant(c.value));
 }

--- a/components/core/wf/code_generation/control_flow_graph.cc
+++ b/components/core/wf/code_generation/control_flow_graph.cc
@@ -208,9 +208,10 @@ void control_flow_graph::factorize_sums(const std::size_t num_passes) {
 #endif
 }
 
-control_flow_graph control_flow_graph::convert_conditionals_to_control_flow() && {
+control_flow_graph control_flow_graph::convert_conditionals_to_control_flow(
+    bool convert_ternaries) && {
   WF_FUNCTION_TRACE();
-  return ir_control_flow_converter{std::move(*this)}.convert();
+  return ir_control_flow_converter{std::move(*this), convert_ternaries}.convert();
 }
 
 // A hash-set of values:

--- a/components/core/wf/code_generation/control_flow_graph.h
+++ b/components/core/wf/code_generation/control_flow_graph.h
@@ -22,7 +22,7 @@ struct optimization_params {
 // Store intermediate representation values and blocks. The blocks are arranged in a graph
 // that describes the control flow in a code-generation function.
 // TODO: I tend to think the structure of this object could be improved:
-//  - The use of "standard blocks" potentially overcomplicates things. The original motivation was
+//  - The use of "standard blocks" potentially over-complicates things. The original motivation was
 //    to learn from examples in compilers, but we only really need if-else support for now.
 //  - I dislike that objects are connected via non-owning pointers. Maybe indices into an array
 //    would be safer. Each `ir::value` object is fairly large, and could could potentially be split
@@ -36,7 +36,7 @@ class control_flow_graph {
   // Consume `this` and convert to a control flow graph that contains jumps.
   // This converts the graph from one with `cond` operations to one with multiple blocks and jump
   // operations.
-  control_flow_graph convert_conditionals_to_control_flow() &&;
+  control_flow_graph convert_conditionals_to_control_flow(bool convert_ternaries = true) &&;
 
   // Format IR for every value.
   std::string to_string() const;

--- a/components/core/wf/code_generation/cpp_code_generator.h
+++ b/components/core/wf/code_generation/cpp_code_generator.h
@@ -80,6 +80,8 @@ class cpp_code_generator {
 
   virtual std::string operator()(const ast::special_constant& x) const;
 
+  virtual std::string operator()(const ast::ternary& x) const;
+
   virtual std::string operator()(const ast::variable_ref& x) const;
 
   // Accept `ast_element`.

--- a/components/core/wf/code_generation/ir_control_flow_converter.cc
+++ b/components/core/wf/code_generation/ir_control_flow_converter.cc
@@ -40,8 +40,9 @@ static auto get_reverse_ordered_output_values(
   return std::make_tuple(std::move(required_outputs_queue), std::move(optional_outputs));
 }
 
-ir_control_flow_converter::ir_control_flow_converter(control_flow_graph&& input)
-    : values_(std::move(input.values_)) {
+ir_control_flow_converter::ir_control_flow_converter(control_flow_graph&& input,
+                                                     const bool convert_ternaries)
+    : values_(std::move(input.values_)), convert_ternaries_(convert_ternaries) {
   visited_.reserve(values_.size());
 
   WF_ASSERT_EQ(1, input.blocks_.size(),
@@ -182,7 +183,7 @@ std::vector<ir::value_ptr> ir_control_flow_converter::process_non_conditionals(
       continue;
     }
 
-    if (top->is_op<ir::cond>()) {
+    if (top->is_op<ir::cond>() && convert_ternaries_) {
       // Defer conditionals to be processed together later:
       queued_conditionals.push_back(top);
       continue;

--- a/components/core/wf/code_generation/ir_control_flow_converter.h
+++ b/components/core/wf/code_generation/ir_control_flow_converter.h
@@ -14,7 +14,7 @@ namespace wf {
 class ir_control_flow_converter {
  public:
   // Construct from existing control flow graph. The contents are moved, and `input` is left empty.
-  explicit ir_control_flow_converter(control_flow_graph&& input);
+  explicit ir_control_flow_converter(control_flow_graph&& input, bool convert_ternaries);
 
   // Convert all ternary `cond` statements into conditionals, introducing new blocks and jump
   // statements in the process. Return a new control flow graph (consuming `this` in the process).
@@ -52,9 +52,10 @@ class ir_control_flow_converter {
   ir::block_ptr create_block();
 
   std::vector<ir::value::unique_ptr> values_;
-  std::vector<ir::block::unique_ptr> blocks_{};
-  std::unordered_set<ir::const_value_ptr> visited_{};
+  std::vector<ir::block::unique_ptr> blocks_;
+  std::unordered_set<ir::const_value_ptr> visited_;
   ir::block::unique_ptr input_block_;
+  bool convert_ternaries_;
 };
 
 }  // namespace wf

--- a/components/core/wf/code_generation/ir_value.cc
+++ b/components/core/wf/code_generation/ir_value.cc
@@ -48,6 +48,7 @@ precedence value::operation_precedence() const {
             load.variant());
       },
       [](const ir::div&) constexpr { return precedence::multiplication; },
+      [](const ir::cond&) constexpr { return precedence::ternary; },
       [](const auto&) constexpr { return precedence::none; });
 }
 

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -49,6 +49,7 @@ static std::vector<std::string_view> get_attributes(const ast::function_signatur
   result.push_back("clippy::collapsible_else_if");
   result.push_back("clippy::needless_late_init");
   result.push_back("unused_variables");
+  result.push_back("unused_parens");
   return result;
 }
 
@@ -366,6 +367,11 @@ std::string rust_code_generator::operator()(const ast::parenthetical& x) const {
 
 std::string rust_code_generator::operator()(const ast::special_constant& x) const {
   return std::string{rust_string_for_symbolic_constant(x.value)};
+}
+
+std::string rust_code_generator::operator()(const ast::ternary& x) const {
+  return fmt::format("if {} {{ {} }} else {{ {} }}", make_view(x.condition), make_view(x.left),
+                     make_view(x.right));
 }
 
 std::string rust_code_generator::operator()(const ast::variable_ref& x) const { return x.name; }

--- a/components/core/wf/code_generation/rust_code_generator.h
+++ b/components/core/wf/code_generation/rust_code_generator.h
@@ -77,6 +77,8 @@ class rust_code_generator {
 
   virtual std::string operator()(const ast::special_constant& x) const;
 
+  virtual std::string operator()(const ast::ternary& x) const;
+
   virtual std::string operator()(const ast::variable_ref& x) const;
 
   // Accept `ast_element`.

--- a/components/core/wf/enumerations.h
+++ b/components/core/wf/enumerations.h
@@ -17,6 +17,7 @@ enum class precedence : int {
   addition,
   multiplication,
   power,
+  ternary,
   none = std::numeric_limits<int>::max(),
 };
 
@@ -154,6 +155,8 @@ constexpr std::string_view string_from_precedence(const precedence p) noexcept {
       return "multiplication";
     case precedence::power:
       return "power";
+    case precedence::ternary:
+      return "ternary";
     case precedence::none:
       return "none";
   }

--- a/components/core/wf/utility/strings.h
+++ b/components/core/wf/utility/strings.h
@@ -113,7 +113,7 @@ std::string join_enumerate(const std::string_view separator, const Container& co
 
 // Indent a string and prefix/suffix it with open and closing brackets.
 template <typename Formatter, typename Container>
-void join_and_indent(std::string& output, const std::size_t indendation,
+void join_and_indent(std::string& output, const std::size_t indentation,
                      const std::string_view open, const std::string_view close,
                      const std::string_view separator, const Container& container,
                      Formatter&& formatter) {
@@ -123,13 +123,13 @@ void join_and_indent(std::string& output, const std::size_t indendation,
   output.reserve(output.size() + joined.size());
 
   // Indent the first line:
-  output.insert(output.end(), indendation, ' ');
+  output.insert(output.end(), indentation, ' ');
 
   for (auto char_it = joined.begin(); char_it != joined.end(); ++char_it) {
     output.push_back(*char_it);
     // Every instance of a newline should have indentation (as long as the string is not ending).
     if (*char_it == '\n' && std::next(char_it) != joined.end()) {
-      output.insert(output.end(), indendation, ' ');
+      output.insert(output.end(), indentation, ' ');
     }
   }
   output.append(close);

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -186,7 +186,8 @@ def create_function_description(func: T.Callable[..., CodegenFuncInvocationResul
 def generate_function(func: T.Callable[..., CodegenFuncInvocationResult],
                       generator: T.Union[CppGenerator, RustGenerator, BaseGenerator],
                       name: T.Optional[str] = None,
-                      optimization_params: T.Optional[OptimizationParams] = None) -> str:
+                      optimization_params: T.Optional[OptimizationParams] = None,
+                      convert_ternaries: bool = True) -> str:
     """
     Accept a python function that manipulates symbolic mathematical expressions, and convert it
     to code in the language emitted by ``generator``. This is a three-step process:
@@ -205,10 +206,14 @@ def generate_function(func: T.Callable[..., CodegenFuncInvocationResult],
 
     Args:
         func: A python function with type-annotated arguments. See
-          :func:`wrenfold.code_generation.create_function_description` for notes on the expected signature.
+          :func:`wrenfold.code_generation.create_function_description` for notes on the expected
+          signature.
         generator: Instance of a code generator, eg. :class:`wrenfold.code_generation.CppGenerator`.
         name: Name of the function. If unspecified, ``func.__name__`` will be used.
-        optimization_params: Parameters governing simplifications/optimizations applied to the output code.
+        optimization_params: Parameters governing simplifications/optimizations applied to the
+          output code.
+        convert_ternaries: Whether to convert ternary :func:`wrenfold.sym.where` statements to
+          if-else control flow. Defaults to true.
 
     Returns: Generated code.
 
@@ -243,7 +248,8 @@ def generate_function(func: T.Callable[..., CodegenFuncInvocationResult],
         }
     """
     description = create_function_description(func=func, name=name)
-    func_ast = transpile(description, params=optimization_params)
+    func_ast = transpile(
+        description, optimization_params=optimization_params, convert_ternaries=convert_ternaries)
     return generator.generate(definition=func_ast)
 
 

--- a/components/wrapper/pywrenfold/ast_wrapper.cc
+++ b/components/wrapper/pywrenfold/ast_wrapper.cc
@@ -382,6 +382,18 @@ void wrap_ast(py::module_& m) {
           "Enum indicating the value of the constant.")
       .doc() = "Emit a mathematical constant";
 
+  map.at<ast::ternary>()
+      .def_property_readonly("condition", to_inner_accessor(&ast::ternary::condition),
+                             py::return_value_policy::reference, py::keep_alive<0, 1>(),
+                             "Value that should be wrapped in parentheses.")
+      .def_property_readonly("left", to_inner_accessor(&ast::ternary::left),
+                             py::return_value_policy::reference, py::keep_alive<0, 1>(),
+                             "Value when the condition is true.")
+      .def_property_readonly("right", to_inner_accessor(&ast::ternary::right),
+                             py::return_value_policy::reference, py::keep_alive<0, 1>(),
+                             "Value when the condition is false.")
+      .doc() = "A ternary expression: ``condition ? left : right``";
+
   map.at<ast::variable_ref>()
       .def_property_readonly(
           "name", [](const ast::variable_ref& v) { return v.name; }, "Name of the variable.")

--- a/components/wrapper/pywrenfold/docs/codegen_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/codegen_wrapper.h
@@ -22,7 +22,9 @@ your project.
 
 Args:
   desc: :class:`wrenfold.code_generation.FunctionDescription` object.
-  params: Optional parameters to control subexpression elimination.
+  optimization_params: Optional parameters to control subexpression elimination.
+  convert_ternaries: If true, ternary :func:`wrenfold.sym.where` statements become if-else control
+    flow.
 
 Returns:
   Instance of :class:`wrenfold.ast.FunctionDefinition`.
@@ -50,7 +52,7 @@ subexpressions required to evaluate the function.
 
 Args:
   desc: :class:`wrenfold.code_generation.FunctionDescription` object.
-  params: Optional parameters to control subexpression elimination.
+  optimization_params: Optional parameters to control subexpression elimination.
 
 Returns:
   A dict mapping from ``OutputKey`` to output expressions, and a list of intermediate subexpressions


### PR DESCRIPTION
Part 1 of implementing https://github.com/wrenfold/wrenfold/issues/248 (Python generation)

This change adds a `convert_ternaries` parameter that permits the user to select a configuration where `sym.where` conditional statements are left in ternary form, rather than being converted to if-else blocks.

This is so that we can more easily emit conditionals like `np.where`, `th.where`, `tf.where` when targeting NumPy/PyTorch/TensorFlow code.

**Breaking** change: `transpile` parameter `params` is renamed to `optimization_params`.