### PR TITLE
Add C99 generation example + an example of Kannala-Brandt camera model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ if(DEFINED SKBUILD_PROJECT_NAME AND DEFINED SKBUILD_PROJECT_VERSION)
     ${SKBUILD_PROJECT_NAME}
     VERSION ${SKBUILD_PROJECT_VERSION}
     DESCRIPTION "Tools for generating code from symbolic math."
-    LANGUAGES CXX)
+    LANGUAGES CXX C)
   message(STATUS "Building project version: ${SKBUILD_PROJECT_VERSION}")
   set(WF_BUILD_EXTRAS_DEFAULT OFF)
 else()
-  project(wrenfold CXX)
+  project(wrenfold CXX C)
   set(WF_BUILD_EXTRAS_DEFAULT ON)
 endif()
 

--- a/docs/source/reference/new_language.rst
+++ b/docs/source/reference/new_language.rst
@@ -3,16 +3,16 @@ Adding a new target language
 
 wrenfold can be extended to target new languages by customizing the code generation step. For a
 complete demonstration, refer to the
-`python_generation <https://github.com/wrenfold/wrenfold/blob/main/examples/python_generation/python_generation.py>`__
+`c_generation <https://github.com/wrenfold/wrenfold/blob/main/examples/c_generation>`__
 example. This section provides a brief overview.
 
 To begin with, one must subclass the :class:`wrenfold.code_generation.BaseGenerator` type in python.
 **At a minimum**, a ``format_function_definition`` method must be defined for the
 :class:`wrenfold.code_generation.FunctionDefinition` type (the top level AST node).
 
-Most nodes in the AST will have children - for example :class:`wrenfold.ast.Add` has a member
-``args`` that enumerates the operands of an N-ary addition. To facilitate recursive formatting, the
-``BaseGenerator`` type provides an overloaded
+Most nodes in the syntax tree will have children - for example :class:`wrenfold.ast.Add` has a
+member ``args`` that enumerates the operands of an N-ary addition. To facilitate recursive
+formatting, the ``BaseGenerator`` type provides an overloaded
 :func:`wrenfold.code_generation.BaseGenerator.format` method that automatically delegates to the
 appropriately named formatter on your subclass.
 
@@ -28,7 +28,7 @@ For example, when printing ``ast.Add`` we can recurse on ``add.args``:
 
         def format_add(self, add: ast.Add) -> str:
             # Calling `format(...)` will automatically delegate to the appropriate overload.
