### PR TITLE
Make NumPy the default python target

### DIFF
--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -261,7 +261,7 @@ def generate_function(func: T.Callable[..., CodegenFuncInvocationResult],
 
 def generate_python(
     func: T.Callable[..., CodegenFuncInvocationResult],
-    target: PythonGeneratorTarget,
+    target: PythonGeneratorTarget = PythonGeneratorTarget.NumPy,
     convert_ternaries: T.Optional[bool] = None,
     context: T.Optional[T.Dict[str, T.Any]] = None,
     import_target_module: bool = True,

--- a/components/wrapper/tests/python_code_generation_test.py
+++ b/components/wrapper/tests/python_code_generation_test.py
@@ -569,8 +569,7 @@ class NumPyCodeGenerationTest(PythonCodeGenerationTestBase):
     def generate(cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
                  batch: bool, **kwargs) -> T.Callable:
         _, optional_arg_flags = cls.get_optional_output_flags(func)
-        func_gen, code = code_generation.generate_python(
-            func=func, target=code_generation.PythonGeneratorTarget.NumPy, **kwargs)
+        func_gen, code = code_generation.generate_python(func=func, **kwargs)
         if cls.VERBOSE:
             print(code)
 


### PR DESCRIPTION
As a convenience, make `NumPy` the default target when invoking `generate_python`.