### PR TITLE
Add apply_preamble to the python code generator

### DIFF
--- a/components/core/wf/code_generation/python_code_generator.h
+++ b/components/core/wf/code_generation/python_code_generator.h
@@ -109,6 +109,8 @@ class python_code_generator {
   constexpr python_generator_float_width float_width() const noexcept { return float_width_; }
   constexpr std::size_t indentation() const noexcept { return indent_; }
 
+  std::string apply_preamble(std::string_view code) const;
+
  protected:
   python_generator_target target_;
   python_generator_float_width float_width_;

--- a/components/wrapper/pywrenfold/code_formatting_wrapper.cc
+++ b/components/wrapper/pywrenfold/code_formatting_wrapper.cc
@@ -343,6 +343,8 @@ void wrap_code_formatting_operations(py::module_& m) {
                              "Float precision applied to all NumPy arrays and tensors.")
       .def_property_readonly("indentation", &python_code_generator::indentation,
                              "Amount of spaces used to indent nested scopes.")
+      .def("apply_preamble", &python_code_generator::apply_preamble, py::arg("code"),
+           "Apply a preamble to generated code.")
       .doc() = "Generates Python code. Can target NumPy, PyTorch, or JAX.";
 }
 


### PR DESCRIPTION
Adds `apply_preamble` to the python code generator which simply uses the specified `target` to add the appropriate import statements to the code.

Also adds a simple unit test to verify functionality.