### PR TITLE
Add new documentation page regarding returning matrices

### DIFF
--- a/components/core/test_support/wf_test_support/numeric_testing.h
+++ b/components/core/test_support/wf_test_support/numeric_testing.h
@@ -254,7 +254,7 @@ auto create_evaluator_with_output_expressions(type_list<ArgSymbolicTypes...>,
 // to numeric types.
 template <typename ReturnType, typename... Args>
 auto create_evaluator(ReturnType (*func)(Args... args)) {
-  // Scrape the the types of the input arguments:
+  // Scrape the types of the input arguments:
   custom_type_registry registry{};
   std::tuple arg_types = detail::record_arg_types(registry, type_list<Args...>{});
 

--- a/components/core/wf/code_generation/cpp_code_generator.cc
+++ b/components/core/wf/code_generation/cpp_code_generator.cc
@@ -28,8 +28,10 @@ constexpr static std::string_view cpp_string_from_numeric_type(
 
 std::string cpp_code_generator::operator()(const matrix_type&) const {
   throw type_error(
-      "The default C++ code-generator treats all matrices as spans. You likely want to implement a "
-      "formatter override for the the `{}` type.",
+      "The default C++ code-generator treats all matrices as spans. You probably want to implement "
+      "a "
+      "formatter override for the `{}` type.\n"
+      "See: https://wrenfold.org/reference/returning_matrices",
       matrix_type::snake_case_name_str);
 }
 
@@ -261,7 +263,8 @@ std::string cpp_code_generator::operator()(const ast::compare& x) const {
 std::string cpp_code_generator::operator()(const ast::construct_matrix&) const {
   throw type_error(
       "The default C++ code-generator treats all matrices as spans. We cannot construct one "
-      "directly. You likely want to implement an override for the the `{}` ast type.",
+      "directly. You probably want to implement an override for the `{}` ast type.\n"
+      "See: https://wrenfold.org/reference/returning_matrices",
       ast::construct_matrix::snake_case_name_str);
 }
 

--- a/components/core/wf/code_generation/rust_code_generator.cc
+++ b/components/core/wf/code_generation/rust_code_generator.cc
@@ -54,8 +54,10 @@ static std::vector<std::string_view> get_attributes(const ast::function_signatur
 
 std::string rust_code_generator::operator()(const matrix_type&) const {
   throw type_error(
-      "The default Rust code-generator treats all matrices as spans. You likely want to implement "
-      "a formatter override for the the `{}` type.",
+      "The default Rust code-generator treats all matrices as spans. You probably want to "
+      "implement "
+      "a formatter override for the `{}` type.\n"
+      "See: https://wrenfold.org/reference/returning_matrices",
       matrix_type::snake_case_name_str);
 }
 
@@ -272,8 +274,9 @@ std::string rust_code_generator::operator()(const ast::compare& x) const {
 std::string rust_code_generator::operator()(const ast::construct_matrix&) const {
   throw type_error(
       "The default Rust code-generator treats all matrices as span traits. We cannot construct "
-      "one directly. You likely want to implement an override for the the ConstructMatrix ast "
-      "type.");
+      "one directly. You probably want to implement an override for the `{}` ast type.\n"
+      "See: https://wrenfold.org/reference/returning_matrices",
+      ast::construct_matrix::snake_case_name_str);
 }
 
 std::string rust_code_generator::operator()(const ast::construct_custom_type& x) const {

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -117,6 +117,7 @@ if(${SPHINX_FOUND})
       source/reference/introduction.rst
       source/reference/new_language.rst
       source/reference/pendulum.py
+      source/reference/returning_matrices.rst
       source/reference/rotations.py
       source/reference/rotations.rst
       source/reference/symbolic_manipulation.rst

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -11,6 +11,7 @@ User guide
    advanced_derivatives
    generating_code
    integrating_code
+   returning_matrices
    generating_python
    conditionals
    rotations

--- a/docs/source/reference/integrating_code.rst
+++ b/docs/source/reference/integrating_code.rst
@@ -34,8 +34,10 @@ reference for all output matrices and vectors. The rationale is twofold:
   * With a forwarding reference we can accept non-const r-value arguments (such as temporary views
     into larger buffers).
 
-Of course, you can :doc:`customize code generation <new_language>` to your liking if this behavior
-is undesirable.
+.. tip::
+
+    In order to *return* a matrix we need to instantiate an actual object that owns storage. This is
+    covered in the section :doc:`Returning matrices <returning_matrices>`.
 
 The generated function invokes ``wf::make_optional_output_span<2, 1>`` on ``df`` in order to create
 a 2D span with dimensions ``(2, 1)``. Because this argument is optional, we can pass one of two
@@ -108,6 +110,8 @@ With our custom specialization in hand, we can call ``step_clamped`` with our ma
     // In cases where we do not care about the optional output, pass nullptr.
     const double step_2 = step_clamped(0.781, nullptr);
 
+.. _Using Eigen:
+
 Using Eigen
 ^^^^^^^^^^^
 
@@ -143,6 +147,8 @@ Generated C++ functions depend directly on:
 
 You can add these includes to your output code manually, or use the provided convenience function:
 :func:`wrenfold.code_generation.CppGenerator.apply_preamble`.
+
+.. _Rust Integration:
 
 Rust
 ----

--- a/docs/source/reference/returning_matrices.rst
+++ b/docs/source/reference/returning_matrices.rst
@@ -1,0 +1,102 @@
+Returning matrices
+==================
+
+The :doc:`Calling generated code <integrating_code>` section covered how to integrate a simple toy
+function (smoothstep with a Jacobian) into a C++ projected. Our ``step_clamped`` function generates
+a C++ function with the signature:
+
+.. code:: cpp
+
+  template <typename Scalar, typename T1>
+  Scalar step_clamped(const Scalar x, T1&& df)
+  {
+      auto _df = wf::make_optional_output_span<2, 1>(df);
+      // ...
+  }
+
+So far, we have yielded the output ``df`` as an output argument. We do not need to know
+anything about the linear algebra framework employed at runtime. The user provides the necessary
+specialization of :doc:`wf::convert_to_span <../cpp_api/span>` for type ``T1``, and wrenfold fills out
+the span ``_df`` with the results (default implementations are provided for :ref:`Eigen <Using Eigen>`
+and :ref:`nalgebra <Rust Integration>`).
+
+What if we want to **return** ``df`` directly, rather than passing it out as an argument? To achieve
+this, we need to define a custom code formatter and override two methods. For C++, this could look
+like:
+
+.. code:: python
+
+  from wrenfold import ast, code_generation, type_info
+
+  class CustomCppGenerator(code_generation.CppGenerator):
+    """Custom C++ generator to allow returning Eigen matrices."""
+
+    def format_matrix_type(self, mat: type_info.MatrixType):
+        """This methods specifies how we declare the return value type."""
+        return f"Eigen::Matrix<double, {mat.rows}, {mat.cols}>"
+
+    def format_construct_matrix(self, element: ast.ConstructMatrix) -> str:
+        """This method specifies how we construct the return value type."""
+        formatted_args = ", ".join(self.format(x) for x in element.args)
+        matrix_name = f"Eigen::Matrix<double, {element.type.rows}, {element.type.cols}>"
+        # In this case, we use the Eigen streaming operator:
+        return f"({matrix_name}() << {formatted_args}).finished()"
+
+Next, we alter the definition of ``step_clamped`` to return a vector with our outputs:
+
+.. code:: python
+
+  def step_clamped(x: type_annotations.FloatScalar):
+    """The clamped smoothstep polynomial."""
+    # First express the polynomials in terms of `xv`.
+    xv = sym.symbols('xv', real=True)
+    f = 3 * sym.pow(xv, 2) - 2 * sym.pow(xv, 3)
+    df = sym.vector(f.diff(xv), f.diff(xv, 2))
+
+    # Replace `xv` with the clamped argument.
+    x_clamped = sym.min(sym.max(x, 0), 1)
+    f = f.subs(xv, x_clamped)
+    df = df.subs(xv, x_clamped)
+
+    return sym.vstack([sym.vector(f), df])
+
+Then we generate the ``step_clamped`` function again using the custom generator:
+
+.. code:: python
+
+  # Note: We pass CustomCppGenerator here instead:
+  cpp = code_generation.generate_function(func=step_clamped, generator=CustomCppGenerator())
+  print(cpp)
+
+.. code:: cpp
+
+  // This snippet has been formatted with clang-format for clarity.
+  template <typename Scalar>
+  Eigen::Matrix<double, 3, 1> step_clamped(const Scalar x) {
+    // ...
+    const Scalar v002 = x;
+    Scalar v006;
+    if (v002 < static_cast<Scalar>(0)) {
+      v006 = static_cast<Scalar>(0);
+    } else {
+      v006 = v002;
+    }
+    Scalar v009;
+    if (static_cast<Scalar>(1) < v006) {
+      v009 = static_cast<Scalar>(1);
+    } else {
+      v009 = v006;
+    }
+    const Scalar v042 = -v009;
+    return (Eigen::Matrix<double, 3, 1>()
+                << v009 * v009 *
+                      (static_cast<Scalar>(3) + static_cast<Scalar>(2) * v042),
+            v009 * static_cast<Scalar>(6) * (static_cast<Scalar>(1) + v042),
+            static_cast<Scalar>(6) + static_cast<Scalar>(12) * v042)
+        .finished();
+  }
+
+Note that we had to define two methods on ``CustomCppGenerator``:
+
+  1. ``format_matrix_type``, which governs how the type will appear in the return signature.
+  2. ``format_construct_matrix``, which generates code that will invoke the constructor.


### PR DESCRIPTION
Motivated by https://github.com/wrenfold/wrenfold/issues/312

This change adds a new page to the documentation to better explain the procedure for customizing the C++ code generator to return Eigen types. The new page is explicitly linked from the exception that is thrown when the necessary override is missing.