### PR TITLE
Python examples and tests use `-m` module invocation

### DIFF
--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -9,11 +9,11 @@ import dataclasses
 import typing as T
 import unittest
 
-from test_base import MathTestBase
-
 from wrenfold import ast, code_generation, external_functions, sym, type_info
 from wrenfold.enumerations import StdMathFunction
 from wrenfold.type_annotations import FloatScalar, Opaque, Vector2
+
+from .test_base import MathTestBase
 
 
 def func1(x: FloatScalar, y: FloatScalar, v: Vector2):

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -7,9 +7,9 @@ don't accidentally remove any.
 import functools
 import unittest
 
-from test_base import MathTestBase
-
 from wrenfold import enumerations, exceptions, expressions, sym
+
+from .test_base import MathTestBase
 
 
 class ExpressionWrapperTest(MathTestBase):

--- a/components/wrapper/tests/external_function_wrapper_test.py
+++ b/components/wrapper/tests/external_function_wrapper_test.py
@@ -4,8 +4,6 @@ Test ability to create and insert user-specified external functions into the exp
 import dataclasses
 import unittest
 
-from test_base import MathTestBase
-
 from wrenfold import (
     custom_types,
     exceptions,
@@ -14,6 +12,8 @@ from wrenfold import (
     type_info,
 )
 from wrenfold.type_annotations import FloatScalar, Opaque, Vector2, Vector3
+
+from .test_base import MathTestBase
 
 
 class ExternalFunctionWrapperTest(MathTestBase):

--- a/components/wrapper/tests/geometry_wrapper_test.py
+++ b/components/wrapper/tests/geometry_wrapper_test.py
@@ -5,10 +5,10 @@ NB: Most of this is tested in `quaternion_test.cc`. This is just a test of the w
 """
 import unittest
 
-from test_base import MathTestBase
-
 from wrenfold import sym
 from wrenfold.geometry import Quaternion
+
+from .test_base import MathTestBase
 
 
 class GeometryWrapperTest(MathTestBase):

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -8,9 +8,10 @@ import typing as T
 import unittest
 
 import numpy as np
-from test_base import MathTestBase
 
 from wrenfold import exceptions, sym
+
+from .test_base import MathTestBase
 
 
 class MatrixWrapperTest(MathTestBase):

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -6,9 +6,10 @@ import typing as T
 import unittest
 
 import sympy as sp
-from test_base import MathTestBase
 
 from wrenfold import sym, sympy_conversion, type_info
+
+from .test_base import MathTestBase
 
 # Some shorthand for the purpose of this test:
 spy = sympy_conversion.to_sympy


### PR DESCRIPTION
Python examples and tests now use the `-m` module invocation when run from CMake. This enables relative imports between different sub-directories in the repository.