### PR TITLE
Set c++ standard in clang-format config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,4 @@ ColumnLimit: 100
 PointerAlignment: Left
 DerivePointerAlignment: false
 IncludeBlocks: Preserve
+Standard: c++20


### PR DESCRIPTION
Specify c++ standard in clang-format file to resolve issue with CLion IDE.