### PR TITLE
Add some new test coverage, add tests for tree_formatter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,6 +72,7 @@ jobs:
           -DWF_STUBS_REQUIRED=ON
           -DWF_DOCS_REQUIRED=OFF
           -DWF_CODE_COVERAGE=ON
+          -DWF_BUILD_WITH_TRACING=ON
           -DPython_ROOT_DIR=${{ env.Python_ROOT_DIR }}
           -DPython_FIND_STRATEGY=LOCATION
           -DPython_FIND_REGISTRY=NEVER
@@ -109,6 +110,8 @@ jobs:
           '/usr/include/*'
           '/usr/lib/*'
           '*/dependencies/*'
+          '*/core/tests/*'
+          '*/core/test_support/'
 
       - name: Generate HTML report
         working-directory: ${{github.workspace}}/build

--- a/components/core/test_support/wf_test_support/test_macros.h
+++ b/components/core/test_support/wf_test_support/test_macros.h
@@ -137,7 +137,7 @@ testing::AssertionResult string_equal_test_helper(const std::string_view,
     return testing::AssertionSuccess();
   }
   return testing::AssertionFailure() << fmt::format(
-             "String `{}` does not match ({}).ToString(), where:\n({}).ToString() = {}\n"
+             "String `{}` does not match ({}).to_string(), where:\n({}).to_string() = {}\n"
              "The expression tree for `{}` is:\n{}",
              escape_newlines(a), name_b, name_b, escape_newlines(b_str), name_b,
              b.to_expression_tree_string());

--- a/components/core/tests/CMakeLists.txt
+++ b/components/core/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_single_file_test(stack_allocator_test.cc)
 add_single_file_test(static_vector_test.cc)
 add_single_file_test(string_utils_test.cc)
 add_single_file_test(substitute_test.cc)
