### PR TITLE
Add code coverage github action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,147 @@
+name: coverage
+
+on:
+  # Allow manual trigger for this workflow.
+  workflow_dispatch:
+
+  # Run every Monday
+  schedule:
+    - cron: "0 0 * * 1"
+
+
+jobs:
+  build:
+    name: build-coverage
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: "bash -el {0}"
+    env:
+      BRANCH: ${{ github.head_ref || github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        id: pyinstall
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Print python location
+        shell: bash
+        run: echo ${{ steps.pyinstall.outputs.python-path }}
+
+      - name: Install python packages
+        run: |
+          ${{ steps.pyinstall.outputs.python-path }} -m pip install -r requirements.txt
+
+      - name: Install PyTorch
+        run: >
+          ${{ steps.pyinstall.outputs.python-path }} -m pip install
+          torch
+          --extra-index-url https://download.pytorch.org/whl/cpu
+
+      - name: Add repositories for GCC
+        run: sudo apt-add-repository ppa:ubuntu-toolchain-r/test
+
+      - name: Install GCC and lcov
+        run: |
+          sudo apt update
+          sudo apt install g++-13 lcov
+
+      - name: Save gcov location
+        run: |
+          echo "GCOV=$(which gcov-13)" >> $GITHUB_ENV
+
+      - name: Create build directory
+        run: cmake -E make_directory ${{github.workspace}}/build
+
+      - name: Configure
+        working-directory: ${{github.workspace}}/build
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: >
+          cmake ${{github.workspace}}
+          -DCMAKE_BUILD_TYPE=Debug
+          -Wno-deprecated
+          -G Ninja
+          -DWF_STUBS_REQUIRED=ON
+          -DWF_DOCS_REQUIRED=OFF
+          -DWF_CODE_COVERAGE=ON
+          -DPython_ROOT_DIR=${{ env.Python_ROOT_DIR }}
+          -DPython_FIND_STRATEGY=LOCATION
+          -DPython_FIND_REGISTRY=NEVER
+          -DPython_FIND_FRAMEWORK=NEVER
+          -DPython_FIND_VIRTUALENV=NEVER
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: |
+          threads=`nproc`
+          cmake --build . --config Debug --parallel $threads
+
+      - name: Run CTest
+        working-directory: ${{github.workspace}}/build
+        run: ctest --output-on-failure
+
+      # With newer lcov in Ubuntu-24.04, the `mismatch` error triggers on gtest functions.
+      - name: Generate coverage
+        working-directory: ${{github.workspace}}/build
+        run: >
+          lcov
+          --gcov-tool ${{ env.GCOV }}
+          --directory .
+          --capture
+          --output-file coverage.info
+          --ignore-errors mismatch
+
+      - name: Filter coverage
+        working-directory: ${{github.workspace}}/build
+        run: >
+          lcov
+          --gcov-tool ${{ env.GCOV }}
+          --remove
+          coverage.info -o filtered.info
+          '/usr/include/*'
+          '/usr/lib/*'
+          '*/dependencies/*'
+
+      - name: Generate HTML report
+        working-directory: ${{github.workspace}}/build
+        run: |
+          genhtml filtered.info --output-directory coverage
+
+      - name: Archive report
+        working-directory: ${{github.workspace}}/build
+        run: |
+          tar -czf coverage.tar.gz coverage
+
+      - name: Extract coverage percentage
+        working-directory: ${{github.workspace}}/build
+        run: >
+          echo "COVERAGE=$(${{ steps.pyinstall.outputs.python-path }} ${{github.workspace}}/support/print_coverage.py ${{ env.GCOV }} ${{github.workspace}}/build/filtered.info)"
+          >> $GITHUB_ENV
+
+      - name: Print coverage
+        run: echo ${{ env.COVERAGE }}
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 0d939a81f2048609c1d3758371e94b7d
+          filename: wrenfold.json
+          label: Test Coverage
+          message: ${{ env.COVERAGE }}
+          color: green
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ${{github.workspace}}/build/coverage.tar.gz
+          retention-days: 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(WF_BUILD_EXTRAS "Build tests, benchmarks, examples, and docs."
        ${WF_BUILD_EXTRAS_DEFAULT})
 option(WF_STUBS_REQUIRED "Fail if stubgen cannot be found." OFF)
 option(WF_DOCS_REQUIRED "Fail if sphinx/doxygen cannot be found." OFF)
+option(WF_CODE_COVERAGE "Build in code coverag mode." OFF)
 
 # Add third party code
 add_subdirectory(dependencies)
@@ -57,6 +58,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL
                                              "AppleClang")
   # Disable unused local typedef on Clang:
   list(APPEND WF_SHARED_WARNING_FLAGS -Wno-unused-local-typedef)
+endif()
+
+# Add an empty interface target to specify code-coverage configuration:
+add_library(wf_coverage_config INTERFACE)
+if(WF_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Turn off optimization, add debug info, and enable coverage.
+  target_compile_options(wf_coverage_config INTERFACE -O0 -g --coverage)
+  target_link_options(wf_coverage_config INTERFACE --coverage)
 endif()
 
 # Custom target that groups together all the rust code-generation.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 <!--- badges_start --->
 <p align="center">
-<a href="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml?query=branch%3Amain"><img alt="GitHub Actions Workflow Status" src="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+<a href="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI Status" src="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+<a href="https://github.com/wrenfold/wrenfold/actions/workflows/coverage.yml?query=branch%3Amain"><img alt="Code Coverage Status" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gareth-cross/0d939a81f2048609c1d3758371e94b7d/raw/wrenfold.json"></a>
 <a href="https://pypi.org/project/wrenfold/"><img alt="Python versions badge" src="https://img.shields.io/pypi/pyversions/wrenfold"/></a>
 <a href="https://anaconda.org/conda-forge/wrenfold"><img alt="conda-forge version badge" src="https://anaconda.org/conda-forge/wrenfold/badges/version.svg"/></a>
 <a href="https://crates.io/crates/wrenfold-traits"><img src="https://img.shields.io/crates/v/wrenfold-traits.svg" alt="crates.io"></a>
 <img alt="C++17" src="https://img.shields.io/badge/c++-17-blue" />
-<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
 </p>
 <!--- badges_end --->
 
@@ -145,3 +145,7 @@ wrenfold was originally created by [me](https://github.com/gareth-cross) after d
 The project began as a part-time hobby for fun, and has evolved into a more full-featured framework over time. wrenfold is in the early stages of receiving feedback from a wider audience. There will be rough edges and undoubtedly some bugs. If you find something broken or missing, please consider [filing a ticket](https://github.com/wrenfold/wrenfold/issues/new/choose). I aim to continue developing and expanding the framework. For details of upcoming work, see the [planned features list](https://github.com/wrenfold/wrenfold/issues?q=is%3Aissue+is%3Aopen+label%3Afeature).
 
 If you are interested in collaboration opportunities or have general questions, please [reach out](mailto:gcross.code@icloud.com?subject=Wrenfold).
+
+## License
+
+wrenfold uses the [MIT License](./LICENSE).

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -154,6 +154,7 @@ if(MSVC)
   target_compile_options(wf_core PRIVATE /bigobj /EHs)
 endif()
 
+target_link_libraries(wf_core wf_coverage_config)
 target_link_libraries(wf_core wf_runtime fmt::fmt-header-only
                       absl::inlined_vector absl::span absl::flat_hash_set)
 if(WIN32)

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -219,7 +219,7 @@ TEST(CppGenerationTest, TestFloor) {
 TEST(CppGenerationTest, TestHyperbolicTrigFunctions) {
   EXPECT_EQ(std::cosh(1.6), gen::cosh_test(1.6));
   EXPECT_EQ(std::sinh(-1.3), gen::sinh_test(-1.3));
-  EXPECT_EQ(std::tanh(0.22), gen::tanh_test(0.22));
+  EXPECT_NEAR(std::tanh(0.22), gen::tanh_test(0.22), 1.0e-16);
   EXPECT_EQ(std::acosh(2.1), gen::acosh_test(2.1));
   EXPECT_EQ(std::asinh(-5.2), gen::asinh_test(-5.2));
   EXPECT_EQ(std::atanh(0.42), gen::atanh_test(0.42));

--- a/components/runtime/CMakeLists.txt
+++ b/components/runtime/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(wf_runtime INTERFACE ${RUNTIME_SOURCES})
 target_include_directories(
   wf_runtime INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                        $<INSTALL_INTERFACE:include>)
+target_link_libraries(wf_runtime INTERFACE wf_coverage_config)
 
 if(WF_BUILD_EXTRAS)
   add_subdirectory(tests)

--- a/docs/PACKAGE_README.md
+++ b/docs/PACKAGE_README.md
@@ -11,6 +11,7 @@
 <!--- badges_start --->
 <p align="center">
 <a href="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml?query=branch%3Amain"><img alt="GitHub Actions Workflow Status" src="https://github.com/wrenfold/wrenfold/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+<a href="https://github.com/wrenfold/wrenfold/actions/workflows/coverage.yml?query=branch%3Amain"><img alt="Code Coverage Status" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gareth-cross/0d939a81f2048609c1d3758371e94b7d/raw/wrenfold.json"></a>
 <a href="https://pypi.org/project/wrenfold/"><img alt="Python versions badge" src="https://img.shields.io/pypi/pyversions/wrenfold"/></a>
 <a href="https://crates.io/crates/wrenfold-traits"><img src="https://img.shields.io/crates/v/wrenfold-traits.svg" alt="crates.io"></a>
 <img alt="C++17" src="https://img.shields.io/badge/c++-17-blue" />

--- a/examples/c_generation/c_span_types.h
+++ b/examples/c_generation/c_span_types.h
@@ -34,8 +34,8 @@ typedef struct output_span2d output_span2d_t;
 // We assume a column-major ordering to match Eigen.
 inline double get_input_value(const input_span2d_t span, const uint32_t row, const uint32_t col) {
   assert(span.data);
-  assert(row < span->rows);
-  assert(col < span->cols);
+  assert(row < span.rows);
+  assert(col < span.cols);
   return span.data[row + col * span.stride];
 }
 

--- a/support/print_coverage.py
+++ b/support/print_coverage.py
@@ -1,0 +1,22 @@
+"""
+Print the code-coverage percentage. Invoked from coverage.yml
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    output = subprocess.check_output(
+        ["lcov", "--gcov-tool", sys.argv[1], "--summary",
+         Path(sys.argv[2]).absolute()])
+    output = output.decode("utf-8")
+    # Pull the percentage coverage out:
+    regex = re.compile(r"lines\.+:\s+([0-9.]+)\%", flags=re.IGNORECASE)
+    percentage, = regex.findall(output)
+    print(f"{percentage}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add a github action that computes code coverage using GCC `lcov`
- Add `WF_CODE_COVERAGE` flag to CMake.
- Fix a couple of places where `Debug` mode builds were broken.