### PR TITLE
Remove MSVC2019 github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,6 @@ jobs:
       matrix:
         sys:
           - {
-              os: windows-2019,
-              shell: pwsh,
-              compiler_packages: "",
-              name_suffix: "default",
-              cc_env: "cl.exe",
-              cxx_env: "cl.exe"
-            }
-          - {
               os: windows-2022,
               shell: pwsh,
               compiler_packages: "",


### PR DESCRIPTION
VS2019 runners are being deprecated.