+add_single_file_test(tree_formatter_test.cc)
 add_single_file_test(type_list_test.cc)
 
 add_compiled_code_generator(

--- a/components/core/tests/derivatives_test.cc
+++ b/components/core/tests/derivatives_test.cc
@@ -258,6 +258,7 @@ TEST(DerivativesTest, TestDerivativeExpression) {
   ASSERT_IDENTICAL(derivative::create(abs(x + y), x, 2), f.diff(x));
   ASSERT_IDENTICAL(derivative::create(f, y, 1), f.diff(y));
   ASSERT_IDENTICAL(0, f.diff(z));
+  ASSERT_THROW(derivative::create(abs(x), x, 0), wf::invalid_argument_error);
 }
 
 TEST(DerivativesTest, TestUnevaluated) {
@@ -443,6 +444,7 @@ TEST(DerivativesTest, TestStopDerivative) {
   ASSERT_IDENTICAL(3 * cos(3 * y) * stop_diff(x * y), (sin(3 * y) * stop_diff(x * y)).diff(y));
   ASSERT_IDENTICAL(-sin(y) * stop_diff(2 * y), (sin(y) * stop_diff(2 * y)).diff(y, 2));
   ASSERT_NOT_IDENTICAL(stop_diff(x), stop_diff(y));
+  ASSERT_IDENTICAL(stop_diff(x), stop_diff(stop_diff(x)));
 }
 
 }  // namespace wf

--- a/components/core/tests/integer_utils_test.cc
+++ b/components/core/tests/integer_utils_test.cc
@@ -57,6 +57,7 @@ struct prime_factors_order {
 };
 
 TEST(IntegerUtils, TestComputePrimeFactors) {
+  ASSERT_TRUE(compute_prime_factors(0).empty());
   // Factor numbers 1 -> 10000.
   for (int64_t i = 1; i < 10000; ++i) {
     const std::vector<prime_factor> result = compute_prime_factors(i);

--- a/components/core/tests/matrix_operations_test.cc
+++ b/components/core/tests/matrix_operations_test.cc
@@ -60,6 +60,7 @@ TEST(MatrixOperationsTest, TestConstruct) {
   ASSERT_THROW(m(0, -1), dimension_error);
   ASSERT_THROW(m(5, 0), dimension_error);
   ASSERT_THROW(m(1, 10), dimension_error);
+  ASSERT_THROW(m[0], dimension_error);
 }
 
 TEST(MatrixOperationsTest, TestGetBlock) {
@@ -180,6 +181,10 @@ TEST(MatrixOperationsTest, TestStack) {
       }
     }
   }
+
+  ASSERT_THROW(hstack({}), wf::dimension_error);
+  ASSERT_THROW(vstack({}), wf::dimension_error);
+  ASSERT_THROW(diagonal_stack({}), wf::dimension_error);
 }
 
 TEST(MatrixOperationsTest, TestAddition) {
@@ -202,6 +207,9 @@ TEST(MatrixOperationsTest, TestAddition) {
   ASSERT_IDENTICAL(make_matrix(2, 2, a + 1, b, c, d + 1), m + make_identity(2));
   ASSERT_IDENTICAL(make_matrix(2, 2, 2 * a, b + c, c + b, d + d), m + m.transposed());
   ASSERT_IDENTICAL(make_zeros(2, 2), make_matrix(2, 2, a, b, c, d) - make_matrix(2, 2, a, b, c, d));
+
+  ASSERT_THROW(make_zeros(2, 3) + make_identity(2), wf::dimension_error);
+  ASSERT_THROW(make_vector(a, b, c) + make_row_vector(c, b, a), wf::dimension_error);
 }
 
 TEST(MatrixOperationsTest, TestMultiplication) {
@@ -471,6 +479,16 @@ TEST(MatrixOperationsTest, TestFactorizeLU5) {
 }
 #endif
 
+TEST(MatrixOperationsTest, TestDeterminantNonSquare) {
+  ASSERT_THROW(determinant(make_zeros(2, 3)), wf::dimension_error);
+  ASSERT_THROW(determinant(make_zeros(3, 2)), wf::dimension_error);
+}
+
+TEST(MatrixOperationsTest, TestDeterminant1x1) {
+  ASSERT_IDENTICAL(1, determinant(make_identity(1)));
+  ASSERT_IDENTICAL(5, determinant(make_vector(5)));
+}
+
 TEST(MatrixOperationsTest, TestDeterminant2x2) {
   auto I2 = make_identity(2);
   ASSERT_IDENTICAL(1, determinant(I2));
@@ -506,7 +524,6 @@ TEST(MatrixOperationsTest, TestDeterminant3x3) {
   ASSERT_IDENTICAL(-60, determinant(M3));
 }
 
-// TODO: Test the LU factors against the cofactor method?
 TEST(MatrixOperationsTest, TestDeterminant) {
   auto M1 = make_matrix(4, 4, 4, -1, -1, -3, 0, 3, -2, -1, 4, 1, 2, 1, -1, 3, -1, 1);
   ASSERT_IDENTICAL(28, determinant(M1));

--- a/components/core/tests/matrix_operations_test.cc
+++ b/components/core/tests/matrix_operations_test.cc
@@ -271,6 +271,9 @@ TEST(MatrixOperationsTest, TestJacobian) {
       make_matrix(3, 3, v2[0].diff(x), v2[0].diff(y), v2[0].diff(z), v2[1].diff(x), v2[1].diff(y),
                   v2[1].diff(z), v2[2].diff(x), v2[2].diff(y), v2[2].diff(z));
   ASSERT_IDENTICAL(v2_jacobian, v2.jacobian({x, y, z}));
+
+  ASSERT_THROW(v1.jacobian(make_zeros(2, 3)), wf::dimension_error);
+  ASSERT_THROW(make_matrix(2, 2, x * x, y - 3, 0, z).jacobian({x, y, z}), wf::dimension_error);
 }
 
 void check_full_piv_lu_solution(

--- a/components/core/tests/numeric_expressions_test.cc
+++ b/components/core/tests/numeric_expressions_test.cc
@@ -1,16 +1,15 @@
 // wrenfold symbolic code generator.
 // Copyright (c) 2024 Gareth Cross
 // For license information refer to accompanying LICENSE file.
-#include "wf/expressions/numeric_expressions.h"
+#include <gtest/gtest.h>
 
-#include "wf_test_support/test_macros.h"
+#include "wf/expressions/numeric_expressions.h"
 
 WF_BEGIN_THIRD_PARTY_INCLUDES
 #include <fmt/core.h>
 WF_END_THIRD_PARTY_INCLUDES
 
 namespace wf {
-using namespace wf::custom_literals;
 
 std::ostream& operator<<(std::ostream& stream, const wf::integer_constant& i) {
   stream << fmt::format("Integer({})", i.value());
@@ -20,6 +19,14 @@ std::ostream& operator<<(std::ostream& stream, const wf::integer_constant& i) {
 std::ostream& operator<<(std::ostream& stream, const wf::rational_constant& r) {
   stream << fmt::format("Rational({} / {})", r.numerator(), r.denominator());
   return stream;
+}
+
+TEST(NumericExpressionsTest, TestFormatters) {
+  ASSERT_EQ("33", fmt::format("{}", integer_constant{33}));
+  ASSERT_EQ("-5", fmt::format("{}", integer_constant{-5}));
+  ASSERT_EQ("(2 / 3)", fmt::format("{}", rational_constant{2, 3}));
+  ASSERT_EQ("(-1 / 10)", fmt::format("{}", rational_constant{-1, 10}));
+  ASSERT_EQ(fmt::format("{}", 2.3123), fmt::format("{}", float_constant{2.3123}));
 }
 
 TEST(NumericExpressionsTest, TestRational) {
@@ -34,6 +41,7 @@ TEST(NumericExpressionsTest, TestRational) {
   ASSERT_FALSE(a.try_convert_to_integer());
   ASSERT_EQ(a, rational_constant(16, 64));
   ASSERT_EQ(0.25, static_cast<float_constant>(a).value());
+  ASSERT_NE(a, rational_constant(-3, 8));
 
   const rational_constant b{30, 10};
   ASSERT_TRUE(b.try_convert_to_integer());

--- a/components/core/tests/plain_formatter_test.cc
+++ b/components/core/tests/plain_formatter_test.cc
@@ -3,10 +3,15 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/constants.h"
 #include "wf/expressions/substitute_expression.h"
+#include "wf/expressions/variable.h"
 #include "wf/functions.h"
 #include "wf/matrix_functions.h"
 
 #include "wf_test_support/test_macros.h"
+
+WF_BEGIN_THIRD_PARTY_INCLUDES
+#include <fmt/ostream.h>
+WF_END_THIRD_PARTY_INCLUDES
 
 namespace wf {
 using namespace wf::custom_literals;
@@ -149,6 +154,7 @@ TEST(PlainFormatterTest, TestBuiltInFunctions) {
   ASSERT_STR_EQ("acosh(x + y)", acosh(x + y));
   ASSERT_STR_EQ("asinh(5*x)", asinh(5 * x));
   ASSERT_STR_EQ("atanh(x/y)", atanh(x / y));
+  ASSERT_STR_EQ("sign(x)", signum(x));
 }
 
 TEST(PlainFormatterTest, TestMatrix) {
@@ -197,6 +203,24 @@ TEST(PlainFormatterTest, TestScalarConstants) {
 TEST(PlainFormatterTest, TestBooleanConstants) {
   ASSERT_STR_EQ("True", constants::boolean_true);
   ASSERT_STR_EQ("False", constants::boolean_false);
+}
+
+TEST(PlainFormatterTest, TestVariableExpressions) {
+  ASSERT_STR_EQ("x", make_expr<variable>("x", number_set::unknown));
+  ASSERT_STR_EQ("$arg(0, 3)", make_expr<variable>(function_argument_variable(
+                                  0, 3, numeric_primitive_type::boolean)));
+  const unique_variable u(number_set::complex);
+  ASSERT_STR_EQ(fmt::format("$u_{}", u.index()), make_expr<variable>(u));
+}
+
+TEST(PlainFormatterTest, TestFmtIntegration) {
+  const auto [x, y] = make_symbols("x", "y");
+  // Test that fmt::formatter specialization works.
+  ASSERT_EQ("x*y", fmt::format("{}", x * y));
+  ASSERT_EQ("x < y", fmt::format("{}", x < y));
+  ASSERT_EQ("[[x], [y], [3]]", fmt::format("{}", make_vector(x, y, 3)));
+  ASSERT_EQ("x", fmt::format("{}", fmt::streamed(x)));
+  ASSERT_EQ("x < y", fmt::format("{}", fmt::streamed(x < y)));
 }
 
 }  // namespace wf

--- a/components/core/tests/substitute_test.cc
+++ b/components/core/tests/substitute_test.cc
@@ -163,6 +163,10 @@ TEST(SubstituteTest, TestMultiplications) {
 
   // Check recursion behavior - this should not collapse to x:
   ASSERT_IDENTICAL(log(x * x), log(x * log(x * x)).subs(log(x * x), x));
+
+  // Failed case where no integer multiple is possible:
+  ASSERT_IDENTICAL(y * w, (y * w).subs(pow(y, z) * w, 5));
+  ASSERT_IDENTICAL(pow(y, z) * w, (pow(y, z) * w).subs(y * w, 5));
 }
 
 TEST(SubstituteTest, TestMatrix) {

--- a/components/core/tests/tree_formatter_test.cc
+++ b/components/core/tests/tree_formatter_test.cc
@@ -1,0 +1,161 @@
+// wrenfold symbolic code generator.
+// Copyright (c) 2024 Gareth Cross
+// For license information refer to accompanying LICENSE file.
+#include "wf/constants.h"
+#include "wf/expressions/function_expressions.h"
+#include "wf/expressions/substitute_expression.h"
+#include "wf/functions.h"
+
+#include "wf_test_support/test_macros.h"
+
+#define ASSERT_TREE_STR_EQ(val1, val2) \
+  ASSERT_PRED_FORMAT2(wf::tree_formatter_test_helper, val1, val2)
+
+namespace wf {
+using namespace wf::custom_literals;
+
+template <typename ExprType>
+testing::AssertionResult tree_formatter_test_helper(const std::string_view,
+                                                    const std::string_view name_b,
+                                                    const std::string_view a, const ExprType& b) {
+  const std::string b_str = b.to_expression_tree_string();
+  if (a == b_str) {
+    return testing::AssertionSuccess();
+  }
+  return testing::AssertionFailure() << fmt::format(
+             "String `{}` does not match ({}).to_expression_tree_string(), "
+             "where:\n({}).to_expression_tree_string() is:\n"
+             "{}\n",
+             escape_newlines(a), name_b, name_b, b_str);
+}
+
+TEST(TreeFormatterTest, TestAddition) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+  ASSERT_TREE_STR_EQ(R"(Addition:
+├─ Variable (x, unknown)
+├─ Variable (y, unknown)
+└─ Variable (z, unknown))",
+                     x + y + z);
+}
+
+TEST(TreeFormatterTest, TestBuiltInFunctionInvocation) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(BuiltInFunctionInvocation (asin):
+└─ Multiplication:
+   ├─ Variable (x, unknown)
+   └─ Variable (y, unknown))",
+                     asin(x * y));
+  ASSERT_TREE_STR_EQ(R"(BuiltInFunctionInvocation (sign):
+└─ Variable (y, unknown))",
+                     signum(y));
+}
+
+TEST(TreeFormatterTest, TestConstants) {
+  ASSERT_TREE_STR_EQ("BooleanConstant (true)", constants::boolean_true);
+  ASSERT_TREE_STR_EQ("BooleanConstant (false)", constants::boolean_false);
+  ASSERT_TREE_STR_EQ("ComplexInfinity", constants::complex_infinity);
+  ASSERT_TREE_STR_EQ("Undefined", constants::undefined);
+  ASSERT_TREE_STR_EQ("ImaginaryUnit", constants::imaginary_unit);
+  ASSERT_TREE_STR_EQ("IntegerConstant (1)", 1_s);
+  ASSERT_TREE_STR_EQ("RationalConstant (2 / 3)", 2_s / 3);
+  ASSERT_TREE_STR_EQ("FloatConstant (1.32)", 1.32_s);
+  ASSERT_TREE_STR_EQ("SymbolicConstant (pi)", constants::pi);
+  ASSERT_TREE_STR_EQ("SymbolicConstant (E)", constants::euler);
+}
+
+TEST(TreeFormatterTest, TestConditional) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+  ASSERT_TREE_STR_EQ(R"(Conditional:
+├─ Relational (<)
+│  ├─ IntegerConstant (0)
+│  └─ Variable (x, unknown)
+├─ Variable (y, unknown)
+└─ Variable (z, unknown))",
+                     where(x > 0, y, z));
+}
+
+TEST(TreeFormatterTest, TestDerivative) {
+  const auto [x, y] = make_symbols("x", "y");
+  const symbolic_function f{"foo"};
+  ASSERT_TREE_STR_EQ(R"(Derivative (order = 2):
+├─ SymbolicFunctionInvocation (foo):
+│  ├─ Variable (x, unknown)
+│  └─ Variable (y, unknown)
+└─ Variable (y, unknown))",
+                     f(x, y).diff(y, 2));
+}
+
+TEST(TreeFormatterTest, TestIverson) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(IversonBracket:
+└─ Relational (==)
+   ├─ Variable (x, unknown)
+   └─ Variable (y, unknown))",
+                     iverson(x == y));
+}
+
+TEST(TreeFormatterTest, TestMatrix) {
+  ASSERT_TREE_STR_EQ(R"(Matrix (2, 3):
+├─ IntegerConstant (1)
+├─ IntegerConstant (0)
+├─ IntegerConstant (0)
+├─ IntegerConstant (0)
+├─ IntegerConstant (1)
+└─ IntegerConstant (0))",
+                     make_identity(2, 3));
+}
+
+TEST(TreeFormatterTest, TestMultiplication) {
+  const auto [x, y, z] = make_symbols("x", "y", "z");
+  ASSERT_TREE_STR_EQ(R"(Multiplication:
+├─ Variable (x, unknown)
+├─ Variable (y, unknown)
+└─ Variable (z, unknown))",
+                     x * y * z);
+}
+
+TEST(TreeFormatterTest, TestPower) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(Power:
+├─ Addition:
+│  ├─ Variable (x, unknown)
+│  └─ Variable (y, unknown)
+└─ Multiplication:
+   ├─ IntegerConstant (2)
+   └─ Variable (y, unknown))",
+                     pow(x + y, 2 * y));
+}
+
+TEST(TreeFormatterTest, TestStopDerivative) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(StopDerivative:
+└─ Addition:
+   ├─ Variable (x, unknown)
+   └─ Multiplication:
+      ├─ IntegerConstant (-1)
+      └─ Variable (y, unknown))",
+                     stop_diff(x - y));
+}
+
+TEST(TreeFormatterTest, TestSubstitution) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(Substitution:
+├─ Power:
+│  ├─ Variable (x, unknown)
+│  └─ IntegerConstant (2)
+├─ Variable (x, unknown)
+└─ Variable (y, unknown))",
+                     substitution::create(x * x, x, y));
+}
+
+TEST(TreeFormatterTest, TestUnevaluated) {
+  const auto [x, y] = make_symbols("x", "y");
+  ASSERT_TREE_STR_EQ(R"(Unevaluated:
+└─ Multiplication:
+   ├─ IntegerConstant (5)
+   ├─ Variable (x, unknown)
+   └─ Variable (y, unknown))",
+                     make_unevaluated(x * 5 * y));
+}
+
+}  // namespace wf

