### PR TITLE
Fix bug where nested matrix in custom type resulted in segfault

### DIFF
--- a/components/core/tests/cpp_generation_gen.cc
+++ b/components/core/tests/cpp_generation_gen.cc
@@ -28,6 +28,9 @@ class custom_cpp_code_generator final : public cpp_code_generator {
     if (custom.is_native_type<symbolic::MixedNumerics>()) {
       return "wf::numeric::MixedNumerics";
     }
+    if (custom.is_native_type<symbolic::FancyAggregateType>()) {
+      return "wf::numeric::FancyAggregateType";
+    }
     return cpp_code_generator::operator()(custom);
   }
 

--- a/components/core/tests/rust_generation_gen.cc
+++ b/components/core/tests/rust_generation_gen.cc
@@ -24,6 +24,9 @@ class custom_rust_code_generator final : public rust_code_generator {
     if (custom.is_native_type<wf::symbolic::MixedNumerics>()) {
       return "crate::types::MixedNumerics";
     }
+    if (custom.is_native_type<symbolic::FancyAggregateType>()) {
+      return "crate::types::FancyAggregateType";
+    }
     return rust_code_generator::operator()(custom);
   }
 

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -994,6 +994,33 @@ pub fn nested_custom_type_1<>(c: &crate::types::Circle, p: &crate::types::Point2
 
 #[inline]
 #[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn nested_custom_type_2<>(x: f64, y: f64, c: &crate::types::Circle) -> crate::types::FancyAggregateType
+{
+  // Operation counts:
+  // add: 5
+  // call: 4
+  // multiply: 5
+  // negate: 2
+  // total: 16
+  
+  let v001: f64 = y;
+  let v023: f64 = c.center.y();
+  let v021: f64 = c.center.x();
+  let v000: f64 = x;
+  let v007: f64 = c.radius;
+  crate::types::FancyAggregateType {
+    pt: crate::types::Point2d::new(v000 * v001, v000 + v007 + -v001),
+    circle: crate::types::Circle {
+      center: crate::types::Point2d::new((v000).cos(), (v001).sin()),
+      radius: 32f64 * std::f64::consts::PI
+    },
+    matrix: nalgebra::SMatrix::<f64, 2, 1>::new((v000).abs() + -(v001).cos(), v001 * (3i64) as f64),
+    scalar: v007 + v021 * v021 + v023 * v023
+  }
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn external_function_call_1<>(x: f64, y: f64) -> f64
 {
   // Operation counts:

--- a/components/core/tests/rust_generation_test/src/types.rs
+++ b/components/core/tests/rust_generation_test/src/types.rs
@@ -41,6 +41,15 @@ impl Circle {
     }
 }
 
+// Declare so we can check that nested_custom_type_2 compiles.
+#[derive(Debug, Copy, Clone)]
+pub struct FancyAggregateType {
+    pub pt: Point2d,
+    pub circle: Circle,
+    pub matrix: nalgebra::Vector2<f64>,
+    pub scalar: f64,
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct MixedNumerics {
     pub value: f64,

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -129,6 +129,14 @@ struct Circle {
   scalar_expr radius{0};
 };
 
+// A type with a bunch of members of different types + nesting.
+struct FancyAggregateType {
+  Point2d pt{};
+  Circle circle{};
+  ta::static_matrix<2, 1> matrix{0, 0};
+  scalar_expr scalar{0};
+};
+
 }  // namespace symbolic
 
 template <>
@@ -146,6 +154,17 @@ struct custom_type_registrant<symbolic::Circle> {
     return custom_type_builder<symbolic::Circle>(registry, "Circle")
         .add_field("center", &symbolic::Circle::center)
         .add_field("radius", &symbolic::Circle::radius);
+  }
+};
+
+template <>
+struct custom_type_registrant<symbolic::FancyAggregateType> {
+  auto operator()(custom_type_registry& registry) const {
+    return custom_type_builder<symbolic::FancyAggregateType>(registry, "FancyAggregateType")
+        .add_field("pt", &symbolic::FancyAggregateType::pt)
+        .add_field("circle", &symbolic::FancyAggregateType::circle)
+        .add_field("matrix", &symbolic::FancyAggregateType::matrix)
+        .add_field("scalar", &symbolic::FancyAggregateType::scalar);
   }
 };
 
@@ -176,6 +195,17 @@ inline auto nested_custom_type_1(symbolic::Circle a, symbolic::Point2d b) {
   symbolic::Circle result{};
   result.radius = where(d <= a.radius, a.radius, d);
   result.center = a.center;
+  return result;
+}
+
+// For testing construction and return of complex types.
+// These operations have no real mathematical significance.
+inline auto nested_custom_type_2(scalar_expr x, scalar_expr y, symbolic::Circle c) {
+  symbolic::FancyAggregateType result{
+      symbolic::Point2d{x * y, x - y + c.radius},
+      symbolic::Circle{symbolic::Point2d{cos(x), sin(y)}, 32.0 * constants::pi},
+      ta::static_matrix<2, 1>(abs(x) - cos(y), 3 * y),
+      c.radius + pow(c.center.x, 2) + pow(c.center.y, 2)};
   return result;
 }
 

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -44,6 +44,8 @@ std::string generate_test_expressions(Generator gen) {
   generate_func(gen, code, &custom_type_2, "custom_type_2", arg("theta"), arg("radius"));
   generate_func(gen, code, &custom_type_3, "custom_type_3");
   generate_func(gen, code, &nested_custom_type_1, "nested_custom_type_1", arg("c"), arg("p"));
+  generate_func(gen, code, &nested_custom_type_2, "nested_custom_type_2", arg("x"), arg("y"),
+                arg("c"));
   generate_func(gen, code, &external_function_call_1, "external_function_call_1", arg("x"),
                 arg("y"));
   generate_func(gen, code, &external_function_call_2, "external_function_call_2", arg("u"),

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -57,6 +57,7 @@ struct type_constructor {
     matrix_args.reserve(mat.size());
     std::copy_n(std::make_move_iterator(contents_.begin()) + index_, mat.size(),
                 std::back_inserter(matrix_args));
+    index_ += mat.size();
     return ast::construct_matrix{mat, std::move(matrix_args)};
   }
 

--- a/components/core/wf/code_generation/ast_visitor.h
+++ b/components/core/wf/code_generation/ast_visitor.h
@@ -28,6 +28,7 @@ const auto& cast_to_index(const ast_element& element) noexcept {
 // Visit `ast_element` with `f`. The visitor is passed a const reference.
 template <typename F>
 auto visit(const ast_element& element, F&& f) {
+  WF_ASSERT(element.impl(), "Element is empty.");
   constexpr std::size_t num_types = type_list_size_v<ast_element::types>;
   return wf::detail::visit_switch<num_types>(element.index(), [&](const auto integral_constant) {
     constexpr std::size_t type_index = integral_constant();
@@ -37,7 +38,8 @@ auto visit(const ast_element& element, F&& f) {
 
 // If the underlying type is `T`, return a const pointer to it. Otherwise return nullptr.
 template <typename T>
-maybe_null<const T*> get_if(const ast_element& element) noexcept {
+maybe_null<const T*> get_if(const ast_element& element) {
+  WF_ASSERT(element.impl(), "Element is empty.");
   using types = ast_element::types;
   static_assert(type_list_contains_v<T, types>);
   if (element.index() == type_list_index_v<T, types>) {


### PR DESCRIPTION
There was a gross segfault that could occur when a matrix/vector was a member of a custom type and was _not_ the last member of the custom type. Current tests only worked on the case where the matrix **was** the last member.

This change fixed this bugs and introduces new test coverage on custom/aggregate types to discourage this from happening again.

This is an example of a problematic type that could trigger the behavior:
```python
@dataclasses.dataclass
class SimStateSymbolic:
    position: Vector2
    velocity: Vector2
```
Accessing the AST elements that describe `velocity` would produce a segfault when because we would be accessing a moved-from element.