### PR TITLE
Update version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "bspline_demo"
-version = "0.2.3"
+version = "0.0.1"
 dependencies = [
  "arrayvec",
  "bspline_rust_test",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "cart_pole_demo"
-version = "0.2.3"
+version = "0.0.1"
 dependencies = [
  "arrayvec",
  "colorgrad",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "wrenfold-test-utils"
-version = "0.2.3"
+version = "0.0.1"
 dependencies = [
  "approx 0.5.1",
  "nalgebra 0.33.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-package.version = "0.2.3"
+package.version = "0.0.1"
 package.license = "MIT"
 package.edition = "2021"
 package.authors = ["Gareth <gcross.code@icloud.com>"]

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -20,11 +20,11 @@ wrenfold is also available as a `conda-forge <https://anaconda.org/conda-forge/w
 **Alternatively**, python wheels may also be obtained from the
 `GitHub Releases Page <https://github.com/wrenfold/wrenfold/releases>`_. Select the ``whl`` file
 appropriate to your OS and python version. For example, for python 3.10 on arm64 OSX you would
-download and install ``wrenfold-0.2.3-cp310-cp310-macosx_11_0_arm64.whl``:
+download and install ``wrenfold-0.X.Y-cp310-cp310-macosx_11_0_arm64.whl``:
 
 .. code:: bash
 
-   pip install wrenfold-0.2.3-cp310-cp310-macosx_11_0_arm64.whl
+   pip install wrenfold-0.X.Y-cp310-cp310-macosx_11_0_arm64.whl
 
 Validating the install
 ----------------------
@@ -34,7 +34,7 @@ After installation, open a python REPL and test that wrenfold can be imported:
 .. code:: python
 
    import wrenfold
-   print(wrenfold.__version__)  # prints: 0.2.3
+   print(wrenfold.__version__)  # prints: 0.X.Y
 
    from wrenfold import sym
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wrenfold"
-version = "0.2.3"
+version = "0.3.0"
 requires-python = ">=3.9"
 authors = [
     { name = "Gareth Cross", email = "gcross.code@icloud.com" },

--- a/support/conda/wrenfold/meta.yaml
+++ b/support/conda/wrenfold/meta.yaml
@@ -1,8 +1,6 @@
-{% set version = "0.2.3" %}
-
 package:
   name: wrenfold
-  version: {{ version }}
+  version: 0.3.0
 
 source:
   path: ../../..


### PR DESCRIPTION
- Update version 0.3.0
- Stop the practice of matching the Cargo.toml version to the pyproject.toml