--- a/components/core/wf/expression_visitor.h
+++ b/components/core/wf/expression_visitor.h
@@ -45,18 +45,6 @@ auto visit(const expression_base<D, M>& expr, F&& visitor) {
       });
 }
 
-// Visit a std::variant of different `expression_base` types.
-template <typename... Ts, typename F>
-auto visit(const std::variant<Ts...>& variant, F&& visitor) {
-  return std::visit(
-      [&visitor](const auto& x) {
-        using T = std::decay_t<decltype(x)>;
-        static_assert(inherits_expression_base_v<T>);
-        return visit(x, std::forward<F>(visitor));
-      },
-      variant);
-}
-
 // Visit two expressions with an invocable that accepts two concrete types in its operator()(...)
 // signature.
 template <typename U, typename V, typename VisitorType>

--- a/components/core/wf/expressions/addition.cc
+++ b/components/core/wf/expressions/addition.cc
@@ -7,7 +7,6 @@
 #include "wf/expressions/multiplication.h"
 #include "wf/expressions/numeric_expressions.h"
 #include "wf/expressions/special_constants.h"
-#include "wf/utility/overloaded_visit.h"
 
 namespace wf {
 

--- a/components/core/wf/expressions/matrix.cc
+++ b/components/core/wf/expressions/matrix.cc
@@ -3,7 +3,7 @@
 // For license information refer to accompanying LICENSE file.
 #include "wf/expressions/matrix.h"
 
-#include "wf/expression_visitor.h"
+#include "wf/constants.h"
 #include "wf/expressions/addition.h"
 #include "wf/utility/assertions.h"
 
@@ -32,22 +32,6 @@ matrix matrix::get_block(const index_t row, const index_t col, const index_t nro
     data.push_back(get_unchecked(i + row, j + col));
   });
   return matrix(nrows, ncols, std::move(data));