-            # If the argument is an `ast.Add`, it will recurse back into this method, for example.
+            # If the argument is an `ast.Add`, it will recurse back into this method.
             return ' + '.join(self.format(x) for x in add.args)
 
         # ... more overloads ...

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,7 @@
+set(WF_EXAMPLES_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_subdirectory(bspline)
+add_subdirectory(c_generation)
 add_subdirectory(custom_types)
 add_subdirectory(imu_integration)
 add_subdirectory(motion_planning)

--- a/examples/c_generation/CMakeLists.txt
+++ b/examples/c_generation/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_py_code_generator(
+  c_generation_generate
+  c_generation.py
+  OUTPUT_FILE_NAME
+  generated.h
+  SOURCE_FILES
+  c_generation.py
+  c_code_generator.py
+  ${WF_EXAMPLES_DIR}/shared_expressions.py)
+
+add_cpp_test(
+  c_generation_test
+  GENERATOR_TARGET
+  c_generation_generate
+  SOURCE_FILES
+  c_generation_test.cc
+  c_span_types.h
+  c_generation.c
+  INCLUDE_DIRECTORIES
+  ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_property(TARGET c_generation_test PROPERTY C_STANDARD 11)

--- a/examples/c_generation/README.md
+++ b/examples/c_generation/README.md
@@ -1,0 +1,12 @@
+# c_generation
+
+This is an example of defining a custom code generator in Python. The target language is C99. The generator is defined in
+[c_code_generator.py](./c_code_generator.py).
+
+This example can be invoked by running:
+
+```bash
+python -m examples.c_generation.c_generation <path to output header>
+```
+
+At runtime, the generated code depends on two simple span types defined in [c_span_types.h](./c_span_types.h). By overriding methods on `CCodeGenerator` (such as `format_function_signature`), you can customize the types used to pass input and output matrices to the generated function.

--- a/examples/c_generation/c_code_generator.py
+++ b/examples/c_generation/c_code_generator.py
@@ -1,0 +1,286 @@
+import typing as T
+
+from wrenfold import ast, code_generation, type_info
+from wrenfold.enumerations import (
+    RelationalOperation,
+    StdMathFunction,
+    SymbolicConstant,
+)
+
+
+# noinspection PyMethodMayBeStatic
+class CCodeGenerator(code_generation.BaseGenerator):
+    """
+    A custom code-generator that emits C code. I have endeavored to make this compatible
+    with C99. Not being a C programmer myself, it might have small mistakes.
+
+    By inheriting `BaseGenerator` and implementing the methods below, you can adapt wrenfold
+    to whatever language or API you like.
+    """
+
+    def __init__(self, indent: int = 2):
+        super().__init__()
+        assert indent > 0, f"indent = {indent}"
+        self._indent: str = " " * indent
+
+    def _indent_and_join(self, lines: T.Iterable[str]) -> str:
+        lines_split = []
+        for line in lines:
+            lines_split.extend(line.splitlines())
+        return self._indent + f"\n{self._indent}".join(lines_split)
+
+    @staticmethod
+    def _format_numeric_type(t: type_info.NumericType) -> str:
+        if t == type_info.NumericType.Bool:
+            return "bool"
+        elif t == type_info.NumericType.Integer:
+            return "int64_t"
+        elif t == type_info.NumericType.Float:
+            return "double"
+        else:
+            raise NotImplementedError(f"Unsupported type: {t}")
+
+    def format_scalar_type(self, t: type_info.ScalarType) -> str:
+        return self._format_numeric_type(t.numeric_type)
+
+    def format_custom_type(self, custom: type_info.CustomType) -> str:
+        return custom.name
+
+    def format_add(self, add: ast.Add) -> str:
+        return " + ".join(self.format(x) for x in add.args)
+
+    def format_assign_output_matrix(self, mat: ast.AssignOutputMatrix) -> str:
+        """Call `set_output_value` on every element of the matrix."""
+        mat_type = mat.arg.type
+        assert isinstance(mat_type, type_info.MatrixType)
+        result = []
+        # Optional args are pointers, non-optional are const spans.
+        addr_of = "&" if not mat.arg.is_optional else ""
+        for index, val in enumerate(mat.value.args):
+            row, col = mat_type.compute_indices(idx=index)
+            result.append(
+                f"set_output_value({addr_of}{mat.arg.name}, {row}, {col}, {self.format(val)});")
+        return "\n".join(result)
+
+    def format_assign_output_scalar(self, scalar: ast.AssignOutputScalar) -> str:
+        """Scalar arguments are passed as non-const pointers we assign to."""
+        return f"*{scalar.arg.name} = {self.format(scalar.value)};"
+
+    def format_assign_output_struct(self, struct: ast.AssignOutputStruct) -> str:
+        """Assign to a struct."""
+        return f"*{struct.arg.name} = {self.format(struct.value)};"
+
+    def format_assign_temporary(self, temp: ast.AssignTemporary) -> str:
+        return f"{temp.left} = {self.format(temp.right)};"
+
+    def format_boolean_literal(self, b: ast.BooleanLiteral) -> str:
+        """We assume the user has included stdbool.h so we can use true/false."""
+        return "true" if b.value else "false"
+
+    def format_branch(self, branch: ast.Branch) -> str:
+        result = f"if ({self.format(branch.condition)}) {{\n"
+        result += self._indent_and_join(self.format(x) for x in branch.if_branch)
+        if len(branch.else_branch) > 0:
+            result += "\n} else {\n"
+            result += self._indent_and_join(self.format(x) for x in branch.else_branch)
+        result += "\n}"
+        return result
+
+    def format_call_external_function(self, call: ast.CallExternalFunction) -> str:
+        """You can override this method to customize the generated name for external functions."""
+        return (f"{call.function.name}(" + ", ".join(self.format(x) for x in call.args) + ")")
+
+    def format_call_std_function(self, call: ast.CallStdFunction) -> str:
+        if call.function == StdMathFunction.Signum:
+            # There is no standard sign function in C.
+            sign_arg = self.format(call.args[0])
+            return f"(double)(int(0.0 < {sign_arg}) - int({sign_arg} < 0.0))"
+        functions = {
+            StdMathFunction.Cos: "cos",
+            StdMathFunction.Sin: "sin",
+            StdMathFunction.Tan: "tan",
+            StdMathFunction.Acos: "acos",
+            StdMathFunction.Asin: "asin",
+            StdMathFunction.Atan: "atan",
+            StdMathFunction.Sqrt: "sqrt",
+            StdMathFunction.Cosh: "cosh",
+            StdMathFunction.Sinh: "sinh",
+            StdMathFunction.Tanh: "tanh",
+            StdMathFunction.Acosh: "acosh",
+            StdMathFunction.Asinh: "asinh",
+            StdMathFunction.Atanh: "atanh",
+            StdMathFunction.Abs: "fabs",
+            StdMathFunction.Log: "log",
+            StdMathFunction.Signum: "sign",
+            StdMathFunction.Floor: "floor",
+            StdMathFunction.Atan2: "atan2",
+            StdMathFunction.Powi: "pow",
+            StdMathFunction.Powf: "pow",
+        }
+        return (f"{functions[call.function]}(" + ", ".join(self.format(x) for x in call.args) + ")")
+
+    def format_cast(self, cast: ast.Cast) -> str:
+        return f"({self._format_numeric_type(cast.destination_type)})({self.format(cast.arg)})"
+
+    def format_comment(self, comment: ast.Comment) -> str:
+        return "\n".join(f"// {x}" for x in comment.split_lines())
+
+    def format_compare(self, compare: ast.Compare) -> str:
+        if compare.operation == RelationalOperation.LessThan:
+            op = "<"
+        elif compare.operation == RelationalOperation.LessThanOrEqual:
+            op = "<="
+        elif compare.operation == RelationalOperation.Equal:
+            op = "=="
+        else:
+            raise NotImplementedError(f"Unknown operation: {compare.operation}")
+        return f"{self.format(compare.left)} {op} {self.format(compare.right)}"
+
+    def format_construct_matrix(self, matrix: ast.ConstructMatrix) -> str:
+        """
+        If we want to return output matrices, we need to generate code that can allocate and fill
+        them here.
+        """
+        raise NotImplementedError("Not implemented in this example.")
+
+    def format_construct_custom_type(self, custom: ast.ConstructCustomType) -> str:
+        """Use C99 designated initializer syntax to create structs."""
+        fields = ', '.join(f".{f.name} = {self.format(custom.get_field_value(f.name))}"
+                           for f in custom.type.fields)
+        return f"{{ {fields} }}"
+
+    def format_declaration(self, decl: ast.Declaration) -> str:
+        if isinstance(decl.type, (type_info.ScalarType, type_info.CustomType)):
+            if decl.value is not None:
+                return f"const {self.format(decl.type)} {decl.name} = {self.format(decl.value)};"
+            else:
+                return f"{self.format(decl.type)} {decl.name};"
+        else:
+            # TODO: Add allocation and initialization of matrix here.
+            raise TypeError("Declaration of matrices not implemented for this generator.")
+
+    def format_divide(self, div: ast.Divide) -> str:
+        return f"{self.format(div.left)} / {self.format(div.right)}"
+
+    def format_float_literal(self, flt: ast.FloatLiteral) -> str:
+        return f"(double)({flt.value})"
+
+    def format_get_argument(self, get: ast.GetArgument) -> str:
+        return get.argument.name
+
+    def format_get_field(self, get: ast.GetField) -> str:
+        return f"{self.format(get.arg)}.{get.field_name}"
+
+    def format_get_matrix_element(self, get: ast.GetMatrixElement) -> str:
+        return f"get_input_value({self.format(get.arg)}, {get.row}, {get.col})"
+
+    def format_integer_literal(self, i: ast.IntegerLiteral) -> str:
+        return str(i.value)
+
+    def format_multiply(self, mul: ast.Multiply) -> str:
+        return " * ".join(self.format(x) for x in mul.args)
+
+    def format_negate(self, neg: ast.Negate) -> str:
+        return f"-{self.format(neg.arg)}"
+
+    def format_optional_output_branch(self, branch: ast.OptionalOutputBranch) -> str:
+        result = f"if ({branch.argument.name}) {{\n"
+        result += self._indent_and_join(self.format(x) for x in branch.statements)
+        result += "\n}"
+        return result
+
+    def format_parenthetical(self, parenthetical: ast.Parenthetical) -> str:
+        return f"({self.format(parenthetical.contents)})"
+
+    def format_return_object(self, ret: ast.ReturnObject) -> str:
+        if isinstance(ret.value, ast.ConstructCustomType):
+            # We cannot return a struct directly in C, we need to declare it first.
+            result = f"{self.format(ret.value.type)} __ret = {self.format(ret.value)};"
+            result += "\nreturn __ret;"
+            return result
+        return f"return {self.format(ret.value)};"
+
+    def format_special_constant(self, constant: ast.SpecialConstant) -> str:
+        if constant.value == SymbolicConstant.Euler:
+            return "M_E"
+        elif constant.value == SymbolicConstant.Pi:
+            return "M_PI"
+        else:
+            raise NotImplementedError(f"Unsupported constant: {constant.value}")
+
+    def format_ternary(self, ternary: ast.Ternary) -> str:
+        return f"{self.format(ternary.condition)} ? {self.format(ternary.left)} : {self.format(ternary.right)}"
+
+    def format_variable_ref(self, var: ast.VariableRef) -> str:
+        return var.name
+
+    def format_function_definition(self, definition: ast.FunctionDefinition) -> str:
+        """
+        The top-level formatting function. The `FunctionDefinition` object is the root of the
+        syntax tree.
+
+        Args:
+            definition: ast.FunctionDefinition
+        """
+        return (self.format(definition.signature) + " {\n" +
+                self._indent_and_join([self.format(x) for x in definition.body]) + "\n}")
+
+    def format_function_signature(self, sig: ast.FunctionSignature) -> str:
+        """
+        Assemble an argument list
+        """
+        args = []
+        for arg in sig.arguments:
+            if isinstance(arg.type, type_info.MatrixType):
+                if arg.direction == code_generation.ArgumentDirection.Input:
+                    args.append(f"const input_span2d_t {arg.name}")
+                elif not arg.is_optional:
+                    args.append(f"const output_span2d_t {arg.name}")
+                elif arg.is_optional:
+                    # Optional output spans are pass by pointer.
+                    # A null span indicates an output we don't want to compute.
+                    args.append(f"const output_span2d_t* {arg.name}")
+            elif isinstance(arg.type, type_info.CustomType):
+                if arg.is_input:
+                    args.append(f"const {self.format(arg.type)}*")
+                else:
+                    args.append(f"{self.format(arg.type)}*")
+            else:
+                assert isinstance(arg.type, type_info.ScalarType)
+                if arg.is_input:
+                    args.append(f"const {self.format(arg.type)}")
+                else:
+                    args.append(f"{self.format(arg.type)}*")
+
+        return_type = "void"
+        if sig.return_type is not None:
+            if isinstance(sig.return_type, (type_info.ScalarType, type_info.CustomType)):
+                return_type = self.format(sig.return_type)
+            else:
+                raise TypeError("Returning matrices is not supported in this generator yet.")
+
+        return f'inline {return_type} {sig.name}({", ".join(args)})'
+
+
+C_PREAMBLE = """// Machine generated code.
+#ifndef {header_name}_H
+#define {header_name}_H
+
+#ifdef __cplusplus
+extern "C" {{
+#endif  // __cplusplus
+
+#include <math.h>
+#include <stdbool.h>    // bool
+#include <stdint.h>     // int64_t
+
+#include "c_span_types.h"
+
+{code}
+
+#ifdef __cplusplus
+}}
+#endif  // __cplusplus
+
+#endif // {header_name}_H
+"""

--- a/examples/c_generation/c_generation.c
+++ b/examples/c_generation/c_generation.c
@@ -1,0 +1,7 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+
+// We test this file from C++ in `c_generation_test.cc`, but we still want to validate that the
+// generated code will compile as C. To that end, we include the generated code in this C module.
+#include "generated.h"

--- a/examples/c_generation/c_generation.py
+++ b/examples/c_generation/c_generation.py
@@ -1,0 +1,54 @@
+"""
+Generate some example functions in C:
+- Kannala-Brandt camera model (forward and backward projection).
+- A method that converts a rotation matrix to a quaternion.
+"""
+import argparse
+import dataclasses
+
+from wrenfold import code_generation, geometry, type_annotations
+
+from ..shared_expressions import (
+    kb_camera_projection_with_jacobians,
+    kb_camera_unprojection_with_jacobians,
+)
+from .c_code_generator import C_PREAMBLE, CCodeGenerator
+
+
+@dataclasses.dataclass
+class quaternion_t:
+    """
+    The equivalent C-struct is declared in `c_span_types.h`.
+    """
+    w: type_annotations.FloatScalar
+    x: type_annotations.FloatScalar
+    y: type_annotations.FloatScalar
+    z: type_annotations.FloatScalar
+
+
+def quaternion_from_rotation_matrix(R: type_annotations.Matrix3):
+    """
+    We use this method to test construction of a struct in C (quaternion_t).
+    """
+    q = geometry.Quaternion.from_rotation_matrix(R)
+    return quaternion_t(w=q.w, x=q.x, y=q.y, z=q.z)
+
+
+def main(args: argparse.Namespace):
+    functions = [
+        code_generation.generate_function(function, generator=CCodeGenerator())
+        for function in (kb_camera_projection_with_jacobians, kb_camera_unprojection_with_jacobians,
+                         quaternion_from_rotation_matrix)
+    ]
+    code = C_PREAMBLE.format(code="\n\n".join(functions), header_name="C_GENERATION_EXAMPLE")
+    code_generation.mkdir_and_write_file(code=code, path=args.output)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=str, help="Output path")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/examples/c_generation/c_generation_test.cc
+++ b/examples/c_generation/c_generation_test.cc
@@ -1,0 +1,281 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#include "wf_test_support/eigen_test_macros.h"
+#include "wf_test_support/numerical_jacobian.h"
+
+#include "generated.h"
+
+namespace wf {
+
+// Test coefficients for 4 different types of cameras.
+// We return tuples of (coefficients, max_image_plane_radius).
+const auto& get_fisheye_coefficients() {
+  static const std::vector<std::tuple<Eigen::Vector4d, double>> coeffs = {
+      // Stereographic
+      std::make_tuple(Eigen::Vector4d{0.08327424, 0.00852979, 0.00063325, 0.00017048}, 1.99),
+      // Equidistant.
+      std::make_tuple(Eigen::Vector4d{0.0, 0.0, 0.0, 0.0}, M_PI / 2),
+      // Equisolid.
+      std::make_tuple(
+          Eigen::Vector4d{-4.16666666e-02, 5.20833056e-04, -3.09988000e-06, 1.06158708e-08}, 1.41),
+      // Orthogonal.
+      std::make_tuple(
+          Eigen::Vector4d{-1.66666587e-01, 8.33305775e-03, -1.98095183e-04, 2.60641004e-06}, 0.99),
+  };
+  return coeffs;
+}
+
+template <typename Scalar, int Rows, int Cols>
+input_span2d_t input_span_from_eigen(const Eigen::Matrix<Scalar, Rows, Cols>& v) {
+  return input_span2d_t{v.data(), static_cast<uint32_t>(v.rows()), static_cast<uint32_t>(v.cols()),
+                        static_cast<uint32_t>(v.outerStride())};
+}
+
+template <typename Scalar, int Rows, int Cols>
+output_span2d_t output_span_from_eigen(Eigen::Matrix<Scalar, Rows, Cols>& v) {
+  return output_span2d_t{v.data(), static_cast<uint32_t>(v.rows()), static_cast<uint32_t>(v.cols()),
+                         static_cast<uint32_t>(v.outerStride())};
+}
+
+// Test round-trip un-projection --> projection with the Kannala-Brandt (KB) camera model.
+TEST(CGenerationTest, TestKbCameraRoundTrip) {
+  constexpr double cx = (320.0 - 1) / 2.0;
+  constexpr double cy = (240.0 - 1) / 2.0;
+  const double pixel_radius = std::sqrt(std::pow(cx, 2) + std::pow(cy, 2));
+
+  for (const auto& [coeffs, max_radius] : get_fisheye_coefficients()) {
+    const double f = pixel_radius / max_radius;
+    const Eigen::Vector4d K{f * 1.05, f * 1.03, cx, cy};
+
+    for (int y = 0; y < 240; y += 10) {
+      for (int x = 0; x < 320; x += 10) {
+        const Eigen::Vector2d p_pixels{static_cast<double>(x), static_cast<double>(y)};
+
+        Eigen::Vector3d p_cam;
+        kb_camera_unprojection_with_jacobians(
+            input_span_from_eigen(p_pixels), input_span_from_eigen(K),
+            input_span_from_eigen(coeffs), output_span_from_eigen(p_cam), nullptr, nullptr,
+            nullptr);
+
+        Eigen::Vector2d p_pixels_out;
+        kb_camera_projection_with_jacobians(
+            input_span_from_eigen(p_cam), input_span_from_eigen(K), input_span_from_eigen(coeffs),
+            output_span_from_eigen(p_pixels_out), nullptr, nullptr, nullptr);
+
+        ASSERT_EIGEN_NEAR(p_pixels, p_pixels_out, 1.0e-4);
+      }
+    }
+  }
+}
+
+// Test jacobians of the KB camera model projection.
+TEST(CGenerationTest, TestKbCameraProjectJacobian) {
+  constexpr double cx = (320.0 - 1) / 2.0;
+  constexpr double cy = (240.0 - 1) / 2.0;
+  const double pixel_radius = std::sqrt(std::pow(cx, 2) + std::pow(cy, 2));
+
+  Eigen::Matrix<double, 2, 3> p_pixels_D_p_cam;
+  Eigen::Matrix<double, 2, 4> p_pixels_D_K;
+  Eigen::Matrix<double, 2, 4> p_pixels_D_coeffs;
+
+  auto p_pixels_D_p_cam_span = output_span_from_eigen(p_pixels_D_p_cam);
+  auto p_pixels_D_K_span = output_span_from_eigen(p_pixels_D_K);
+  auto p_pixels_D_coeffs_span = output_span_from_eigen(p_pixels_D_coeffs);
+
+  for (const auto& [coeffs, max_radius] : get_fisheye_coefficients()) {
+    const double f = pixel_radius / max_radius;
+    const Eigen::Vector4d K{f * 1.05, f * 1.03, cx, cy};
+
+    // Iterate over a bunch of unit vectors in camera frame:
+    for (double theta = 0.01; theta < M_PI / 2; theta += 0.1) {
+      for (double phi = -M_PI; phi < M_PI; phi += 0.1) {
+        const Eigen::Vector3d p_cam{std::cos(phi) * std::sin(theta),
+                                    std::sin(phi) * std::sin(theta), std::cos(theta)};
+
+        Eigen::Vector2d p_pixels_out;
+        kb_camera_projection_with_jacobians(
+            input_span_from_eigen(p_cam), input_span_from_eigen(K), input_span_from_eigen(coeffs),
+            output_span_from_eigen(p_pixels_out), &p_pixels_D_p_cam_span, &p_pixels_D_K_span,
+            &p_pixels_D_coeffs_span);
+
+        // Compute derivative wrt p_cam numerically:
+        const auto p_pixels_D_p_cam_num =
+            numerical_jacobian(p_cam, [&](const Eigen::Vector3d& p_cam_perturbed) {
+              Eigen::Vector2d p_pixels_out;
+              kb_camera_projection_with_jacobians(
+                  input_span_from_eigen(p_cam_perturbed), input_span_from_eigen(K),
+                  input_span_from_eigen(coeffs), output_span_from_eigen(p_pixels_out), nullptr,
+                  nullptr, nullptr);
+              return p_pixels_out;
+            });
+        ASSERT_EIGEN_NEAR(p_pixels_D_p_cam_num, p_pixels_D_p_cam, 1.0e-8);
+
+        // Compute derivative wrt K numerically:
+        const auto p_pixels_D_K_num =
+            numerical_jacobian(K, [&](const Eigen::Vector4d& K_perturbed) {
+              Eigen::Vector2d p_pixels_out;
+              kb_camera_projection_with_jacobians(
+                  input_span_from_eigen(p_cam), input_span_from_eigen(K_perturbed),
+                  input_span_from_eigen(coeffs), output_span_from_eigen(p_pixels_out), nullptr,
+                  nullptr, nullptr);
+              return p_pixels_out;
+            });
+        ASSERT_EIGEN_NEAR(p_pixels_D_K_num, p_pixels_D_K, 1.0e-8);
+
+        // Compute derivative wrt coeffs numerically:
+        const auto p_pixels_D_coeffs_num =
+            numerical_jacobian(coeffs, [&](const Eigen::Vector4d& coeffs_perturbed) {
+              Eigen::Vector2d p_pixels_out;
+              kb_camera_projection_with_jacobians(
+                  input_span_from_eigen(p_cam), input_span_from_eigen(K),
+                  input_span_from_eigen(coeffs_perturbed), output_span_from_eigen(p_pixels_out),
+                  nullptr, nullptr, nullptr);
+              return p_pixels_out;
+            });
+        ASSERT_EIGEN_NEAR(p_pixels_D_coeffs_num, p_pixels_D_coeffs, 1.0e-8);
+      }
+    }
+  }
+}
+
+TEST(CGenerationTest, TestKbCameraUnprojectJacobian) {
+  constexpr double cx = (320.0 - 1) / 2.0;
+  constexpr double cy = (240.0 - 1) / 2.0;
+  const double pixel_radius = std::sqrt(std::pow(cx, 2) + std::pow(cy, 2));
+
+  Eigen::Matrix<double, 3, 2> p_cam_D_p_pixels;
+  Eigen::Matrix<double, 3, 4> p_cam_D_K;
+  Eigen::Matrix<double, 3, 4> p_cam_D_coeffs;
+
+  auto p_cam_D_p_pixels_span = output_span_from_eigen(p_cam_D_p_pixels);
+  auto p_cam_D_K_span = output_span_from_eigen(p_cam_D_K);
+  auto p_cam_D_coeffs_span = output_span_from_eigen(p_cam_D_coeffs);
+
+  for (const auto& [coeffs, max_radius] : get_fisheye_coefficients()) {
+    const double f = pixel_radius / max_radius;
+    const Eigen::Vector4d K{f * 1.05, f * 1.03, cx, cy};
+
+    // Iterate over a bunch of pixel coordinates:
+    for (int y = 0; y < 240; y += 10) {
+      for (int x = 0; x < 320; x += 10) {
+        const Eigen::Vector2d p_pixels{static_cast<double>(x), static_cast<double>(y)};
+
+        Eigen::Vector3d p_cam_out;
+        kb_camera_unprojection_with_jacobians(
+            input_span_from_eigen(p_pixels), input_span_from_eigen(K),
+            input_span_from_eigen(coeffs), output_span_from_eigen(p_cam_out),
+            &p_cam_D_p_pixels_span, &p_cam_D_K_span, &p_cam_D_coeffs_span);
+
+        // Compute derivative wrt p_pixels:
+        const auto p_cam_D_p_pixels_num =
+            numerical_jacobian(p_pixels, [&](const Eigen::Vector2d& p_pixels_perturbed) {
+              Eigen::Vector3d p_cam_out;
+              kb_camera_unprojection_with_jacobians(
+                  input_span_from_eigen(p_pixels_perturbed), input_span_from_eigen(K),
+                  input_span_from_eigen(coeffs), output_span_from_eigen(p_cam_out), nullptr,
+                  nullptr, nullptr);
+              return p_cam_out;
+            });
+        ASSERT_EIGEN_NEAR(p_cam_D_p_pixels_num, p_cam_D_p_pixels, 1.0e-8);
+
+        // Compute derivative wrt K:
+        const auto p_cam_D_K_num = numerical_jacobian(K, [&](const Eigen::Vector4d& K_perturbed) {
+          Eigen::Vector3d p_cam_out;
+          kb_camera_unprojection_with_jacobians(
+              input_span_from_eigen(p_pixels), input_span_from_eigen(K_perturbed),
+              input_span_from_eigen(coeffs), output_span_from_eigen(p_cam_out), nullptr, nullptr,
+              nullptr);
+          return p_cam_out;
+        });
+        ASSERT_EIGEN_NEAR(p_cam_D_K_num, p_cam_D_K, 1.0e-8);
+
+        // Compute derivative wrt K.
+        // Use a much smaller step size here to accommodate the solver.
+        const auto p_cam_D_coeffs_num = numerical_jacobian(
+            coeffs,
+            [&](const Eigen::Vector4d& coeffs_perturbed) {
+              Eigen::Vector3d p_cam_out;
+              kb_camera_unprojection_with_jacobians(
+                  input_span_from_eigen(p_pixels), input_span_from_eigen(K),
+                  input_span_from_eigen(coeffs_perturbed), output_span_from_eigen(p_cam_out),
+                  nullptr, nullptr, nullptr);
+              return p_cam_out;
+            },
+            1.0e-5);
+        ASSERT_EIGEN_NEAR(p_cam_D_coeffs_num, p_cam_D_coeffs, 1.0e-6);
+      }
+    }
+  }
+}
+
+// Flip the sign of `actual` to match `ref` (if they do not match).
+void flip_sign_to_match(const Eigen::Quaterniond& ref, quaternion_t& actual) {
+  // Take the first non-zero element:
+  for (const auto& [r, a] :
+       {std::make_tuple(ref.w(), actual.w), std::make_tuple(ref.x(), actual.x),
+        std::make_tuple(ref.y(), actual.y), std::make_tuple(ref.z(), actual.z)}) {
+    if (r != 0) {
+      if (std::signbit(r) != std::signbit(a)) {
+        actual.w *= -1;
+        actual.x *= -1;
+        actual.y *= -1;
+        actual.z *= -1;
+      }
+      break;
+    }
+  }
+}
+
+TEST(CGenerationTest, TestQuaternionFromMatrix) {
+  // Some edge cases and random quaternions.
+  const std::vector<Eigen::Quaterniond> qs_edge = {
+      {1.0, 0.0, 0.0, 0.0},
+      {-1.0, 0.0, 0.0, 0.0},
+      {0, 1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0},
+      {0, -1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0},
+      {0, 1 / std::sqrt(2.0), -1 / std::sqrt(2.0), 0},
+      {0, 0, 1 / std::sqrt(2.0), 1 / std::sqrt(2.0)},
+      {0, 0, -1 / std::sqrt(2.0), 1 / std::sqrt(2.0)},
+      {0, 0, 1 / std::sqrt(2.0), -1 / std::sqrt(2.0)},
+      {1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0, 0},
+      {-1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0, 0},
+      {1 / std::sqrt(2.0), -1 / std::sqrt(2.0), 0, 0},
+  };
+
+  const std::vector<Eigen::Quaterniond> qs_random = {
+      {-0.51879141, -0.43584291, 0.68075724, 0.27832716},
+      {0.40285343, 0.49457606, -0.65747589, 0.40103503},
+      {0.20803629, -0.15572734, -0.56428821, 0.7836126},
+      {0.80776844, -0.16735421, 0.49527993, -0.2723977},
+      {0.29067337, -0.27204595, 0.76530082, -0.50578122},
+      {0.64262622, 0.03507511, 0.37740948, -0.66585536},
+      {-0.57799396, 0.0972896, -0.56068941, -0.58488042},
+      {-0.40712309, -0.79537291, 0.28588786, 0.34626703},
+      {0.55416343, -0.42971437, -0.15799486, 0.6951878},
+      {0.14457519, -0.48679597, -0.86128872, 0.0175908}};
+
+  for (const auto& q : qs_edge) {
+    const Eigen::Matrix3d R = q.toRotationMatrix();
+    quaternion_t q_recovered = quaternion_from_rotation_matrix(input_span_from_eigen(R));
+
+    flip_sign_to_match(q, q_recovered);
+    ASSERT_NEAR(q.w(), q_recovered.w, 1.0e-12);
+    ASSERT_NEAR(q.x(), q_recovered.x, 1.0e-12);
+    ASSERT_NEAR(q.y(), q_recovered.y, 1.0e-12);
+    ASSERT_NEAR(q.z(), q_recovered.z, 1.0e-12);
+  }
+
+  for (const auto& q : qs_random) {
+    const Eigen::Matrix3d R = q.toRotationMatrix();
+    quaternion_t q_recovered = quaternion_from_rotation_matrix(input_span_from_eigen(R));
+
+    flip_sign_to_match(q, q_recovered);
+    ASSERT_NEAR(q.w(), q_recovered.w, 1.0e-8);
+    ASSERT_NEAR(q.x(), q_recovered.x, 1.0e-8);
+    ASSERT_NEAR(q.y(), q_recovered.y, 1.0e-8);
+    ASSERT_NEAR(q.z(), q_recovered.z, 1.0e-8);
+  }
+}
+
+}  // namespace wf

--- a/examples/c_generation/c_span_types.h
+++ b/examples/c_generation/c_span_types.h
@@ -1,0 +1,64 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+
+#ifndef WF_C_SPAN_TYPES_H
+#define WF_C_SPAN_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <assert.h>
+#include <stdint.h>  //  uint32_t
+
+// A const 2D span over double precision values.
+struct input_span2d {
+  const double* data;
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t stride;  //  Stride for column-major ordered data.
+};
+typedef struct input_span2d input_span2d_t;
+
+// A non-const 2D span over double precision values.
+struct output_span2d {
+  double* data;
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t stride;
+};
+typedef struct output_span2d output_span2d_t;
+
+// Read a value from an instance of `input_span2d`.
+// We assume a column-major ordering to match Eigen.
+inline double get_input_value(const input_span2d_t span, const uint32_t row, const uint32_t col) {
+  assert(span.data);
+  assert(row < span->rows);
+  assert(col < span->cols);
+  return span.data[row + col * span.stride];
+}
+
+// Write a value to an instance of `output_span2d`.
+inline void set_output_value(const output_span2d_t* span, const uint32_t row, const uint32_t col,
+                             const double value) {
+  assert(span->data);
+  assert(row < span->rows);
+  assert(col < span->cols);
+  span->data[row + col * span->stride] = value;
+}
+
+// A simple quaternion struct.
+struct quaternion {
+  double w;
+  double x;
+  double y;
+  double z;
+};
+typedef struct quaternion quaternion_t;
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // WF_C_SPAN_TYPES_H

--- a/examples/shared_expressions.py
+++ b/examples/shared_expressions.py
@@ -1,0 +1,157 @@
+"""
+Symbolic expressions that are shared among the provided examples.
+"""
+
+from wrenfold import code_generation, sym, type_annotations
+
+
+def kb_fisheye_distortion(theta: type_annotations.FloatScalar,
+                          coeffs: type_annotations.Vector4) -> sym.Expr:
+    """Evaluate the Kannala-Brandt fisheye distortion curve (theta -> radius)."""
+    k1, k2, k3, k4 = coeffs
+    radius = theta * (1 + k1 * theta ** 2 + k2 * theta ** 4 + k3 * theta ** 6 + k4 * theta ** 8)
+    return radius
+
+
+def kb_fisheye_invert_distortion(
+    radius: type_annotations.FloatScalar,
+    coeffs: type_annotations.Vector4,
+    num_iters: int = 6,
+) -> sym.Expr:
+    """
+    Invert `kb_fisheye_distortion` with newton solver.
+
+    Args:
+        radius: radius in the image plane.
+        coeffs: Radial distortion coefficients [k1, k2, k3, 4].
+        num_iters: Number of iterations to unroll.
+
+    Tip:
+        We symbolically unroll `num_iters` of iteration. You may wish to raise this number if the
+        accuracy proves insufficient for your camera model.
+    """
+    assert num_iters > 0, f"num_iters = {num_iters}"
+
+    theta = 0
+    for iteration in range(0, num_iters):
+        # Evaluate the forward projection model:
+        theta_sym = sym.symbols("theta", nonnegative=True)
+        r_predicted = kb_fisheye_distortion(theta=theta_sym, coeffs=coeffs)
+
+        # Compute derivative wrt theta.
+        r_D_theta = r_predicted.diff(theta_sym).subs(theta_sym, theta)
+
+        error = r_predicted.subs(theta_sym, theta) - radius
+        updated_theta = sym.max(theta - error / r_D_theta, 0)
+
+        if iteration + 1 < num_iters:
+            theta = sym.stop_derivative(updated_theta)
+        else:
+            # Only allow derivative to propagate on the final iteration.
+            # In other words, we will linearize about the _solution_ of the solver.
+            theta = updated_theta
+
+    return theta
+
+
+def kb_camera_projection(
+    p_cam: type_annotations.Vector3,
+    K: type_annotations.Vector4,
+    coeffs: type_annotations.Vector4,
+):
+    """
+    Evaluate the projection model of a Kannala-Brandt camera model. Only the 4 radial distortion
+    coefficients are implemented in this example.
+
+    Args:
+        p_cam: Incident vector in camera coordinates. We assume it has non-zero norm.
+        K: Intrinsic parameters as a 4-element vector [fx, fy, cx, cy].
+        coeffs: Radial distortion coefficients [k1, k2, k3, 4].
+    """
+    # Angle with respect to the optical axis.
+    # We could use acos() here and probably be a bit faster, although we would additionally need to
+    # normalized `p_cam` as well.
+    xy_norm = p_cam[0:2].norm()
+    theta = sym.where(xy_norm > 0, sym.atan2(xy_norm, p_cam[2]), 0)
+
+    # Angle in the image plane:
+    phi = sym.where(xy_norm > 0, sym.atan2(p_cam[1], p_cam[0]), 0)
+
+    # Distort theta with the radial model:
+    r = kb_fisheye_distortion(theta=theta, coeffs=coeffs)
+
+    # Compute image plane location:
+    p_image = sym.vector(sym.cos(phi) * r, sym.sin(phi) * r, 1)
+
+    # Convert to pixel coordinates
+    fx, fy, cx, cy = K
+    return sym.vector(fx * p_image[0] + cx, fy * p_image[1] + cy)
+
+
+def kb_camera_unprojection(
+    p_pixels: type_annotations.Vector2,
+    K: type_annotations.Vector4,
+    coeffs: type_annotations.Vector4,
+):
+    """
+    Evaluate the un-projection model of a Kannala-Brandt camera model. This function computes the
+    inverse (up to scale) of `kb_camera_projection`.
+
+    Args:
+        p_cam: Incident vector in camera coordinates.
+        K: Intrinsic parameters as a 4-element vector [fx, fy, cx, cy].
+        coeffs: Radial distortion coefficients [k1, k2, k3, 4].
+    """
+    fx, fy, cx, cy = K
+    p_image = sym.vector((p_pixels[0] - cx) / fx, (p_pixels[1] - cy) / fy)
+    radius = p_image.norm()
+
+    # Convert to angle in radians.
+    theta = kb_fisheye_invert_distortion(radius, coeffs)
+
+    # Angle to the point in the image plane:
+    phi = sym.where(radius > 0, sym.atan2(p_image[1], p_image[0]), 0)
+
+    # Convert back to a unit vector:
+    return sym.vector(sym.cos(phi) * sym.sin(theta), sym.sin(phi) * sym.sin(theta), sym.cos(theta))
+
+
+def kb_camera_projection_with_jacobians(
+    p_cam: type_annotations.Vector3,
+    K: type_annotations.Vector4,
+    coeffs: type_annotations.Vector4,
+):
+    """
+    Code-generate the Kannala-Brandt camera model with Jacobians.
+    """
+    p_pixels = kb_camera_projection(p_cam=p_cam, K=K, coeffs=coeffs)
+    p_pixels_D_p_cam = sym.jacobian(p_pixels, p_cam)
+    p_pixels_D_K = sym.jacobian(p_pixels, K)
+    p_pixels_D_coeffs = sym.jacobian(p_pixels, coeffs)
+    return [
+        code_generation.OutputArg(p_pixels, name="p_pixels"),
+        code_generation.OutputArg(p_pixels_D_p_cam, name="p_pixels_D_p_cam", is_optional=True),
+        code_generation.OutputArg(p_pixels_D_K, name="p_pixels_D_K", is_optional=True),
+        code_generation.OutputArg(p_pixels_D_coeffs, name="p_pixels_D_coeffs", is_optional=True),
+    ]
+
+
+def kb_camera_unprojection_with_jacobians(
+    p_pixels: type_annotations.Vector2,
+    K: type_annotations.Vector4,
+    coeffs: type_annotations.Vector4,
+):
+    """
+    Code-generate the Kannala-Brandt camera model with Jacobians.
+    """
+    p_cam = kb_camera_unprojection(p_pixels=p_pixels, K=K, coeffs=coeffs)
+    p_cam_D_p_pixels = sym.jacobian(p_cam, p_pixels)
+    p_cam_D_K = sym.jacobian(p_cam, K)
+    p_cam_D_coeffs = sym.jacobian(p_cam, coeffs)
+
+    return [
+        code_generation.OutputArg(p_cam, name="p_cam"),
+        code_generation.OutputArg(p_cam_D_p_pixels, name="p_cam_D_p_pixels", is_optional=True),
+        code_generation.OutputArg(p_cam_D_K, name="p_cam_D_K", is_optional=True),
+        code_generation.OutputArg(p_cam_D_coeffs, name="p_cam_D_coeffs", is_optional=True),
+    ]

--- a/support/test_wheel.py
+++ b/support/test_wheel.py
@@ -1,45 +1,58 @@
 """
 Run commands intended to test a built python wheel.
 """
+
+import glob
+import os
 import subprocess
 import sys
 import tempfile
+import typing as T
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent.absolute()
 
 
+def get_module_path(script_path: T.Union[Path, str]) -> str:
+    if isinstance(script_path, str):
+        script_path = Path(script_path)
+    test_path = script_path.with_suffix("").relative_to(ROOT)
+    return str(test_path).replace(os.path.sep, ".")
+
+
 def main():
     # Run all the unit tests.
     print("Running package tests...")
-    subprocess.check_call([
-        sys.executable, "-m", "unittest", "discover",
-        str(ROOT / "components" / "wrapper" / "tests"), "--pattern", "*_test.py"
-    ])
+    wrapper_test_dir = ROOT / "components" / "wrapper" / "tests"
+    for filename in glob.glob(str(wrapper_test_dir / "*_test.py")):
+        subprocess.check_call([sys.executable, "-m", get_module_path(filename)], cwd=str(ROOT))
 
     # Run all the generators to make sure they don't crash.
     print("Running all examples...")
-    ex = ROOT / "examples"
-    subprocess.check_call([sys.executable, str(ex / "python_generation" / "python_generation.py")])
-
-    for script in [
-        [ex / "bspline" / "bspline.py", "--language", "cpp"],
-        [ex / "bspline" / "bspline.py", "--language", "rust"],
-        [ex / "c_generation" / "c_generation.py"],
-        [ex / "custom_types" / "custom_types_gen.py", "--language", "cpp"],
-        [ex / "custom_types" / "custom_types_gen.py", "--language", "rust"],
-        [ex / "imu_integration" / "imu_integration.py"],
-        [ex / "motion_planning" / "problem.py"],
-        [ex / "quaternion_interpolation" / "quaternion_interpolation.py"],
-        [ex / "rosenbrock" / "rosenbrock.py"],
-        [ex / "rotation_error" / "rotation_error.py"],
+    ex = ROOT / Path("examples")
+    for script, needs_output_file in [
+        ([ex / "bspline" / "bspline.py", "--language", "cpp"], True),
+        ([ex / "bspline" / "bspline.py", "--language", "rust"], True),
+        ([ex / "c_generation" / "c_generation.py"], True),
+        ([ex / "custom_types" / "custom_types_gen.py", "--language", "cpp"], True),
+        ([ex / "custom_types" / "custom_types_gen.py", "--language", "rust"], True),
+        ([ex / "imu_integration" / "imu_integration.py"], True),
+        ([ex / "motion_planning" / "problem.py"], True),
+        ([ex / "quaternion_interpolation" / "quaternion_interpolation.py"], True),
+        ([ex / "rosenbrock" / "rosenbrock.py"], True),
+        ([ex / "rotation_error" / "rotation_error.py"], True),
+        ([ex / "python_generation" / "python_generation.py"], False)
     ]:
-        with tempfile.NamedTemporaryFile("w", prefix="codegen_") as fd:
-            fd.close()  # Need to close it so we can overwrite the file.
-            cmd = " ".join([str(x) for x in script])
-            print(f'Running: {cmd}')
-            subprocess.check_call([sys.executable] + [str(x) for x in script] + [fd.name])
+        command = [sys.executable, "-m", get_module_path(script[0])] + script[1:]
+        print(f"Running: {' '.join([str(x) for x in command])}")
+
+        if needs_output_file:
+            with tempfile.NamedTemporaryFile("w", prefix="codegen_") as fd:
+                fd.close()  # Need to close it so we can overwrite the file.
+                subprocess.check_call(command + [fd.name], cwd=str(ROOT))
+        else:
+            subprocess.check_call(command, cwd=str(ROOT))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/support/test_wheel.py
+++ b/support/test_wheel.py
@@ -25,6 +25,7 @@ def main():
     for script in [
         [ex / "bspline" / "bspline.py", "--language", "cpp"],
         [ex / "bspline" / "bspline.py", "--language", "rust"],
+        [ex / "c_generation" / "c_generation.py"],
         [ex / "custom_types" / "custom_types_gen.py", "--language", "cpp"],
         [ex / "custom_types" / "custom_types_gen.py", "--language", "rust"],
         [ex / "imu_integration" / "imu_integration.py"],


### PR DESCRIPTION
After https://github.com/wrenfold/wrenfold/pull/288 merges, the `python_generation` example will be going away (since this functionality is just part of the core library).

In in the interest of having an example of custom-language support, I have added a _new_ example that targets C99. In the process I also added an implementation of the Kannala-Brandt camera model to `examples/shared_expressions.py`. These expressions are generated in the `c_generation` example.