### PR TITLE
Add `stop_derivative` expression type

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(
   wf/expressions/matrix.h
   wf/expressions/multiplication.cc
   wf/expressions/multiplication.h
+  wf/expressions/stop_derivative.cc
+  wf/expressions/stop_derivative.h
   wf/expressions/numeric_expressions.h
   wf/expressions/power.cc
   wf/expressions/power.h

--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -153,7 +153,7 @@ inline testing::AssertionResult expect_complex_near(
     return testing::AssertionFailure() << fmt::format(
                "std::complex comparison {a} == {b} failed because:\n"
                "{a} = ({a_real}, {a_imag}) and,\n{b} = ({b_real}, {b_imag})\n"
-               "The diference between them is {a} - {b} = ({delta_real}, {delta_imag}).\n"
+               "The difference between them is {a} - {b} = ({delta_real}, {delta_imag}).\n"
                "And {name_tol} evaluates to: {tol}.\n",
                fmt::arg("a", name_a), fmt::arg("b", name_b), fmt::arg("a_real", a.real()),
                fmt::arg("a_imag", a.imag()), fmt::arg("b_real", b.real()),

--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -436,4 +436,13 @@ TEST(DerivativesTest, TestSubstitution) {
   }
 }
 
+TEST(DerivativesTest, TestStopDerivative) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_IDENTICAL(0, stop_diff(x * y).diff(x));
+  ASSERT_IDENTICAL(0, stop_diff(x * y).diff(y, 2));
+  ASSERT_IDENTICAL(3 * cos(3 * y) * stop_diff(x * y), (sin(3 * y) * stop_diff(x * y)).diff(y));
+  ASSERT_IDENTICAL(-sin(y) * stop_diff(2 * y), (sin(y) * stop_diff(2 * y)).diff(y, 2));
+  ASSERT_NOT_IDENTICAL(stop_diff(x), stop_diff(y));
+}
+
 }  // namespace wf

--- a/components/core/tests/ir_conversion_test.cc
+++ b/components/core/tests/ir_conversion_test.cc
@@ -813,6 +813,17 @@ TEST(IrTest, TestBuiltInFunctions) {
   check_expressions_with_output_permutations(expected_expressions, output_ir);
 }
 
+TEST(IrTest, TestStopDerivative) {
+  // Test that stop_derivative is stripped during conversion.
+  auto [_, ir] = create_ir([](scalar_expr x, scalar_expr y) { return stop_diff(x * y); }, "func",
+                           arg("x"), arg("y"));
+
+  auto [expected_expressions, __] =
+      create_ir([](scalar_expr x, scalar_expr y) { return x * y; }, "func", arg("x"), arg("y"));
+
+  check_expressions(expected_expressions, ir);
+}
+
 // Make a external function that accepts two arguments (one scalar, one matrix).
 class custom_func_1 : public declare_external_function<
                           custom_func_1, scalar_expr,

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -168,6 +168,12 @@ TEST(PlainFormatterTest, TestDerivativeExpression) {
                 signum(a).diff(a, 2, non_differentiable_behavior::abstract));
 }
 