-}
-
-void matrix::set_block(const index_t row, const index_t col, const index_t nrows,
-                       const index_t ncols, const matrix& block) {
-  if (row < 0 || row + nrows > rows_ || col < 0 || col + ncols > cols_) {
-    throw dimension_error(
-        "Block [position: ({}, {}), size: ({}, {})] is out of bounds for matrix of shape ({}, {})",
-        row, col, nrows, ncols, rows_, cols_);
-  }
-  if (block.rows() != nrows || block.cols() != ncols) {
-    throw dimension_error("Block shape ({}, {}) does not match requested shape ({}, {})",
-                          block.rows(), block.cols(), nrows, ncols);
-  }
-  iter_matrix(nrows, ncols, [&](index_t i, index_t j) {
-    set_unchecked(i + row, j + col, block.get_unchecked(i, j));
-  });
 }
 
 matrix matrix::transposed() const {

--- a/components/core/wf/expressions/matrix.h
+++ b/components/core/wf/expressions/matrix.h
@@ -47,16 +47,8 @@ class matrix {
     return data_[compute_index(i, j)];
   }
 
-  // Set with no bounds checking.
-  void set_unchecked(const index_t i, const index_t j, const scalar_expr& value) noexcept {
-    data_[compute_index(i, j)] = value;
-  }
-
   // Get a sub-block from this matrix.
   matrix get_block(index_t row, index_t col, index_t nrows, index_t ncols) const;
-
-  // Set a sub-block of this matrix.
-  void set_block(index_t row, index_t col, index_t nrows, index_t ncols, const matrix& block);
 
   // Transpose the matrix.
   matrix transposed() const;

--- a/components/core/wf/expressions/numeric_expressions.h
+++ b/components/core/wf/expressions/numeric_expressions.h
@@ -20,7 +20,7 @@ class rational_constant;
 // An integral constant.
 class integer_constant {
  public:
-  static constexpr std::string_view name_str = "Integer";
+  static constexpr std::string_view name_str = "IntegerConstant";
   static constexpr bool is_leaf_node = true;
 
   using value_type = checked_int;
@@ -62,7 +62,7 @@ class integer_constant {
 // A rational value (in form numerator / denominator).
 class rational_constant {
  public:
-  static constexpr std::string_view name_str = "Rational";
+  static constexpr std::string_view name_str = "RationalConstant";
   static constexpr bool is_leaf_node = true;
 
   using value_type = checked_int;
@@ -142,7 +142,7 @@ class rational_constant {
 // A floating point constant.
 class float_constant {
  public:
-  static constexpr std::string_view name_str = "Float";
+  static constexpr std::string_view name_str = "FloatConstant";
   static constexpr bool is_leaf_node = true;
 
   using value_type = double;

--- a/components/core/wf/expressions/special_constants.h
+++ b/components/core/wf/expressions/special_constants.h
@@ -16,7 +16,7 @@ namespace wf {
 // A symbolic constant, like pi or euler's number.
 class symbolic_constant {
  public:
-  static constexpr std::string_view name_str = "Constant";
+  static constexpr std::string_view name_str = "SymbolicConstant";
   static constexpr bool is_leaf_node = true;
 
   // Construct with name.

--- a/components/core/wf/tree_formatter.cc
+++ b/components/core/wf/tree_formatter.cc
@@ -192,14 +192,22 @@ void tree_formatter_visitor::format_append(const std::string_view fmt_str, Args&
 template <typename T>
 void tree_formatter_visitor::visit_left(const T& expr) {
   indentations_.push_back(true);
-  visit(expr, *this);
+  if constexpr (is_any_expression_v<T>) {
+    std::visit(*this, expr);
+  } else {
+    visit(expr, *this);
+  }
   indentations_.pop_back();
 }
 
 template <typename T>
 void tree_formatter_visitor::visit_right(const T& expr) {
   indentations_.push_back(false);
-  visit(expr, *this);
+  if constexpr (is_any_expression_v<T>) {
+    std::visit(*this, expr);
+  } else {
+    visit(expr, *this);
+  }
   indentations_.pop_back();
 }
 

--- a/components/wrapper/pywrenfold/matrix_wrapper.cc
+++ b/components/wrapper/pywrenfold/matrix_wrapper.cc
@@ -350,6 +350,11 @@ void wrap_matrix_operations(py::module_& m) {
           [](const matrix_expr& self,
              const std::variant<std::vector<scalar_expr>, matrix_expr>& vars,
              const bool use_abstract) {
+            if (self.rows() != 1 && self.cols() != 1) {
+              throw dimension_error(
+                  "Jacobian can only be computed on vectors. Received dimensions: [{}, {}]",
+                  self.rows(), self.cols());
+            }
             return jacobian(self.as_matrix().children(), span_from_variant(vars),
                             use_abstract ? non_differentiable_behavior::abstract
                                          : non_differentiable_behavior::constant);

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -180,9 +180,12 @@ class CodeGenerationWrapperTest(MathTestBase):
         definition = code_generation.transpile(desc)
         sig = definition.signature
 
+        self.assertEqual('FunctionDescription(\'func2\', 6 args)', repr(desc))
         self.assertEqual('func2', sig.name)
         self.assertEqual(type_info.ScalarType(type_info.NumericType.Float), sig.return_type)
 
+        self.assertEqual('Argument(x: matrix_type<2, 1>)', repr(sig.arguments[0]))
+        self.assertEqual('Argument(z: floating_point)', repr(sig.arguments[2]))
         self._check_arg(
             sig.arguments[0],
             'x',
@@ -230,6 +233,7 @@ class CodeGenerationWrapperTest(MathTestBase):
 
         ctype = sig.arguments[1].type
         self.assertIsInstance(ctype, type_info.CustomType)
+        self.assertEqual(f'CustomType(\'Point2d\', 2 fields, {repr(Point2d)})', repr(ctype))
         self.assertEqual('Point2d', ctype.name)
         self.assertEqual(Point2d, ctype.python_type)
         self.assertEqual(2, ctype.total_size)
@@ -244,6 +248,8 @@ class CodeGenerationWrapperTest(MathTestBase):
     def test_opaque_func(self):
         """Test we can customize invocation of a custom function."""
         code = code_generation.generate_function(opaque_type_func, generator=CustomCppGenerator())
+        self.assertEqual('external_func(foo: OpaqueType, bar: floating_point) -> floating_point',
+                         repr(external_func))
         self.assertTrue('custom::external_func' in code)
 
     def test_nested_type_func(self):

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -65,6 +65,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertNotIdentical(b, c)
         self.assertEqual('Variable', a.type_name)
         self.assertEqual((), a.args)
+        self.assertRaises(exceptions.InvalidArgumentError, lambda: sym.unique_symbols(count=0))
 
     def test_is_identical_to(self):
         """Test calling is_identical_to and __eq__."""
@@ -331,6 +332,8 @@ class ExpressionWrapperTest(MathTestBase):
     def test_relational(self):
         """Test creating relational expressions."""
         x, y, z = sym.symbols('x, y, z')
+        self.assertIsInstance(x < y, sym.BooleanExpr)
+        self.assertEqual("Relational", (x < y).type_name)
         self.assertIdentical(x < y, y > x)
         self.assertIdentical(z > 0, 0 < z)
         self.assertIdentical(x >= 0.0, 0.0 <= x)

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -143,6 +143,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertReprEqual('I', sym.I)
         self.assertReprEqual('E', sym.E)
         self.assertReprEqual('2 + 5*I', 2 + 5 * sym.I)
+        self.assertReprEqual('acos(x)*asin(y)*atan(z)', sym.acos(x) * sym.asin(y) * sym.atan(z))
 
     def test_bool_conversion(self):
         """Test that only true and false can be converted to bool."""
@@ -412,6 +413,9 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertEqual(123, (sym.integer(100) + x).subs(x, 23).eval())
         self.assertEqual(complex(1, 2), (1 + sym.I * 2).eval())
         self.assertEqual(complex(0.23, 0.5), (x + sym.I * y).subs(x, 0.23).subs(y, 0.5).eval())
+
+        self.assertRaises(exceptions.TypeError, lambda: sym.derivative(x, y, 1).eval())
+        self.assertRaises(exceptions.TypeError, lambda: sym.zoo.eval())
 
     def test_cse(self):
         """Test calling eliminate_subexpressions()."""

--- a/components/wrapper/tests/external_function_wrapper_test.py
+++ b/components/wrapper/tests/external_function_wrapper_test.py
@@ -114,6 +114,7 @@ class ExternalFunctionWrapperTest(MathTestBase):
 
         self.assertIsInstance(f, TestType)
         self.assertIsInstance(f._provenance, sym.CompoundExpr)
+        self.assertRaises(exceptions.TypeError, lambda: bool(f._provenance))
         self.assertEqual("ExternalFunctionInvocation", f._provenance.type_name)
 
         # Pass it to another function:

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -284,7 +284,7 @@ class MatrixWrapperTest(MathTestBase):
             sym.matrix([[x, y], [z, a], [b, c]]),
             sym.matrix([x, y, z, a, b, c]).reshape((3, 2)),
         )
-        self.assertRaises(exceptions.DimensionError, lambda: sym.eye(2).reshape(4, 5))
+        self.assertRaises(exceptions.DimensionError, lambda: sym.eye(2).reshape((4, 5)))
         self.assertRaises(exceptions.DimensionError, lambda: sym.eye(4).reshape(-2, 8))
         self.assertRaises(exceptions.DimensionError, lambda: sym.eye(4).reshape(2, -8))
 
@@ -426,6 +426,7 @@ class MatrixWrapperTest(MathTestBase):
 
         self.assertRaises(exceptions.DimensionError, lambda: sym.jacobian(m, []))
         self.assertRaises(exceptions.DimensionError, lambda: sym.jacobian(sym.zeros(2, 2), m))
+        self.assertRaises(exceptions.DimensionError, lambda: sym.zeros(2, 3).jacobian([x, y, z]))
 
     def test_subs(self):
         """Test calling subs on a matrix."""

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import sympy as sp
 
-from wrenfold import sym, sympy_conversion, type_info
+from wrenfold import exceptions, sym, sympy_conversion, type_info
 
 from .test_base import MathTestBase
 
@@ -357,6 +357,12 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(m2_wf, m2_sp)
         self.assertIdenticalFromSp(sym.eye(2), sp.eye(2))
         self.assertIdenticalFromSp(sym.zeros(3, 5), sp.zeros(3, 5))
+
+    def test_unsupported(self):
+        x, y = sym.symbols('x, y')
+        self.assertRaises(exceptions.TypeError, lambda: spy(sym.stop_derivative(x * y)))
+        u = sym.unique_symbols(1)
+        self.assertRaises(exceptions.TypeError, lambda: spy(u))
 
 
 if __name__ == '__main__':

--- a/support/code_coverage.py
+++ b/support/code_coverage.py
@@ -1,0 +1,67 @@
+"""
+Run code-coverage report locally.
+"""
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.absolute()
+
+
+def main(args: argparse.Namespace):
+    if args.build_dir is None:
+        args.build_dir = REPO_ROOT / "build"
+    if args.gcov_tool is None:
+        args.gcov_tool = "gcov"
+
+    build_dir = Path(args.build_dir).absolute()
+    output_dir = Path(args.output).absolute()
+    os.makedirs(str(output_dir), exist_ok=True)
+
+    # Generate coverage summary:
+    subprocess.check_call([
+        "lcov",
+        "--gcov-tool",
+        args.gcov_tool,
+        "--directory",
+        str(build_dir),
+        "--capture",
+        "--output-file",
+        str(output_dir / "coverage.info"),
+    ])
+
+    # Filter the summary:
+    subprocess.check_call([
+        "lcov",
+        "--gcov-tool",
+        args.gcov_tool,
+        "--remove",
+        str(output_dir / "coverage.info"),
+        "-o",
+        str(output_dir / "filtered.info"),
+        "/usr/include/*",
+        "/usr/lib/*",
+        "*/dependencies/*",
+    ])
+
+    # Generate HTML report:
+    subprocess.check_call([
+        "genhtml",
+        str(output_dir / "filtered.info"),
+        "--output-directory",
+        str(output_dir),
+    ])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-b", "--build-dir", type=str, help="Path to build-directory")
+    parser.add_argument("-o", "--output", type=str, help="Output directory", required=True)
+    parser.add_argument("-g", "--gcov-tool", type=str, help="Path to gcov command")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/support/code_coverage.py
+++ b/support/code_coverage.py
@@ -44,6 +44,8 @@ def main(args: argparse.Namespace):
         "/usr/include/*",
         "/usr/lib/*",
         "*/dependencies/*",
+        "*/core/tests/*",
+        "*/core/test_support/*",
     ])
 
     # Generate HTML report:


### PR DESCRIPTION
Change https://github.com/wrenfold/wrenfold/pull/296 added code-coverage analysis. The report revealed that test coverage was generally quite good, with a few small opportunities for improvement:
- There were some minor edge cases that could benefit from tests (new test cases added).
- The code coverage revealed a couple of unused methods (removed).
- `tree_formatter` lacked any tests (new tests added).