### PR TITLE
Change PyProject build type to Release instead of RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(WF_BUILD_EXTRAS "Build tests, benchmarks, examples, and docs."
        ${WF_BUILD_EXTRAS_DEFAULT})
 option(WF_STUBS_REQUIRED "Fail if stubgen cannot be found." OFF)
 option(WF_DOCS_REQUIRED "Fail if sphinx/doxygen cannot be found." OFF)
-option(WF_CODE_COVERAGE "Build in code coverag mode." OFF)
+option(WF_CODE_COVERAGE "Build in code coverage mode." OFF)
 
 # Add third party code
 add_subdirectory(dependencies)
@@ -66,6 +66,9 @@ if(WF_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   # Turn off optimization, add debug info, and enable coverage.
   target_compile_options(wf_coverage_config INTERFACE -O0 -g --coverage)
   target_link_options(wf_coverage_config INTERFACE --coverage)
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(FATAL_ERROR "Build type must be Debug to build code coverage.")
+  endif()
 endif()
 
 # Custom target that groups together all the rust code-generation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,15 +46,11 @@ build-backend = "scikit_build_core.build"
 cmake.version = ">=3.20"
 # It seems like setting `build-type` is insufficient on Windows, and we fall back to Debug.
 # Place it in the `args` list to force a release build.
-cmake.args = ["-G", "Ninja", "-Wno-deprecated", "-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DWF_STUBS_REQUIRED=ON"]
-cmake.verbose = true
-cmake.build-type = "RelWithDebInfo"
-
+cmake.args = ["-G", "Ninja", "-Wno-deprecated", "-DCMAKE_BUILD_TYPE=Release", "-DWF_STUBS_REQUIRED=ON"]
+cmake.build-type = "Release"
 ninja.version = ">=1.5"
 ninja.make-fallback = false
-
 logging.level = "WARNING"
-
 wheel.packages = ["components/python/wrenfold"]
 wheel.license-files = [
     "LICENSE",
@@ -62,6 +58,7 @@ wheel.license-files = [
     "dependencies/fmt/LICENSE",
     "dependencies/pybind11/LICENSE"
 ]
+build.verbose = true
 
 [tool.cibuildwheel]
 skip = ["*musllinux_*", "*-win32", "*_i686", "pp*"]


### PR DESCRIPTION
In [0.10.6](https://scikit-build-core.readthedocs.io/en/stable/changelog.html#version-0-10-6), `scikit-build-core` changed the default behavior to not strip symbols. This meant that after #280 it was necessary to change the default flag to `Release`.