+TEST(PlainFormatterTest, TestStopDerivative) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_STR_EQ("StopDerivative(x)", stop_diff(x));
+  ASSERT_STR_EQ("StopDerivative(x*y)", stop_diff(x * y));
+}
+
 TEST(PlainFormatterTest, TestSubstitutionExpression) {
   const auto [x, y] = make_symbols("x", "y");
   ASSERT_STR_EQ("Subs(x**2, x, 2 + y)", substitution::create(x * x, x, y + 2));
@@ -176,6 +182,11 @@ TEST(PlainFormatterTest, TestSubstitutionExpression) {
 TEST(PlainFormatterTest, TestComplexInfinity) { ASSERT_STR_EQ("zoo", constants::complex_infinity); }
 
 TEST(PlainFormatterTest, TestUndefined) { ASSERT_STR_EQ("nan", constants::undefined); }
+
+TEST(PlainFormatterTest, TestUnevaluated) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_STR_EQ("(x*y)", make_unevaluated(x * y));
+}
 
 TEST(PlainFormatterTest, TestScalarConstants) {
   ASSERT_STR_EQ("pi", constants::pi);

--- a/components/core/tests/scalar_operations_test.cc
+++ b/components/core/tests/scalar_operations_test.cc
@@ -1368,4 +1368,14 @@ TEST(ScalarOperationsTest, TestNumericSetsSubstitution) {
   ASSERT_EQ(number_set::unknown, determine_numeric_set(substitution::create(complex, real, 0)));
 }
 
+TEST(ScalarOperationsTest, TestNumericSetStopDerivative) {
+  const scalar_expr real{"x", number_set::real};
+  const scalar_expr complex{"z", number_set::complex};
+  const scalar_expr w{"w", number_set::unknown};
+  ASSERT_EQ(number_set::real, determine_numeric_set(stop_diff(real)));
+  ASSERT_EQ(number_set::complex, determine_numeric_set(stop_diff(complex)));
+  ASSERT_EQ(number_set::real_non_negative, determine_numeric_set(stop_diff(real * real)));
+  ASSERT_EQ(number_set::unknown, determine_numeric_set(stop_diff(w)));
+}
+
 }  // namespace wf

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -396,8 +396,14 @@ ir::value_ptr ir_form_visitor::operator()(const relational& relational) {
                         maybe_cast(left, promoted_type), maybe_cast(right, promoted_type));
 }
 
+ir::value_ptr ir_form_visitor::operator()(const stop_derivative& nd) {
+  // Has no meaning at this step, so strip it:
+  return operator()(nd.arg());
+}
+
 ir::value_ptr ir_form_visitor::operator()(const substitution&) const {
-  throw type_error("Cannot generate code with expressions containing: {}", substitution::name_str);
+  throw type_error("Cannot generate code with expressions containing: `{}`",
+                   substitution::name_str);
 }
 
 ir::value_ptr ir_form_visitor::operator()(const symbolic_constant& constant) {

--- a/components/core/wf/code_generation/ir_form_visitor.h
+++ b/components/core/wf/code_generation/ir_form_visitor.h
@@ -62,6 +62,7 @@ class ir_form_visitor {
   ir::value_ptr operator()(const power& power);
   ir::value_ptr operator()(const rational_constant& r);
   ir::value_ptr operator()(const relational& relational);
+  ir::value_ptr operator()(const stop_derivative& nd);
   ir::value_ptr operator()(const substitution& subs) const;
   ir::value_ptr operator()(const symbolic_constant& constant);
   ir::value_ptr operator()(const symbolic_function_invocation& invocation) const;

--- a/components/core/wf/derivative.cc
+++ b/components/core/wf/derivative.cc
@@ -256,6 +256,9 @@ scalar_expr derivative_visitor::operator()(const rational_constant&) const {
   return constants::zero;
 }
 
+// By construction, stop_derivative has a derivative of zero.
+scalar_expr derivative_visitor::operator()(const stop_derivative&) const { return constants::zero; }
+
 scalar_expr derivative_visitor::operator()(const substitution& sub,
                                            const scalar_expr& sub_abstract) {
   // If the target of the substitution is a function of the `x`, play it safe and create an

--- a/components/core/wf/derivative.h
+++ b/components/core/wf/derivative.h
@@ -36,6 +36,7 @@ class derivative_visitor {
   scalar_expr operator()(const float_constant&) const;
   scalar_expr operator()(const power& pow);
   scalar_expr operator()(const rational_constant&) const;
+  scalar_expr operator()(const stop_derivative&) const;
   scalar_expr operator()(const substitution& sub, const scalar_expr& sub_abstract);
   scalar_expr operator()(const symbolic_function_invocation& func,
                          const scalar_expr& func_abstract);

--- a/components/core/wf/expression.cc
+++ b/components/core/wf/expression.cc
@@ -162,7 +162,7 @@ relative_order order_struct<scalar_expr>::compare(const scalar_expr& a,
                 complex_infinity, imaginary_unit, variable, multiplication, addition, power,
                 built_in_function_invocation, symbolic_function_invocation, unevaluated,
                 conditional, iverson_bracket, compound_expression_element, derivative, substitution,
-                undefined>;
+                stop_derivative, undefined>;
   static constexpr auto order =
       get_type_order_indices(scalar_expr::storage_type::types{}, order_of_types{});
 

--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -2,7 +2,6 @@
 // Copyright (c) 2024 Gareth Cross
 // For license information refer to accompanying LICENSE file.
 #pragma once
-#include <memory>
 #include <ostream>  // operator<<
 #include <string>
 
@@ -41,6 +40,7 @@ struct type_list_trait<scalar_meta_type> {
     class multiplication,
     class power,
     class rational_constant,
+    class stop_derivative,
     class substitution,
     class symbolic_function_invocation,
     class undefined,

--- a/components/core/wf/expressions/all_expressions.h
+++ b/components/core/wf/expressions/all_expressions.h
@@ -16,6 +16,7 @@
 #include "wf/expressions/power.h"
 #include "wf/expressions/relational.h"
 #include "wf/expressions/special_constants.h"
+#include "wf/expressions/stop_derivative.h"
 #include "wf/expressions/substitute_expression.h"
 #include "wf/expressions/unevaluated.h"
 #include "wf/expressions/variable.h"

--- a/components/core/wf/expressions/stop_derivative.cc
+++ b/components/core/wf/expressions/stop_derivative.cc
@@ -1,0 +1,18 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#include "wf/expressions/stop_derivative.h"
+
+namespace wf {
+
+scalar_expr stop_derivative::create(scalar_expr arg) {
+  if (arg.is_type<stop_derivative>()) {
+    return arg;
+  } else {
+    return scalar_expr{std::in_place_type_t<stop_derivative>{}, std::move(arg)};
+  }
+}
+
+scalar_expr stop_diff(scalar_expr arg) { return stop_derivative::create(std::move(arg)); }
+
+}  // namespace wf

--- a/components/core/wf/expressions/stop_derivative.h
+++ b/components/core/wf/expressions/stop_derivative.h
@@ -1,0 +1,63 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#pragma once
+#include <span>
+#include <string_view>
+
+#include "wf/expression.h"
+
+namespace wf {
+
+// Expression that stops propagation of derivatives.
+// Taking the derivative of `stop_derivative` is always zero.
+class stop_derivative {
+ public:
+  static constexpr std::string_view name_str = "StopDerivative";
+  static constexpr bool is_leaf_node = false;
+
+  explicit stop_derivative(scalar_expr arg) noexcept : arg_(std::move(arg)) {}
+
+  constexpr auto begin() const noexcept { return std::addressof(arg_); }
+  constexpr auto end() const noexcept { return begin() + 1; }
+
+  constexpr const auto& arg() const noexcept { return arg_; }
+
+  // Get a span over the single child.
+  constexpr auto children() const noexcept {
+    return std::span<const scalar_expr, 1>{begin(), end()};
+  }
+
+  template <typename Operation>
+  scalar_expr map_children(Operation&& operation) const {
+    return create(operation(arg_));
+  }
+
+  // Wrap `arg` in `null_derivative`.
+  // If the argument is already a `null_derivative`, we don't add another.
+  static scalar_expr create(scalar_expr arg);
+
+ private:
+  scalar_expr arg_;
+};
+
+template <>
+struct hash_struct<stop_derivative> {
+  std::size_t operator()(const stop_derivative& n) const noexcept { return hash(n.arg()); }
+};
+
+template <>
+struct is_identical_struct<stop_derivative> {
+  bool operator()(const stop_derivative& a, const stop_derivative& b) const {
+    return are_identical(a.arg(), b.arg());
+  }
+};
+
+template <>
+struct order_struct<stop_derivative> {
+  relative_order operator()(const stop_derivative& a, const stop_derivative& b) const {
+    return order_by(a.arg(), b.arg());
+  }
+};
+
+}  // namespace wf

--- a/components/core/wf/functions.cc
+++ b/components/core/wf/functions.cc
@@ -6,7 +6,6 @@
 #include <complex>
 
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
 #include "wf/integer_utils.h"
 #include "wf/matrix_expression.h"
 #include "wf/numerical_casts.h"

--- a/components/core/wf/functions.h
+++ b/components/core/wf/functions.h
@@ -88,4 +88,8 @@ scalar_expr iverson(const boolean_expr& bool_expression);
 // Implemented in unevaluated.cc
 scalar_expr make_unevaluated(scalar_expr expr);
 
+// Create a `stop_derivative` expression. `stop_diff` acts like a function whose
+// derivative is always zero. Implemented in null_derivative.cc
+scalar_expr stop_diff(scalar_expr arg);
+
 }  // namespace wf

--- a/components/core/wf/number_set.cc
+++ b/components/core/wf/number_set.cc
@@ -235,6 +235,8 @@ class determine_set_visitor {
     return number_set::real_non_negative;
   }
 
+  number_set operator()(const stop_derivative& nd) const { return determine_numeric_set(nd.arg()); }
+
   constexpr number_set operator()(const symbolic_function_invocation&) const noexcept {
     // TODO: Support specifying set on the function.
     return number_set::unknown;

--- a/components/core/wf/plain_formatter.cc
+++ b/components/core/wf/plain_formatter.cc
@@ -322,6 +322,10 @@ std::string plain_formatter::operator()(const relational& relational) {
   return output;
 }
 
+std::string plain_formatter::operator()(const stop_derivative& nd) {
+  return fmt::format("StopDerivative({})", operator()(nd.arg()));
+}
+
 std::string plain_formatter::operator()(const substitution& subs) {
   return fmt::format("Subs({}, {}, {})", operator()(subs.input()), operator()(subs.target()),
                                                                    operator()(subs.replacement()));

--- a/components/core/wf/plain_formatter.h
+++ b/components/core/wf/plain_formatter.h
@@ -40,6 +40,7 @@ class plain_formatter {
   std::string operator()(const power& pow);
   std::string operator()(const rational_constant& rational) const;
   std::string operator()(const relational& relational);
+  std::string operator()(const stop_derivative& nd);
   std::string operator()(const substitution& subs);
   std::string operator()(const symbolic_function_invocation& invocation);
   std::string operator()(const built_in_function_invocation& func);

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -8,7 +8,6 @@
 #include "wf/compound_expression.h"
 #include "wf/expression.h"
 #include "wf/expression_visitor.h"
-#include "wf/expressions/all_expressions.h"
 #include "wf/matrix_expression.h"
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
@@ -114,6 +113,11 @@ void tree_formatter_visitor::operator()(const rational_constant& r) {
 void tree_formatter_visitor::operator()(const relational& relational) {
   format_append("{} ({})", relational::name_str, relational.operation_string());
   visit_all(relational);
+}
+
+void tree_formatter_visitor::operator()(const stop_derivative& nd) {
+  format_append("{}:", stop_derivative::name_str);
+  visit_all(nd.children());
 }
 
 void tree_formatter_visitor::operator()(const symbolic_constant& constant) {

--- a/components/core/wf/tree_formatter.h
+++ b/components/core/wf/tree_formatter.h
@@ -38,6 +38,7 @@ class tree_formatter_visitor {
   void operator()(const power& pow);
   void operator()(const rational_constant& r);
   void operator()(const relational& relational);
+  void operator()(const stop_derivative& nd);
   void operator()(const substitution& subs);
   void operator()(const symbolic_constant& constant);
   void operator()(const symbolic_function_invocation& invocation);

--- a/components/wrapper/pywrenfold/docs/scalar_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/scalar_wrapper.h
@@ -727,6 +727,22 @@ Examples:
   y*(x) + (x*y)
 )doc";
 
+inline constexpr std::string_view stop_derivative = R"doc(
+Wrap a scalar-valued expression in order to block propagation of derivatives. ``stop_derivative``
+acts like a function whose derivative is always zero.
+
+Args:
+  arg: Scalar-valued expression to wrap.
+
+Examples:
+  >>> x, y = sym.symbols('x, y')
+  >>> f = sym.stop_derivative(x * y) * y
+  >>> f.diff(x)
+  0
+  >>> f.diff(y)
+  StopDerivative(x * y)
+)doc";
+
 inline constexpr std::string_view eliminate_subexpressions = R"doc(
 Extract common subexpressions from a scalar-valued expression. The expression tree is traversed and
 unique expressions are counted. Those that appear ``min_occurrences`` or more times are replaced

--- a/components/wrapper/pywrenfold/scalar_wrapper.cc
+++ b/components/wrapper/pywrenfold/scalar_wrapper.cc
@@ -299,6 +299,7 @@ void wrap_scalar_operations(py::module_& m) {
   m.def("iverson", &wf::iverson, "arg"_a, docstrings::iverson.data());
 
   m.def("unevaluated", &wf::make_unevaluated, "arg"_a, docstrings::unevaluated.data());
+  m.def("stop_derivative", &wf::stop_diff, "arg"_a, docstrings::stop_derivative.data());
 
   m.def(
       "eliminate_subexpressions",

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -449,6 +449,16 @@ class ExpressionWrapperTest(MathTestBase):
 
         self.assertRaises(exceptions.TypeError, lambda: sym.derivative(x, y + 2))
 
+    def test_stop_derivative_expression(self):
+        """Test creating a `stop_derivative` expression."""
+        x, y = sym.symbols('x, y')
+        self.assertEqual('StopDerivative', sym.stop_derivative(y).type_name)
+        self.assertEqual('StopDerivative(3*x)', repr(sym.stop_derivative(x * 3)))
+        self.assertIdentical(0, sym.stop_derivative(x).diff(x))
+        self.assertIdentical(
+            sym.cos(y) * sym.stop_derivative(x * y),
+            (sym.stop_derivative(x * y) * sym.sin(y)).diff(y))
+
     def test_substitute_expression(self):
         """Test creation of deferred substitution expression."""
         x, y = sym.symbols('x, y')

--- a/examples/imu_integration/imu_integration_test.cc
+++ b/examples/imu_integration/imu_integration_test.cc
@@ -1,6 +1,8 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
 #include "wf_test_support/eigen_test_macros.h"
 #include "wf_test_support/numerical_jacobian.h"
-#include "wf_test_support/test_macros.h"
 
 #define WF_SPAN_EIGEN_SUPPORT
 #include "wrenfold/span.h"


### PR DESCRIPTION
This change adds the `stop_derivative` expression, which may be used to explicitly stop the propagation of derivatives.  `stop_derivative` is similar to the tensorflow [tf.stop_gradient](https://www.tensorflow.org/api_docs/python/tf/stop_gradient) method. Taking the derivative of `stop_derivative` will always be zero:

```python
>>> x, y = sym.symbols('x, y')
>>> f = sym.stop_derivative(x * y)
>>> f.diff(x)
0
```

This can be useful if you want to perform multiple mathematical operations, but _only_ propagate the final step onto Jacobians. For example when running a numerical root finder:

```python
# Here `f` is a function we want to find the root for, and `df` is its derivative.
x = x0
for iteration in range(0, num_iters):
  # ... omitted: compute `f` and `df`.
  if iteration + 1 < num_iters:
    x = sym.stop_derivative(x - f / df)
  else:
    x = x - f / df # Allow gradient to propagate on final iteration.
```

Now our root-finding solution `x` can be embedded in further symbolic expressions. If it is differentiated, the derivative will be taken _only_ about the solution of the solver (rather than chain-ruling through the whole list of iterations).