### PR TITLE
Switch to ruff for python formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,19 +22,16 @@ repos:
     hooks:
       - id: cmake-format
 
-  - repo: https://github.com/google/yapf
-    rev: 'v0.40.2'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
     hooks:
-      - id: yapf
-        additional_dependencies: [toml]
+      - id: ruff-format
+        types_or: [ python, pyi ]
         exclude: '^dependencies/'
-        require_serial: true
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
+      - id: ruff-check
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+        exclude: '^dependencies/'
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: 'v2.12.0'

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,7 +1,0 @@
-[style]
-based_on_style = yapf
-indent_width = 4
-column_limit = 100
-spaces_around_power_operator = True
-each_dict_entry_on_separate_line = False
-force_multiline_dict = True

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions to wrenfold are welcome. For instructions on setting up your envir
 **Legal notice**: By submitting to this project, you represent that you have the necessary rights to your contribution and that the content you contribute may be provided under the project license (MIT).
 
 When submitting a PR, please adhere to the following:
-- All changes must be formatted by the [pre-commit](https://pre-commit.com) rules. Pre-commit will automatically format C++ (clang-format), Python (yapf), and Rust (rustfmt) code.
+- All changes must be formatted by the [pre-commit](https://pre-commit.com) rules. Pre-commit will automatically format C++ (clang-format), Python (ruff), and Rust (rustfmt) code.
 - C++ code uses snake-case convention throughout.
 - Python code uses snake-case for functions and camel-case for types.
 - Python methods should be type-annotated whenever possible, and docstrings should adhere to [Google Style](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).

--- a/components/core/tests/generation_diff_test.py
+++ b/components/core/tests/generation_diff_test.py
@@ -15,11 +15,12 @@ def main():
 
     working_dir = Path(__file__).parent.absolute()
     try:
-        subprocess.check_call(["git", "diff", "--name-only", "--exit-code",
-                               str(args.filename)],
-                              cwd=str(working_dir))
+        subprocess.check_call(
+            ["git", "diff", "--name-only", "--exit-code", str(args.filename)],
+            cwd=str(working_dir),
+        )
     except subprocess.CalledProcessError:
-        print(f'git diff detected changes in file: {args.filename}')
+        print(f"git diff detected changes in file: {args.filename}")
         exit(1)
 
 

--- a/components/python/wrenfold/__init__.py
+++ b/components/python/wrenfold/__init__.py
@@ -1,4 +1,5 @@
 """Symbolic code-generation tools."""
+
 from pywrenfold import __git_version__, __version__
 
 __author__ = "Gareth <gcross.code@icloud.com>"

--- a/components/python/wrenfold/__init__.py
+++ b/components/python/wrenfold/__init__.py
@@ -1,6 +1,6 @@
 """Symbolic code-generation tools."""
 
-from pywrenfold import __git_version__, __version__
+from pywrenfold import __git_version__, __version__  # noqa: F401
 
 __author__ = "Gareth <gcross.code@icloud.com>"
 __copyright__ = "Copyright (C) 2024 Gareth Cross"

--- a/components/python/wrenfold/ast.py
+++ b/components/python/wrenfold/ast.py
@@ -1,2 +1,3 @@
 """Alias for the pywrenfold.ast module."""
-from pywrenfold.ast import *
+
+from pywrenfold.ast import *  # noqa: F403

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -8,19 +8,19 @@ import pathlib
 import typing as T
 
 from pywrenfold.gen import (
-    Argument,
-    ArgumentDirection,
+    Argument,  # noqa
+    ArgumentDirection,  # noqa
     BaseGenerator,
     CppGenerator,
-    CppMatrixTypeBehavior,
+    CppMatrixTypeBehavior,  # noqa
     FunctionDescription,
     OptimizationParams,
-    OutputKey,
+    OutputKey,  # noqa
     PythonGenerator,
-    PythonGeneratorFloatWidth,
+    PythonGeneratorFloatWidth,  # noqa
     PythonGeneratorTarget,
     RustGenerator,
-    cse_function_description,
+    cse_function_description,  # noqa
     transpile,
 )
 

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -37,7 +37,7 @@ class ReturnValue:
         custom type.
     """
 
-    expression: sym.Expr | sym.MatrixExpr | T.Any
+    expression: T.Union[sym.Expr, sym.MatrixExpr, T.Any]
 
 
 @dataclasses.dataclass
@@ -52,7 +52,7 @@ class OutputArg:
       is_optional: Specify whether the output argument is optional or not.
     """
 
-    expression: sym.Expr | sym.MatrixExpr | T.Any
+    expression: T.Union[sym.Expr, sym.MatrixExpr, T.Any]
     name: str
     is_optional: bool = False
 
@@ -65,7 +65,7 @@ CodegenFuncInvocationResult = T.Union[sym.Expr, sym.MatrixExpr, T.Sequence[Retur
 
 
 def create_function_description(
-    func: T.Callable[..., CodegenFuncInvocationResult], name: str | None = None
+    func: T.Callable[..., CodegenFuncInvocationResult], name: T.Optional[str] = None
 ) -> FunctionDescription:
     """
     Accept a python function that manipulates symbolic mathematical expressions, and convert it
@@ -204,9 +204,9 @@ def create_function_description(
 
 def generate_function(
     func: T.Callable[..., CodegenFuncInvocationResult],
-    generator: CppGenerator | RustGenerator | PythonGenerator | BaseGenerator,
-    name: str | None = None,
-    optimization_params: OptimizationParams | None = None,
+    generator: T.Union[CppGenerator, RustGenerator, PythonGenerator, BaseGenerator],
+    name: T.Optional[str] = None,
+    optimization_params: T.Optional[OptimizationParams] = None,
     convert_ternaries: bool = True,
 ) -> str:
     """
@@ -283,8 +283,8 @@ def generate_function(
 def generate_python(
     func: T.Callable[..., CodegenFuncInvocationResult],
     target: PythonGeneratorTarget = PythonGeneratorTarget.NumPy,
-    convert_ternaries: bool | None = None,
-    context: dict[str, T.Any] | None = None,
+    convert_ternaries: T.Optional[bool] = None,
+    context: T.Optional[dict[str, T.Any]] = None,
     import_target_module: bool = True,
     generator_type: T.Callable[[PythonGeneratorTarget], BaseGenerator] = PythonGenerator,
 ) -> tuple[T.Callable, str]:
@@ -436,7 +436,7 @@ def generate_python(
     return locals_in_out[func.__name__], code
 
 
-def mkdir_and_write_file(code: str, path: str | pathlib.Path) -> None:
+def mkdir_and_write_file(code: str, path: T.Union[str, pathlib.Path]) -> None:
     """
     Write ``code`` to the specified path. Create intermediate directories as required.
 

--- a/components/python/wrenfold/enumerations.py
+++ b/components/python/wrenfold/enumerations.py
@@ -1,4 +1,5 @@
 """
 Alias for the pywrenfold.enumerations module.
 """
-from pywrenfold.enumerations import *
+
+from pywrenfold.enumerations import *  # noqa: F403

--- a/components/python/wrenfold/exceptions.py
+++ b/components/python/wrenfold/exceptions.py
@@ -1,4 +1,5 @@
 """
 Alias for the pywrenfold.exceptions module.
 """
-from pywrenfold.exceptions import *
+
+from pywrenfold.exceptions import *  # noqa: F403

--- a/components/python/wrenfold/expressions.py
+++ b/components/python/wrenfold/expressions.py
@@ -1,2 +1,3 @@
 """Alias for the pywrenfold.expressions module."""
-from pywrenfold.expressions import *
+
+from pywrenfold.expressions import *  # noqa: F403

--- a/components/python/wrenfold/external_functions.py
+++ b/components/python/wrenfold/external_functions.py
@@ -68,7 +68,7 @@ def declare_external_function(
 
     # If custom types are specified, we need to construct `CustomType` objects to pass to C++:
     converted_args: list[
-        str, type_info.ScalarType | type_info.MatrixType | type_info.CustomType
+        tuple[str, T.Union[type_info.ScalarType, type_info.MatrixType, type_info.CustomType]]
     ] = []
     for arg_name, python_arg_type in arguments:
         internal_type = custom_types.convert_to_internal_type(
@@ -128,7 +128,7 @@ def _invoke_external_function(func: PyExternalFunction, *args, **kwargs):
     arg_names_and_types = [(a.name, a.type) for a in func.arguments]
 
     converted_args: list[sym.AnyExpression] = []
-    for arg, (arg_name, arg_type) in zip(combined_args, arg_names_and_types, strict=False):
+    for arg, (arg_name, arg_type) in zip(combined_args, arg_names_and_types):
         if isinstance(arg, (sym.Expr, sym.MatrixExpr)):
             converted_args.append(arg)  # Type is checked later in custom_function.cc
             continue

--- a/components/python/wrenfold/external_functions.py
+++ b/components/python/wrenfold/external_functions.py
@@ -1,6 +1,7 @@
 """
 Utilities for defining user-specified external functions.
 """
+
 import typing as T
 
 from pywrenfold.gen import PyExternalFunction
@@ -16,7 +17,7 @@ class ExternalFunction(PyExternalFunction):
     """
 
     def __init__(self, super_val: PyExternalFunction) -> None:
-        super(ExternalFunction, self).__init__(super_val)
+        super().__init__(super_val)
 
     def __call__(self, *args, **kwargs) -> T.Any:
         """
@@ -27,8 +28,8 @@ class ExternalFunction(PyExternalFunction):
 
 def declare_external_function(
     name: str,
-    arguments: T.Iterable[T.Tuple[str, T.Type]],
-    return_type: T.Type,
+    arguments: T.Iterable[tuple[str, type]],
+    return_type: type,
 ) -> ExternalFunction:
     """
     Declare an external function. External functions are implemented by the user outside of the code
@@ -63,45 +64,54 @@ def declare_external_function(
         An ExternalFunc object that can be invoked via the ``__call__`` operator. The args to
         ``__call__`` should have types matching `arguments`.
     """
-    type_cache: T.Dict[T.Type, custom_types.CodegenType] = dict()
+    type_cache: dict[type, custom_types.CodegenType] = dict()
 
     # If custom types are specified, we need to construct `CustomType` objects to pass to C++:
-    converted_args: T.List[str, T.Union[type_info.ScalarType, type_info.MatrixType,
-                                        type_info.CustomType]] = []
-    for (arg_name, python_arg_type) in arguments:
+    converted_args: list[
+        str, type_info.ScalarType | type_info.MatrixType | type_info.CustomType
+    ] = []
+    for arg_name, python_arg_type in arguments:
         internal_type = custom_types.convert_to_internal_type(
-            python_type=python_arg_type, cached_custom_types=type_cache)
+            python_type=python_arg_type, cached_custom_types=type_cache
+        )
         converted_args.append((arg_name, internal_type))
 
     converted_return_type = custom_types.convert_to_internal_type(
-        python_type=return_type, cached_custom_types=type_cache)
+        python_type=return_type, cached_custom_types=type_cache
+    )
 
     # Create c++ object that will represent this external function.
     wrapper_func = PyExternalFunction(
-        name=name, arguments=converted_args, return_type=converted_return_type)
+        name=name, arguments=converted_args, return_type=converted_return_type
+    )
 
     # Next we make a python wrapper that will handle mapping of data in/out of custom types.
     return ExternalFunction(wrapper_func)
 
 
-def _combine_args(func: PyExternalFunction, args: T.Sequence[T.Any],
-                  kwargs: T.Dict[str, T.Any]) -> T.List[T.Any]:
+def _combine_args(
+    func: PyExternalFunction, args: T.Sequence[T.Any], kwargs: dict[str, T.Any]
+) -> list[T.Any]:
     """
     Combine args and kwargs into one ordered list.
     """
     if len(args) + len(kwargs) != func.num_arguments:
-        raise RuntimeError(f"Incorrect number of arguments passed to function `{func.name}`. " +
-                           f"Expected: {func.num_arguments}, Actual: {len(args) + len(kwargs)}")
+        raise RuntimeError(
+            f"Incorrect number of arguments passed to function `{func.name}`. "
+            + f"Expected: {func.num_arguments}, Actual: {len(args) + len(kwargs)}"
+        )
 
-    index_and_value: T.List[T.Tuple[int, T.Any]] = []
-    for (key, value) in kwargs.items():
+    index_and_value: list[tuple[int, T.Any]] = []
+    for key, value in kwargs.items():
         position = func.arg_position(key)
         if position is None:
             raise KeyError(
-                f"Function `{func.name}` does not accept a keyword argument with name `{key}`.")
+                f"Function `{func.name}` does not accept a keyword argument with name `{key}`."
+            )
         if position < len(args):
             raise RuntimeError(
-                f"More than one value specified for argument `{key}` to function `{func.name}`.")
+                f"More than one value specified for argument `{key}` to function `{func.name}`."
+            )
         index_and_value.append((position, value))
 
     return list(args) + [v for (_, v) in sorted(index_and_value, key=lambda pair: pair[0])]
@@ -117,8 +127,8 @@ def _invoke_external_function(func: PyExternalFunction, *args, **kwargs):
     # The expected types for each argument:
     arg_names_and_types = [(a.name, a.type) for a in func.arguments]
 
-    converted_args: T.List[sym.AnyExpression] = []
-    for arg, (arg_name, arg_type) in zip(combined_args, arg_names_and_types):
+    converted_args: list[sym.AnyExpression] = []
+    for arg, (arg_name, arg_type) in zip(combined_args, arg_names_and_types, strict=False):
         if isinstance(arg, (sym.Expr, sym.MatrixExpr)):
             converted_args.append(arg)  # Type is checked later in custom_function.cc
             continue
@@ -128,13 +138,16 @@ def _invoke_external_function(func: PyExternalFunction, *args, **kwargs):
 
         if not isinstance(arg_type, type_info.CustomType):
             raise TypeError(
-                f"Argument `{arg_name}` of function `{func.name}` should be of type {arg_type}, " +
-                f"but we received type {type(arg)}.")
+                f"Argument `{arg_name}` of function `{func.name}` should be of type {arg_type}, "
+                + f"but we received type {type(arg)}."
+            )
 
         # Check that the type of `arg` matches the type we constructed our `custom_type` with:
         if type(arg) is not arg_type.python_type:
-            raise TypeError(f"Argument `{arg_name}` of function `{func.name}` should be of type " +
-                            f"{arg_type.python_type}, but we received {type(arg)}")
+            raise TypeError(
+                f"Argument `{arg_name}` of function `{func.name}` should be of type "
+                + f"{arg_type.python_type}, but we received {type(arg)}"
+            )
 
         if isinstance(arg, type_annotations.Opaque):
             assert arg_type.total_size == 0, "Custom type should not have any members"
@@ -142,7 +155,8 @@ def _invoke_external_function(func: PyExternalFunction, *args, **kwargs):
             # an external call:
             if arg._provenance is None:
                 raise RuntimeError(
-                    f"Opaque argument {arg_name} to function {func.name} has unclear provenance.")
+                    f"Opaque argument {arg_name} to function {func.name} has unclear provenance."
+                )
             converted_args.append(arg._provenance)
         else:
             expressions = custom_types.map_expressions_out_of_custom_type(instance=arg)
@@ -155,16 +169,18 @@ def _invoke_external_function(func: PyExternalFunction, *args, **kwargs):
 
     # If this is a compound expression, we should convert it to a python type.
     returned_custom_type = func.return_type
-    assert isinstance(
-        returned_custom_type,
-        type_info.CustomType), f"Return type should be custom type: {returned_custom_type}"
+    assert isinstance(returned_custom_type, type_info.CustomType), (
+        f"Return type should be custom type: {returned_custom_type}"
+    )
 
     if issubclass(returned_custom_type.python_type, type_annotations.Opaque):
         return returned_custom_type.python_type(provenance=result)
     else:
         # This is a dataclass type, fill it with expressions:
         expressions = sym.create_compound_expression_elements(
-            provenance=result, num=returned_custom_type.total_size)
+            provenance=result, num=returned_custom_type.total_size
+        )
         result, _ = custom_types.map_expressions_into_custom_type(
-            expressions=expressions, custom_type=returned_custom_type.python_type)
+            expressions=expressions, custom_type=returned_custom_type.python_type
+        )
         return result

--- a/components/python/wrenfold/geometry.py
+++ b/components/python/wrenfold/geometry.py
@@ -1,4 +1,5 @@
 """
 Alias for the pywrenfold.geometry module.
 """
-from pywrenfold.geometry import *
+
+from pywrenfold.geometry import *  # noqa: F403

--- a/components/python/wrenfold/sym.py
+++ b/components/python/wrenfold/sym.py
@@ -1,8 +1,9 @@
 """
 Alias for the pywrenfold `sym` module.
 """
+
 import typing as T
 
-from pywrenfold.sym import *
+from pywrenfold.sym import *  # noqa: F403
 
-AnyExpression = T.Union[Expr, BooleanExpr, MatrixExpr, CompoundExpr]
+AnyExpression = T.Union[Expr, BooleanExpr, MatrixExpr, CompoundExpr]  # noqa: F405

--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -161,7 +161,7 @@ class Conversions:
         """
         # Subs can have multiple replacements - for now we have to chain these together.
         result = self(expr.expr)
-        for variable, value in zip(expr.bound_symbols, expr.point, strict=False):
+        for variable, value in zip(expr.bound_symbols, expr.point):
             result = sym.substitution(result, self(variable), self(value))
 
         return result
@@ -176,7 +176,7 @@ class Conversions:
         args = [self(x) for x in expr.args]
         return sym.Function(sp_func.name)(*args)
 
-    def __call__(self, expr: T.Any) -> sym.Expr | sym.MatrixExpr | sym.BooleanExpr:
+    def __call__(self, expr: T.Any) -> T.Union[sym.Expr, sym.MatrixExpr, sym.BooleanExpr]:
         """
         Convert sympy expression `expr`. We check the different maps stored on self for
         matching values or types, and use the corresponding method to convert.
@@ -194,7 +194,7 @@ class Conversions:
         else:
             return self._convert_expr(expr)
 
-    def _convert_expr(self, expr: T.Any) -> sym.Expr | sym.MatrixExpr | sym.BooleanExpr:
+    def _convert_expr(self, expr: T.Any) -> T.Union[sym.Expr, sym.MatrixExpr, sym.BooleanExpr]:
         func = self.type_map.get(type(expr), None)
         if func is not None:
             args = [self(x) for x in expr.args]
@@ -225,8 +225,8 @@ class Conversions:
 
 def from_sympy(
     expr: T.Union["sympy.Basic", "sympy.MatrixBase"],
-    sp: types.ModuleType | None = None,
-) -> sym.Expr | sym.MatrixExpr | sym.BooleanExpr:
+    sp: T.Optional[types.ModuleType] = None,
+) -> T.Union[sym.Expr, sym.MatrixExpr, sym.BooleanExpr]:
     """
     Convert sympy expressions to wrenfold expressions. This method will recursively traverse
     the sympy expression tree, converting each encountered object to the equivalent wrenfold
@@ -248,8 +248,8 @@ def from_sympy(
 
 
 def to_sympy(
-    expr: sym.Expr | sym.MatrixExpr | sym.BooleanExpr,
-    sp: types.ModuleType | None = None,
+    expr: T.Union[sym.Expr, sym.MatrixExpr, sym.BooleanExpr],
+    sp: T.Optional[types.ModuleType] = None,
     evaluate: bool = True,
 ) -> T.Union["sympy.Basic", "sympy.MatrixBase"]:
     """

--- a/components/python/wrenfold/type_annotations.py
+++ b/components/python/wrenfold/type_annotations.py
@@ -5,6 +5,7 @@ correct inputs.
 You can define new vector/matrix annotations anywhere. They need only inherit from MatrixExpr and
 expose the SHAPE tuple.
 """
+
 import typing as T
 
 from . import sym, type_info
@@ -12,101 +13,121 @@ from . import sym, type_info
 
 class FloatScalar(sym.Expr):
     """Denote a floating-point scalar variable."""
+
     NUMERIC_PRIMITIVE_TYPE = type_info.NumericType.Float
 
 
 class IntScalar(sym.Expr):
     """Denote an integer valued scalar variable."""
+
     NUMERIC_PRIMITIVE_TYPE = type_info.NumericType.Integer
 
 
 class Vector1(sym.MatrixExpr):
     """A 1x1 column vector."""
+
     SHAPE = (1, 1)
 
 
 class Vector2(sym.MatrixExpr):
     """A 2x1 column vector."""
+
     SHAPE = (2, 1)
 
 
 class Vector3(sym.MatrixExpr):
     """A 3x1 column vector."""
+
     SHAPE = (3, 1)
 
 
 class Vector4(sym.MatrixExpr):
     """A 4x1 column vector."""
+
     SHAPE = (4, 1)
 
 
 class Vector5(sym.MatrixExpr):
     """A 5x1 column vector."""
+
     SHAPE = (5, 1)
 
 
 class Vector6(sym.MatrixExpr):
     """A 6x1 column vector."""
+
     SHAPE = (6, 1)
 
 
 class Vector7(sym.MatrixExpr):
     """A 7x1 column vector."""
+
     SHAPE = (7, 1)
 
 
 class Vector8(sym.MatrixExpr):
     """A 8x1 column vector."""
+
     SHAPE = (8, 1)
 
 
 class Vector9(sym.MatrixExpr):
     """A 9x1 column vector."""
+
     SHAPE = (9, 1)
 
 
 class Matrix1(sym.MatrixExpr):
     """A 1x1 square matrix."""
+
     SHAPE = (1, 1)
 
 
 class Matrix2(sym.MatrixExpr):
     """A 2x2 square matrix."""
+
     SHAPE = (2, 2)
 
 
 class Matrix3(sym.MatrixExpr):
     """A 3x3 square matrix."""
+
     SHAPE = (3, 3)
 
 
 class Matrix4(sym.MatrixExpr):
     """A 4x4 square matrix."""
+
     SHAPE = (4, 4)
 
 
 class Matrix5(sym.MatrixExpr):
     """A 5x5 square matrix."""
+
     SHAPE = (5, 5)
 
 
 class Matrix6(sym.MatrixExpr):
     """A 6x6 square matrix."""
+
     SHAPE = (6, 6)
 
 
 class Matrix7(sym.MatrixExpr):
     """A 7x7 square matrix."""
+
     SHAPE = (7, 7)
 
 
 class Matrix8(sym.MatrixExpr):
     """A 8x8 square matrix."""
+
     SHAPE = (8, 8)
 
 
 class Matrix9(sym.MatrixExpr):
     """A 9x9 square matrix."""
+
     SHAPE = (9, 9)
 
 
@@ -122,5 +143,5 @@ class Opaque:
       :func:`wrenfold.code_generation.create_function_description`.
     """
 
-    def __init__(self, provenance: T.Optional[sym.CompoundExpr] = None) -> None:
-        self._provenance: T.Optional[sym.CompoundExpr] = provenance
+    def __init__(self, provenance: sym.CompoundExpr | None = None) -> None:
+        self._provenance: sym.CompoundExpr | None = provenance

--- a/components/python/wrenfold/type_annotations.py
+++ b/components/python/wrenfold/type_annotations.py
@@ -143,5 +143,5 @@ class Opaque:
       :func:`wrenfold.code_generation.create_function_description`.
     """
 
-    def __init__(self, provenance: sym.CompoundExpr | None = None) -> None:
-        self._provenance: sym.CompoundExpr | None = provenance
+    def __init__(self, provenance: T.Optional[sym.CompoundExpr] = None) -> None:
+        self._provenance: T.Optional[sym.CompoundExpr] = provenance

--- a/components/python/wrenfold/type_info.py
+++ b/components/python/wrenfold/type_info.py
@@ -1,4 +1,5 @@
 """
 Alias for the pywrenfold.type_info module.
 """
-from pywrenfold.type_info import *
+
+from pywrenfold.type_info import *  # noqa: F403

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -5,6 +5,7 @@ Most of the output code generation is tested by cpp_generation_test/rust_generat
 examples are also run as tests - these offer a lot more diverse coverage. The purpose of this
 test is just to validate that the wrapper works and exposes the correct members.
 """
+
 import dataclasses
 import typing as T
 import unittest
@@ -23,22 +24,26 @@ def func1(x: FloatScalar, y: FloatScalar, v: Vector2):
 
 def func2(x: Vector2, y: Vector2, z: FloatScalar):
     """Another test function with some output args."""
-    m = sym.where(z > x[1], (x * y.transpose() + sym.eye(2) * sym.cos(z / x[0])).squared_norm(),
-                  z * 5)
+    m = sym.where(
+        z > x[1],
+        (x * y.transpose() + sym.eye(2) * sym.cos(z / x[0])).squared_norm(),
+        z * 5,
+    )
     diff_x = sym.vector(m).jacobian(x)
     diff_y = sym.vector(m).jacobian(y)
     diff_z = sym.vector(m).jacobian([z])
     return [
         code_generation.ReturnValue(m),
-        code_generation.OutputArg(diff_x, name='diff_x', is_optional=False),
-        code_generation.OutputArg(diff_y, name='diff_y', is_optional=False),
-        code_generation.OutputArg(diff_z, name='diff_z', is_optional=True),
+        code_generation.OutputArg(diff_x, name="diff_x", is_optional=False),
+        code_generation.OutputArg(diff_y, name="diff_y", is_optional=False),
+        code_generation.OutputArg(diff_z, name="diff_z", is_optional=True),
     ]
 
 
 @dataclasses.dataclass
 class Point2d:
     """A custom type."""
+
     x: FloatScalar
     y: FloatScalar
 
@@ -55,7 +60,10 @@ class OpaqueType(Opaque):
 
 
 external_func = external_functions.declare_external_function(
-    "external_func", arguments=[('foo', OpaqueType), ('bar', FloatScalar)], return_type=FloatScalar)
+    "external_func",
+    arguments=[("foo", OpaqueType), ("bar", FloatScalar)],
+    return_type=FloatScalar,
+)
 
 
 def opaque_type_func(u: OpaqueType, x: FloatScalar, y: FloatScalar):
@@ -79,14 +87,17 @@ class NestedType2:
 @dataclasses.dataclass
 class NestedType3:
     """A custom type that uses two other custom types."""
+
     fizz: NestedType1
     buzz: NestedType2
 
 
 def nested_type_func(arg0: NestedType1, arg1: NestedType3):
     """Ingest custom types and do something with them."""
-    return sym.cos(arg0.x * arg0.y) / sym.pow(arg1.fizz.x, arg1.buzz.v.norm()) + \
-        arg1.fizz.y * arg1.buzz.z
+    return (
+        sym.cos(arg0.x * arg0.y) / sym.pow(arg1.fizz.x, arg1.buzz.v.norm())
+        + arg1.fizz.y * arg1.buzz.z
+    )
 
 
 class CustomCppGenerator(code_generation.CppGenerator):
@@ -94,21 +105,21 @@ class CustomCppGenerator(code_generation.CppGenerator):
 
     def format_call_std_function(self, element: ast.CallStdFunction) -> str:
         if element.function == StdMathFunction.Cos:
-            return f'custom::cos({self.format(element.args[0])})'
+            return f"custom::cos({self.format(element.args[0])})"
         return self.super_format(element)
 
     def format_call_external_function(self, element: ast.CallExternalFunction) -> str:
         if external_func == element.function:
-            args = ', '.join(self.format(x) for x in element.args)
-            return f'custom::{element.function.name}({args})'
+            args = ", ".join(self.format(x) for x in element.args)
+            return f"custom::{element.function.name}({args})"
         return self.super_format(element)
 
 
 class CodeGenerationWrapperTest(MathTestBase):
-
     @staticmethod
-    def _run_generators(definition: T.Union[ast.FunctionDefinition,
-                                            T.Sequence[ast.FunctionDefinition]]):
+    def _run_generators(
+        definition: ast.FunctionDefinition | T.Sequence[ast.FunctionDefinition],
+    ):
         """Run the generators just to make sure we don't hit an assertion."""
         if isinstance(definition, ast.FunctionDefinition):
             definition = (definition,)
@@ -117,9 +128,13 @@ class CodeGenerationWrapperTest(MathTestBase):
             for generator in [CustomCppGenerator(), code_generation.RustGenerator()]:
                 generator.generate(d)
 
-    def _check_arg(self, arg: code_generation.Argument, name: str,
-                   t: T.Union[type_info.ScalarType, type_info.MatrixType,
-                              type_info.CustomType], direction: code_generation.ArgumentDirection):
+    def _check_arg(
+        self,
+        arg: code_generation.Argument,
+        name: str,
+        t: type_info.ScalarType | type_info.MatrixType | type_info.CustomType,
+        direction: code_generation.ArgumentDirection,
+    ):
         self.assertEqual(name, arg.name)
         self.assertEqual(t, arg.type)
         self.assertEqual(direction, arg.direction)
@@ -128,8 +143,9 @@ class CodeGenerationWrapperTest(MathTestBase):
         """
         Run compute_output_expressions and validate that we can re-assemble
         """
-        expected_outputs: T.Dict[code_generation.OutputKey,
-                                 sym.AnyExpression] = desc.output_expressions()
+        expected_outputs: dict[code_generation.OutputKey, sym.AnyExpression] = (
+            desc.output_expressions()
+        )
 
         params = code_generation.OptimizationParams()
         params.factorization_passes = 0
@@ -145,14 +161,15 @@ class CodeGenerationWrapperTest(MathTestBase):
                 csed_expr = sym.subs(csed_expr, target=var, replacement=val)
 
             # We need to distribute here to check equivalence properly.
-            # This is because the substitution order means some constants won't be distributed over additions.
+            # This is because the substitution order means some constants won't be distributed over
+            # additions.
             self.assertIdentical(sym.distribute(expected), sym.distribute(csed_expr))
 
     def test_func1(self):
         """Test simple function that returns a scalar."""
         desc = code_generation.create_function_description(func1)
         self.assertIsInstance(desc, code_generation.FunctionDescription)
-        self.assertEqual('func1', desc.name)
+        self.assertEqual("func1", desc.name)
 
         definition = code_generation.transpile(desc)
         self.assertIsInstance(definition, ast.FunctionDefinition)
@@ -161,15 +178,27 @@ class CodeGenerationWrapperTest(MathTestBase):
 
         # Check we can introspect the resulting definition/signature:
         sig = definition.signature
-        self.assertEqual('func1', sig.name)
+        self.assertEqual("func1", sig.name)
         self.assertEqual(type_info.ScalarType(type_info.NumericType.Float), sig.return_type)
 
-        self._check_arg(sig.arguments[0], 'x', type_info.ScalarType(type_info.NumericType.Float),
-                        code_generation.ArgumentDirection.Input)
-        self._check_arg(sig.arguments[1], 'y', type_info.ScalarType(type_info.NumericType.Float),
-                        code_generation.ArgumentDirection.Input)
-        self._check_arg(sig.arguments[2], 'v', type_info.MatrixType(2, 1),
-                        code_generation.ArgumentDirection.Input)
+        self._check_arg(
+            sig.arguments[0],
+            "x",
+            type_info.ScalarType(type_info.NumericType.Float),
+            code_generation.ArgumentDirection.Input,
+        )
+        self._check_arg(
+            sig.arguments[1],
+            "y",
+            type_info.ScalarType(type_info.NumericType.Float),
+            code_generation.ArgumentDirection.Input,
+        )
+        self._check_arg(
+            sig.arguments[2],
+            "v",
+            type_info.MatrixType(2, 1),
+            code_generation.ArgumentDirection.Input,
+        )
 
         self._run_generators(definition)
         self._test_cse_function_description(desc)
@@ -180,44 +209,50 @@ class CodeGenerationWrapperTest(MathTestBase):
         definition = code_generation.transpile(desc)
         sig = definition.signature
 
-        self.assertEqual('FunctionDescription(\'func2\', 6 args)', repr(desc))
-        self.assertEqual('func2', sig.name)
+        self.assertEqual("FunctionDescription('func2', 6 args)", repr(desc))
+        self.assertEqual("func2", sig.name)
         self.assertEqual(type_info.ScalarType(type_info.NumericType.Float), sig.return_type)
 
-        self.assertEqual('Argument(x: matrix_type<2, 1>)', repr(sig.arguments[0]))
-        self.assertEqual('Argument(z: floating_point)', repr(sig.arguments[2]))
+        self.assertEqual("Argument(x: matrix_type<2, 1>)", repr(sig.arguments[0]))
+        self.assertEqual("Argument(z: floating_point)", repr(sig.arguments[2]))
         self._check_arg(
             sig.arguments[0],
-            'x',
+            "x",
             type_info.MatrixType(2, 1),
-            direction=code_generation.ArgumentDirection.Input)
+            direction=code_generation.ArgumentDirection.Input,
+        )
         self._check_arg(
             sig.arguments[1],
-            'y',
+            "y",
             type_info.MatrixType(2, 1),
-            direction=code_generation.ArgumentDirection.Input)
+            direction=code_generation.ArgumentDirection.Input,
+        )
         self._check_arg(
             sig.arguments[2],
-            'z',
+            "z",
             type_info.ScalarType(type_info.NumericType.Float),
-            direction=code_generation.ArgumentDirection.Input)
+            direction=code_generation.ArgumentDirection.Input,
+        )
 
         # check output args:
         self._check_arg(
             sig.arguments[3],
-            'diff_x',
+            "diff_x",
             type_info.MatrixType(1, 2),
-            direction=code_generation.ArgumentDirection.Output)
+            direction=code_generation.ArgumentDirection.Output,
+        )
         self._check_arg(
             sig.arguments[4],
-            'diff_y',
+            "diff_y",
             type_info.MatrixType(1, 2),
-            direction=code_generation.ArgumentDirection.Output)
+            direction=code_generation.ArgumentDirection.Output,
+        )
         self._check_arg(
             sig.arguments[5],
-            'diff_z',
+            "diff_z",
             type_info.MatrixType(1, 1),
-            direction=code_generation.ArgumentDirection.OptionalOutput)
+            direction=code_generation.ArgumentDirection.OptionalOutput,
+        )
 
         self._run_generators(definition=definition)
         self._test_cse_function_description(desc=desc)
@@ -228,18 +263,18 @@ class CodeGenerationWrapperTest(MathTestBase):
         definition = code_generation.transpile(desc)
         sig = definition.signature
 
-        self.assertEqual('rotate_point', sig.name)
-        self.assertEqual('p', sig.arguments[1].name)
+        self.assertEqual("rotate_point", sig.name)
+        self.assertEqual("p", sig.arguments[1].name)
 
         ctype = sig.arguments[1].type
         self.assertIsInstance(ctype, type_info.CustomType)
-        self.assertEqual(f'CustomType(\'Point2d\', 2 fields, {repr(Point2d)})', repr(ctype))
-        self.assertEqual('Point2d', ctype.name)
+        self.assertEqual(f"CustomType('Point2d', 2 fields, {repr(Point2d)})", repr(ctype))
+        self.assertEqual("Point2d", ctype.name)
         self.assertEqual(Point2d, ctype.python_type)
         self.assertEqual(2, ctype.total_size)
-        self.assertEqual('x', ctype.fields[0].name)
+        self.assertEqual("x", ctype.fields[0].name)
         self.assertEqual(type_info.ScalarType(type_info.NumericType.Float), ctype.fields[0].type)
-        self.assertEqual('y', ctype.fields[1].name)
+        self.assertEqual("y", ctype.fields[1].name)
         self.assertEqual(type_info.ScalarType(type_info.NumericType.Float), ctype.fields[1].type)
 
         self._run_generators(definition)
@@ -248,9 +283,11 @@ class CodeGenerationWrapperTest(MathTestBase):
     def test_opaque_func(self):
         """Test we can customize invocation of a custom function."""
         code = code_generation.generate_function(opaque_type_func, generator=CustomCppGenerator())
-        self.assertEqual('external_func(foo: OpaqueType, bar: floating_point) -> floating_point',
-                         repr(external_func))
-        self.assertTrue('custom::external_func' in code)
+        self.assertEqual(
+            "external_func(foo: OpaqueType, bar: floating_point) -> floating_point",
+            repr(external_func),
+        )
+        self.assertTrue("custom::external_func" in code)
 
     def test_nested_type_func(self):
         """Test we can create a function description for a complicated nested type."""
@@ -259,7 +296,7 @@ class CodeGenerationWrapperTest(MathTestBase):
 
         ctype = definition.signature.arguments[1].type
         self.assertIsInstance(ctype, type_info.CustomType)
-        self.assertEqual('NestedType3', ctype.name)
+        self.assertEqual("NestedType3", ctype.name)
         self.assertEqual(NestedType3, ctype.python_type)
         self.assertEqual(5, ctype.total_size)
         self._run_generators(definition)
@@ -274,13 +311,16 @@ class CodeGenerationWrapperTest(MathTestBase):
         def boolean_arg_func(x: Boolean, y: FloatScalar):
             return [
                 code_generation.ReturnValue(5 + y * x),
-                code_generation.OutputArg(x, name="x_out")
+                code_generation.OutputArg(x, name="x_out"),
             ]
 
         self.assertRaises(
-            TypeError, lambda: code_generation.generate_function(
-                func=boolean_arg_func, generator=code_generation.RustGenerator()))
+            TypeError,
+            lambda: code_generation.generate_function(
+                func=boolean_arg_func, generator=code_generation.RustGenerator()
+            ),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -118,7 +118,7 @@ class CustomCppGenerator(code_generation.CppGenerator):
 class CodeGenerationWrapperTest(MathTestBase):
     @staticmethod
     def _run_generators(
-        definition: ast.FunctionDefinition | T.Sequence[ast.FunctionDefinition],
+        definition: T.Union[ast.FunctionDefinition, T.Sequence[ast.FunctionDefinition]],
     ):
         """Run the generators just to make sure we don't hit an assertion."""
         if isinstance(definition, ast.FunctionDefinition):
@@ -132,7 +132,7 @@ class CodeGenerationWrapperTest(MathTestBase):
         self,
         arg: code_generation.Argument,
         name: str,
-        t: type_info.ScalarType | type_info.MatrixType | type_info.CustomType,
+        t: T.Union[type_info.ScalarType, type_info.MatrixType, type_info.CustomType],
         direction: code_generation.ArgumentDirection,
     ):
         self.assertEqual(name, arg.name)

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -8,7 +8,7 @@ don't accidentally remove any.
 import functools
 import unittest
 
-from wrenfold import enumerations, exceptions, expressions, sym
+from wrenfold import exceptions, sym
 
 from .test_base import MathTestBase
 

--- a/components/wrapper/tests/expression_wrapper_test.py
+++ b/components/wrapper/tests/expression_wrapper_test.py
@@ -4,6 +4,7 @@ Python tests for the wrapper itself. Most of the algorithmic testing resides in 
 These tests are here to make sure that wrapped methods behave as expected, and that we
 don't accidentally remove any.
 """
+
 import functools
 import unittest
 
@@ -13,36 +14,38 @@ from .test_base import MathTestBase
 
 
 class ExpressionWrapperTest(MathTestBase):
-
     def test_create_symbols(self):
         """Test we can create symbolic variables."""
-        x = sym.symbols('x')
-        y = sym.symbols('y')
-        xy = sym.symbols('x, y')
+        x = sym.symbols("x")
+        y = sym.symbols("y")
+        xy = sym.symbols("x, y")
         self.assertIdentical(x, x)
         self.assertNotIdentical(x, y)
         self.assertIdentical(xy[0], x)
         self.assertIdentical(xy[1], y)
-        self.assertEqual('Variable', x.type_name)
+        self.assertEqual("Variable", x.type_name)
         self.assertEqual((), x.args)
 
         # test multiple strings
-        result = sym.symbols([('a', 'b'), 'c, d'])
+        result = sym.symbols([("a", "b"), "c, d"])
         self.assertIsInstance(result, list)
         self.assertEqual(2, len(result))
-        self.assertIdentical(sym.symbols('a'), result[0][0])
-        self.assertIdentical(sym.symbols('b'), result[0][1])
-        self.assertIdentical(sym.symbols('c'), result[1][0])
-        self.assertIdentical(sym.symbols('d'), result[1][1])
+        self.assertIdentical(sym.symbols("a"), result[0][0])
+        self.assertIdentical(sym.symbols("b"), result[0][1])
+        self.assertIdentical(sym.symbols("c"), result[1][0])
+        self.assertIdentical(sym.symbols("d"), result[1][1])
 
         # apply assumptions:
         self.assertNotIdentical(x, sym.symbols("x", real=True))
         self.assertNotIdentical(
             sym.symbols("x", real=True, nonnegative=True),
-            sym.symbols("x", real=True, positive=True))
+            sym.symbols("x", real=True, positive=True),
+        )
 
-        self.assertRaises(exceptions.InvalidArgumentError,
-                          lambda: sym.symbols("z", real=True, complex=True))
+        self.assertRaises(
+            exceptions.InvalidArgumentError,
+            lambda: sym.symbols("z", real=True, complex=True),
+        )
         self.assertCountEqual([y, x], sym.get_variables(x + y * x - sym.cos(y)))
 
     def test_create_unique_symbols(self):
@@ -51,10 +54,10 @@ class ExpressionWrapperTest(MathTestBase):
         b, c = sym.unique_symbols(count=2)
         self.assertNotIdentical(a, b)
         self.assertNotIdentical(b, c)
-        self.assertEqual('UniqueVariable', a.type_name)
+        self.assertEqual("UniqueVariable", a.type_name)
         self.assertEqual((), a.args)
         self.assertRaises(exceptions.InvalidArgumentError, lambda: sym.unique_symbols(count=0))
-        self.assertCountEqual([a, b, c], sym.get_variables(b * c - sym.sin(c) * a ** 2))
+        self.assertCountEqual([a, b, c], sym.get_variables(b * c - sym.sin(c) * a**2))
 
     def test_is_identical_to(self):
         """Test calling is_identical_to and __eq__."""
@@ -75,10 +78,7 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertEqual(hash(x), hash(x))
         self.assertNotEqual(hash(x), hash(y))  # Not impossible, but very unlikely.
         # use expressions as keys in a dict:
-        storage = {
-            x: 10,
-            y: -13
-        }
+        storage = {x: 10, y: -13}
         self.assertEqual(10, storage[x])
         self.assertEqual(-13, storage[y])
 
@@ -112,31 +112,31 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_repr(self):
         """Test __repr__ method."""
-        x, y, z = sym.symbols('x, y, z')
-        self.assertReprEqual('x', x)
-        self.assertReprEqual('x*y/3', x * y / 3)
-        self.assertReprEqual('3*x + 2*y/5', 3 * x + 2 * y / 5)
-        self.assertReprEqual('x*z**3', z * z * z * x)
-        self.assertReprEqual('5*z/x**2', 5.0 * z / (x * x))
-        self.assertReprEqual('cos(x)*sin(z)', sym.cos(x) * sym.sin(z))
-        self.assertReprEqual('cosh(x)*sinh(z)', sym.cosh(x) * sym.sinh(z))
-        self.assertReprEqual('2 + tanh(z)', 2 + sym.tanh(z))
-        self.assertReprEqual('x**(1/2)', sym.sqrt(x))
-        self.assertReprEqual('21**(1/2)*(x/z)**(1/2)', sym.sqrt(21 * x / z))
-        self.assertReprEqual('atan2(y, x)', sym.atan2(y, x))
-        self.assertReprEqual('abs(x)', sym.abs(x))
-        self.assertReprEqual('where(x < 0, -x, cos(x))', sym.where(x < 0, -x, sym.cos(x)))
-        self.assertReprEqual('Derivative(sign(x), x)', sym.sign(x).diff(x, use_abstract=True))
-        self.assertReprEqual('x == z', sym.eq(x, z))
-        self.assertReprEqual('iverson(z < x)', sym.iverson(x > z))
-        self.assertReprEqual('I', sym.I)
-        self.assertReprEqual('E', sym.E)
-        self.assertReprEqual('2 + 5*I', 2 + 5 * sym.I)
-        self.assertReprEqual('acos(x)*asin(y)*atan(z)', sym.acos(x) * sym.asin(y) * sym.atan(z))
+        x, y, z = sym.symbols("x, y, z")
+        self.assertReprEqual("x", x)
+        self.assertReprEqual("x*y/3", x * y / 3)
+        self.assertReprEqual("3*x + 2*y/5", 3 * x + 2 * y / 5)
+        self.assertReprEqual("x*z**3", z * z * z * x)
+        self.assertReprEqual("5*z/x**2", 5.0 * z / (x * x))
+        self.assertReprEqual("cos(x)*sin(z)", sym.cos(x) * sym.sin(z))
+        self.assertReprEqual("cosh(x)*sinh(z)", sym.cosh(x) * sym.sinh(z))
+        self.assertReprEqual("2 + tanh(z)", 2 + sym.tanh(z))
+        self.assertReprEqual("x**(1/2)", sym.sqrt(x))
+        self.assertReprEqual("21**(1/2)*(x/z)**(1/2)", sym.sqrt(21 * x / z))
+        self.assertReprEqual("atan2(y, x)", sym.atan2(y, x))
+        self.assertReprEqual("abs(x)", sym.abs(x))
+        self.assertReprEqual("where(x < 0, -x, cos(x))", sym.where(x < 0, -x, sym.cos(x)))
+        self.assertReprEqual("Derivative(sign(x), x)", sym.sign(x).diff(x, use_abstract=True))
+        self.assertReprEqual("x == z", sym.eq(x, z))
+        self.assertReprEqual("iverson(z < x)", sym.iverson(x > z))
+        self.assertReprEqual("I", sym.I)
+        self.assertReprEqual("E", sym.E)
+        self.assertReprEqual("2 + 5*I", 2 + 5 * sym.I)
+        self.assertReprEqual("acos(x)*asin(y)*atan(z)", sym.acos(x) * sym.asin(y) * sym.atan(z))
 
     def test_bool_conversion(self):
         """Test that only true and false can be converted to bool."""
-        x, y, z = sym.symbols('x, y, z')
+        x, y, z = sym.symbols("x, y, z")
         self.assertRaises(exceptions.TypeError, lambda: bool(x + 2))
         self.assertRaises(exceptions.TypeError, lambda: bool(2.0 / z))
         self.assertRaises(exceptions.TypeError, lambda: 1 if sym.cos(y * z) + x else 0)
@@ -144,12 +144,12 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertTrue(bool(sym.true))
         self.assertFalse(bool(sym.false))
         self.assertEqual(2.0, 2.0 if sym.true else 0.0)
-        self.assertTrue(0 < sym.integer(5))
-        self.assertFalse(22 == sym.pi)
+        self.assertTrue(sym.integer(5) > 0)
+        self.assertFalse(sym.pi == 22)
 
     def test_compare(self):
         """Test that we can canonically order expressions."""
-        a, b, c = sym.symbols('a, b, c')
+        a, b, c = sym.symbols("a, b, c")
         self.assertEqual(-1, sym.compare(a, b))
         self.assertEqual(1, sym.compare(c, b))
         self.assertEqual(0, sym.compare(b, b))
@@ -160,30 +160,39 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertSequenceEqual([a, b, c], sorted([b, c, a], key=compare_key))
         self.assertSequenceEqual(
             [sym.integer(-5), sym.integer(3), sym.integer(10)],
-            sorted(map(sym.integer, [3, -5, 10]), key=compare_key))
+            sorted(map(sym.integer, [3, -5, 10]), key=compare_key),
+        )
 
         expected_order = [
             sym.float(0.41),
             sym.integer(22),
-            sym.rational(3, 4), a, a * b, a + b, a ** c,
-            sym.cos(a)
+            sym.rational(3, 4),
+            a,
+            a * b,
+            a + b,
+            a**c,
+            sym.cos(a),
         ]
         input_order = [
-            sym.float(0.41), a + b,
+            sym.float(0.41),
+            a + b,
             sym.cos(a),
-            sym.integer(22), a ** c, a * b, a,
-            sym.rational(3, 4)
+            sym.integer(22),
+            a**c,
+            a * b,
+            a,
+            sym.rational(3, 4),
         ]
         self.assertSequenceEqual(expected_order, sorted(input_order, key=compare_key))
 
     def test_basic_scalar_operations(self):
         """Test wrappers for addition, multiplication, subtraction, negation, and power."""
-        p, q = sym.symbols('p, q')
+        p, q = sym.symbols("p, q")
 
         self.assertIsInstance(p + p, sym.Expr)
         self.assertIdentical(2 * p, p + p)
         self.assertIdentical(p, p + 0)
-        self.assertEqual('Addition', (p + q).type_name)
+        self.assertEqual("Addition", (p + q).type_name)
         self.assertCountEqual((p, q), (p + q).args)
         self.assertIdentical(p + p, p + p + p - p)
         self.assertNotIdentical(q + 5.0, q + 5)
@@ -191,21 +200,21 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertNotIdentical(q - 5, q + 5)
 
         self.assertIdentical(p * q, q * p)
-        self.assertEqual('Multiplication', (p * q).type_name)
+        self.assertEqual("Multiplication", (p * q).type_name)
         self.assertCountEqual((p, q), (p * q).args)
         self.assertIdentical(q * q * q / (p * p), sym.pow(q, 3) / sym.pow(p, 2))
         self.assertIdentical(2.0 * p, (p * 6.0) / 3.0)
-        self.assertIdentical(q, -(-q))
-        self.assertIdentical(-q, -(-(-q)))
+        self.assertIdentical(q, -(-q))  # noqa: B002
+        self.assertIdentical(-q, -(-(-q)))  # noqa: B002
 
-        self.assertEqual('Power', (q * q).type_name)
+        self.assertEqual("Power", (q * q).type_name)
         self.assertIdentical(sym.pow(q, 2), q * q)
-        self.assertIdentical(sym.pow(p, q), p ** q)
-        self.assertIdentical(sym.pow(2, q), 2 ** q)
-        self.assertIdentical(sym.pow(p, 5), p ** 5)
-        self.assertIdentical(sym.pow(p, 0.231), p ** 0.231)
+        self.assertIdentical(sym.pow(p, q), p**q)
+        self.assertIdentical(sym.pow(2, q), 2**q)
+        self.assertIdentical(sym.pow(p, 5), p**5)
+        self.assertIdentical(sym.pow(p, 0.231), p**0.231)
         self.assertIdentical(p / q, sym.pow(q / p, -1))
-        self.assertCountEqual((p, q), (p ** q).args)
+        self.assertCountEqual((p, q), (p**q).args)
 
     def test_trig_functions(self):
         """Test that we can call trig functions."""
@@ -262,27 +271,36 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_distribute(self):
         """Test calling distribute on scalar expressions."""
-        a, b, c, d, e, f = sym.symbols('a, b, c, d, e, f')
+        a, b, c, d, e, f = sym.symbols("a, b, c, d, e, f")
         expr = (a + b) * (c + d)
         self.assertIdentical(a * c + a * d + b * c + b * d, expr.distribute())
 
         expr = (a + b) * (c + d) * (e + f)
         self.assertIdentical(
-            a * c * e + a * c * f + a * d * e + a * d * f + b * c * e + b * c * f + b * d * e +
-            b * d * f, expr.distribute())
+            a * c * e
+            + a * c * f
+            + a * d * e
+            + a * d * f
+            + b * c * e
+            + b * c * f
+            + b * d * e
+            + b * d * f,
+            expr.distribute(),
+        )
         self.assertIdentical(expr.distribute(), sym.distribute(expr))
 
     def test_diff(self):
         """Test calling diff on scalar expressions."""
-        x, y, z = sym.symbols('x, y, z')
+        x, y, z = sym.symbols("x, y, z")
 
-        # Most of the tests reside in C++, just check that this works on a bunch of expression types:
+        # Most of the tests reside in C++, just check that this works on a bunch of expression
+        # types:
         self.assertIdentical(1, x.diff(x))
         self.assertIdentical(0, x.diff(var=x, order=2))
-        self.assertIdentical(3 * x ** 2, (x ** 3).diff(x))
+        self.assertIdentical(3 * x**2, (x**3).diff(x))
         self.assertIdentical(x, (x * y).diff(y))
-        self.assertIdentical(-y / x ** 2, (y / x).diff(x))
-        self.assertIdentical(2 * y / (z * x ** 3), (y / (x * z)).diff(x, order=2))
+        self.assertIdentical(-y / x**2, (y / x).diff(x))
+        self.assertIdentical(2 * y / (z * x**3), (y / (x * z)).diff(x, order=2))
 
         self.assertIdentical(z * sym.cos(y * z), sym.sin(y * z).diff(y))
         self.assertIdentical(y * z * sym.cos(y * z) + sym.sin(y * z), (z * sym.sin(y * z)).diff(z))
@@ -290,26 +308,27 @@ class ExpressionWrapperTest(MathTestBase):
 
         self.assertIdentical(1 / x, sym.log(y * x).diff(x))
 
-        self.assertIdentical(-y / (x ** 2 + y ** 2), sym.atan2(y, x).diff(x))
-        self.assertIdentical(2 * x / (x ** 2 + 4 * y ** 2), sym.atan2(2 * y, x).diff(y))
+        self.assertIdentical(-y / (x**2 + y**2), sym.atan2(y, x).diff(x))
+        self.assertIdentical(2 * x / (x**2 + 4 * y**2), sym.atan2(2 * y, x).diff(y))
 
         # Derivatives wrt symbolic function invocations.
-        f = sym.Function('f')
+        f = sym.Function("f")
         g = f(x).diff(x)
         q = f(x, y).diff(y)
         p = g.diff(x)
         self.assertIdentical(1, g.diff(g))
-        self.assertIdentical(2 * g * sym.cos(g ** 2), sym.sin(g ** 2).diff(g))
+        self.assertIdentical(2 * g * sym.cos(g**2), sym.sin(g**2).diff(g))
         self.assertIdentical(0, g.diff(q))
         self.assertIdentical(3, (3 * p + y * g).diff(p))
 
         # Differentiate conditionals:
         self.assertIdentical(
             sym.where(x > 0, 5 * sym.cos(5 * x), 0),
-            sym.where(x > 0, sym.sin(5 * x), y + 5).diff(x))
+            sym.where(x > 0, sym.sin(5 * x), y + 5).diff(x),
+        )
 
         # Diffing a polynomial too many times can trigger arithmetic error (factorial overflow)
-        self.assertRaises(exceptions.ArithmeticError, lambda: (x ** 100).diff(x, 20))
+        self.assertRaises(exceptions.ArithmeticError, lambda: (x**100).diff(x, 20))
 
         # Certain types cannot be passed to `diff`:
         self.assertRaises(exceptions.TypeError, lambda: x.diff(1))
@@ -321,12 +340,12 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_relational(self):
         """Test creating relational expressions."""
-        x, y, z = sym.symbols('x, y, z')
+        x, y, z = sym.symbols("x, y, z")
         self.assertIsInstance(x < y, sym.BooleanExpr)
         self.assertEqual("Relational", (x < y).type_name)
         self.assertIdentical(x < y, y > x)
-        self.assertIdentical(z > 0, 0 < z)
-        self.assertIdentical(x >= 0.0, 0.0 <= x)
+        self.assertIdentical(z > 0, z > 0)
+        self.assertIdentical(x >= 0.0, x >= 0.0)
         self.assertIdentical(sym.true, sym.Expr(1) > 0)
         self.assertIdentical(sym.true, sym.pi > sym.E)
         self.assertEqual((x, y), (x < y).args)
@@ -337,42 +356,45 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_conditionals(self):
         """Test creating conditional logic."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIdentical(sym.where(x < y, y, x), sym.max(x, y))
         self.assertIdentical(sym.where(y < x, y, x), sym.min(x, y))
-        self.assertIdentical(x, sym.where(0 < sym.Expr(1), x, y))
+        self.assertIdentical(x, sym.where(sym.Expr(1) > 0, x, y))
         self.assertIdentical(y - 3, sym.where(sym.pi >= sym.E, y - 3, x * 5))
         self.assertEqual((x < y, sym.cos(x), y), sym.where(x < y, sym.cos(x), y).args)
 
     def test_iverson(self):
         """Test converting boolean values to integer."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIdentical(1, sym.iverson(sym.one < 10.2))
         self.assertIdentical(0, sym.iverson(sym.eq(sym.one, sym.zero)))
         self.assertEqual((x < y,), sym.iverson(x < y).args)
 
     def test_unevaluated(self):
         """Test calling `unevaluated`."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIdentical(sym.unevaluated(x), sym.unevaluated(x))
         self.assertIdentical(sym.unevaluated(x), sym.unevaluated(sym.unevaluated(x)))
 
     def test_subs(self):
         """Test calling subs() on expressions."""
-        x, y, z = sym.symbols('x, y, z')
+        x, y, z = sym.symbols("x, y, z")
         self.assertIdentical(x, x.subs(x, x))
         self.assertIdentical(y, x.subs(x, y))
         self.assertIdentical(2.5, sym.subs(x, x, 2.5))
         self.assertIdentical(0, (x - y).subs(y, x))
         self.assertIdentical(1, sym.subs(x / z, z, x))
-        self.assertIdentical(z ** 2 * x, (x ** 3 * y ** 2).subs(x * y, z))
+        self.assertIdentical(z**2 * x, (x**3 * y**2).subs(x * y, z))
         self.assertIdentical(2 * z, (x + 2 * z - (y * 3) / 2).subs(x - (y * 3) / 2, 0))
         self.assertIdentical(sym.cos(y + 1), sym.cos(x).subs(x, y + 1))
-        self.assertIdentical(z * (sym.cos(x * 2) + 3) + sym.log(sym.cos(x * 2)),
-                             (z * x + sym.log(x - 3)).subs(x,
-                                                           sym.cos(x * 2) + 3))
         self.assertIdentical(
-            sym.sin(z - 3) * sym.abs(z), (sym.sin(y - 3) * x).subs([(y, z), (x, sym.abs(z))]))
+            z * (sym.cos(x * 2) + 3) + sym.log(sym.cos(x * 2)),
+            (z * x + sym.log(x - 3)).subs(x, sym.cos(x * 2) + 3),
+        )
+        self.assertIdentical(
+            sym.sin(z - 3) * sym.abs(z),
+            (sym.sin(y - 3) * x).subs([(y, z), (x, sym.abs(z))]),
+        )
         # Boolean substitution:
         f = sym.where(x > y, sym.cos(x), sym.abs(y))
         self.assertIdentical(sym.cos(x), f.subs(x > y, sym.true))
@@ -380,24 +402,28 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_collect(self):
         """Test calling collect() on expressions."""
-        x, y, z = sym.symbols('x, y, z')
-        self.assertIdentical(x ** 2 * (y + 3), (x ** 2 * y + x ** 2 * 3).collect(x))
-        self.assertIdentical(x ** 2 * (sym.log(y) - sym.pi) + x * (sym.cos(y) + sym.sin(y)),
-                             (x ** 2 * sym.log(y) - x ** 2 * sym.pi + x * sym.cos(y) +
-                              x * sym.sin(y)).collect(x))
+        x, y, z = sym.symbols("x, y, z")
+        self.assertIdentical(x**2 * (y + 3), (x**2 * y + x**2 * 3).collect(x))
+        self.assertIdentical(
+            x**2 * (sym.log(y) - sym.pi) + x * (sym.cos(y) + sym.sin(y)),
+            (x**2 * sym.log(y) - x**2 * sym.pi + x * sym.cos(y) + x * sym.sin(y)).collect(x),
+        )
 
-        f = x ** 2 * y + x ** 2 * 2 + x * y * 5 + x * (y ** 2) * sym.pi - x * y * sym.log(z)
-        self.assertIdentical(x ** 2 * (y + 2) + x * (y ** 2 * sym.pi + y * (5 - sym.log(z))),
-                             f.collect([x, y]))
+        f = x**2 * y + x**2 * 2 + x * y * 5 + x * (y**2) * sym.pi - x * y * sym.log(z)
+        self.assertIdentical(
+            x**2 * (y + 2) + x * (y**2 * sym.pi + y * (5 - sym.log(z))),
+            f.collect([x, y]),
+        )
 
     def test_eval(self):
         """Test calling eval() on an expression."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIdentical(x, x.eval())
         self.assertIdentical(x + 2.0, (x + y).subs(y, 2).eval())
         self.assertEqual(5.3, sym.float(5.3).eval())
         self.assertAlmostEqual(
-            4.3 / 2.71582, (x / y).subs(x, 4.3).subs(y, 2.71582).eval(), places=15)
+            4.3 / 2.71582, (x / y).subs(x, 4.3).subs(y, 2.71582).eval(), places=15
+        )
         self.assertEqual(3923, sym.integer(3923).eval())
         self.assertEqual(123, (sym.integer(100) + x).subs(x, 23).eval())
         self.assertEqual(complex(1, 2), (1 + sym.I * 2).eval())
@@ -408,100 +434,110 @@ class ExpressionWrapperTest(MathTestBase):
 
     def test_cse(self):
         """Test calling eliminate_subexpressions()."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
 
-        def var(idx: int, letter: str = 'v'):
-            return sym.symbols(f'{letter}{idx}')
+        def var(idx: int, letter: str = "v"):
+            return sym.symbols(f"{letter}{idx}")
 
         f1 = sym.cos(x) * sym.cos(x) + y * sym.cos(x)
         f1_cse, replacements = sym.eliminate_subexpressions(f1, None, 2)
 
         v0 = var(0)
-        self.assertIdentical(v0 ** 2 + y * v0, f1_cse)
+        self.assertIdentical(v0**2 + y * v0, f1_cse)
         self.assertEqual(1, len(replacements))
         self.assertSequenceEqual([(v0, sym.cos(x))], replacements)
 
         f2 = sym.abs(y * 2) + sym.cos(y * 2) / x - 5 / x
-        f2_cse, replacements = sym.eliminate_subexpressions(f2, lambda idx: var(idx, 'u'))
+        f2_cse, replacements = sym.eliminate_subexpressions(f2, lambda idx: var(idx, "u"))
 
-        u0, u1 = var(0, 'u'), var(1, 'u')
+        u0, u1 = var(0, "u"), var(1, "u")
         self.assertIdentical(sym.abs(u0) + sym.cos(u0) * u1 - 5 * u1, f2_cse)
         self.assertEqual(2, len(replacements))
         self.assertSequenceEqual([(u0, y * 2), (u1, 1 / x)], replacements)
 
     def test_derivative_expression(self):
         """Test creation of deferred derivative expression."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         f = sym.derivative(sym.sin(x), x)
-        self.assertEqual('Derivative', f.type_name)
-        self.assertEqual('Derivative(sin(x), x)', repr(f))
+        self.assertEqual("Derivative", f.type_name)
+        self.assertEqual("Derivative(sin(x), x)", repr(f))
         self.assertIdentical(sym.derivative(sym.sin(x), x, 2), f.diff(x))
         self.assertIdentical(0, f.diff(y))
 
         f2 = sym.derivative(sym.sin(x) + y, x)
         self.assertIdentical(
-            sym.derivative(function=sym.derivative(sym.sin(x) + y, x), arg=y), f2.diff(y))
+            sym.derivative(function=sym.derivative(sym.sin(x) + y, x), arg=y),
+            f2.diff(y),
+        )
         self.assertSequenceEqual((sym.sin(x) + y, x), f2.args)
 
         self.assertRaises(exceptions.TypeError, lambda: sym.derivative(x, y + 2))
 
     def test_stop_derivative_expression(self):
         """Test creating a `stop_derivative` expression."""
-        x, y = sym.symbols('x, y')
-        self.assertEqual('StopDerivative', sym.stop_derivative(y).type_name)
-        self.assertEqual('StopDerivative(3*x)', repr(sym.stop_derivative(x * 3)))
+        x, y = sym.symbols("x, y")
+        self.assertEqual("StopDerivative", sym.stop_derivative(y).type_name)
+        self.assertEqual("StopDerivative(3*x)", repr(sym.stop_derivative(x * 3)))
         self.assertIdentical(0, sym.stop_derivative(x).diff(x))
         self.assertIdentical(
             sym.cos(y) * sym.stop_derivative(x * y),
-            (sym.stop_derivative(x * y) * sym.sin(y)).diff(y))
+            (sym.stop_derivative(x * y) * sym.sin(y)).diff(y),
+        )
 
     def test_substitute_expression(self):
         """Test creation of deferred substitution expression."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         f = sym.substitution(sym.cos(x), x, 2)
-        self.assertEqual('Substitution', f.type_name)
-        self.assertEqual('Subs(cos(x), x, 2)', repr(f))
+        self.assertEqual("Substitution", f.type_name)
+        self.assertEqual("Subs(cos(x), x, 2)", repr(f))
         self.assertIdentical(22, sym.substitution(22, target=x, replacement=y))
         self.assertIdentical(x + y, sym.substitution(x + y, sym.sin(x), sym.sin(x)))
         self.assertRaises(exceptions.TypeError, lambda: sym.substitution(x + y, 2.12, sym.pi))
         self.assertIdentical(
             sym.substitution(sym.cos(x), y, 22),
-            sym.substitution(sym.sin(x) + y, y, 22).diff(x))
-        self.assertIdentical(-2 * x + sym.substitution(x / sym.abs(x), y, x ** 2),
-                             sym.substitution(sym.abs(x) - y, y, x ** 2).diff(x))
+            sym.substitution(sym.sin(x) + y, y, 22).diff(x),
+        )
         self.assertIdentical(
-            sym.derivative(sym.substitution(sym.cos(x ** 2), x ** 2, y), x),
-            sym.substitution(sym.cos(x ** 2), x ** 2, y).diff(x))
+            -2 * x + sym.substitution(x / sym.abs(x), y, x**2),
+            sym.substitution(sym.abs(x) - y, y, x**2).diff(x),
+        )
+        self.assertIdentical(
+            sym.derivative(sym.substitution(sym.cos(x**2), x**2, y), x),
+            sym.substitution(sym.cos(x**2), x**2, y).diff(x),
+        )
 
     def test_symbolic_function_invocation(self):
         """Test expressions that include symbolic functions."""
-        x, y, z = sym.symbols('x, y, z')
-        f = sym.Function('f')
-        self.assertEqual('f', repr(f))
-        self.assertEqual('f', f.name)
-        self.assertNotIdentical(f, sym.Function('g'))
+        x, y, z = sym.symbols("x, y, z")
+        f = sym.Function("f")
+        self.assertEqual("f", repr(f))
+        self.assertEqual("f", f.name)
+        self.assertNotIdentical(f, sym.Function("g"))
 
         f1 = f(x, y)
-        self.assertEqual('f(x, y)', repr(f1))
+        self.assertEqual("f(x, y)", repr(f1))
         self.assertIdentical(sym.derivative(f1, x), f1.diff(x))
         self.assertIdentical(sym.derivative(f1, x, 2), f1.diff(x, 2))
         self.assertIdentical(0, f1.diff(z))
 
-        f2 = f(sym.sin(x), x ** 2).diff(x)
-        u1, u2 = sorted([v for v in sym.get_variables(f2) if v.type_name == 'UniqueVariable'],
-                        key=functools.cmp_to_key(sym.compare))
+        f2 = f(sym.sin(x), x**2).diff(x)
+        u1, u2 = sorted(
+            [v for v in sym.get_variables(f2) if v.type_name == "UniqueVariable"],
+            key=functools.cmp_to_key(sym.compare),
+        )
 
         self.assertIdentical(
-            sym.cos(x) * sym.substitution(f(u1, x ** 2).diff(u1), u1, sym.sin(x)) + \
-            2 * x * sym.substitution(f(sym.sin(x), u2).diff(u2), u2, x ** 2),
-            f2
+            sym.cos(x) * sym.substitution(f(u1, x**2).diff(u1), u1, sym.sin(x))
+            + 2 * x * sym.substitution(f(sym.sin(x), u2).diff(u2), u2, x**2),
+            f2,
         )
 
     def test_integer_exceptions(self):
         """
         Test that arithmetic exceptions propagate into python.
 
-        Actual logic tested in checked_int_test.cc, here we just test that exceptions are passed into python correctly.
+        Actual logic tested in checked_int_test.cc, here we just test that exceptions are passed
+        into python correctly.
         """
         i64_max = 9223372036854775807
         i64_min = -9223372036854775808
@@ -514,5 +550,5 @@ class ExpressionWrapperTest(MathTestBase):
         self.assertRaises(exceptions.ArithmeticError, lambda: -sym.integer(i64_min))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/components/wrapper/tests/external_function_wrapper_test.py
+++ b/components/wrapper/tests/external_function_wrapper_test.py
@@ -1,6 +1,7 @@
 """
 Test ability to create and insert user-specified external functions into the expression graph.
 """
+
 import dataclasses
 import unittest
 
@@ -11,11 +12,11 @@ from .test_base import MathTestBase
 
 
 class ExternalFunctionWrapperTest(MathTestBase):
-
     def test_scalars(self):
         """Define function that accepts and returns scalars."""
         func = external_functions.declare_external_function(
-            name="func", arguments=[("x", FloatScalar)], return_type=FloatScalar)
+            name="func", arguments=[("x", FloatScalar)], return_type=FloatScalar
+        )
 
         self.assertEqual("func", func.name)
         self.assertEqual(1, func.num_arguments)
@@ -47,7 +48,10 @@ class ExternalFunctionWrapperTest(MathTestBase):
     def test_matrices(self):
         """Define a function that accepts and returns matrices."""
         func = external_functions.declare_external_function(
-            name="func", arguments=[("x", FloatScalar), ("v", Vector3)], return_type=Vector2)
+            name="func",
+            arguments=[("x", FloatScalar), ("v", Vector3)],
+            return_type=Vector2,
+        )
         self.assertEqual(2, func.num_arguments)
         self.assertEqual(type_info.MatrixType(2, 1), func.return_type)
 
@@ -71,11 +75,15 @@ class ExternalFunctionWrapperTest(MathTestBase):
         @dataclasses.dataclass
         class TestType:
             """A dummy type we use for this test."""
+
             a: FloatScalar
             b: Vector2
 
         func = external_functions.declare_external_function(
-            name="func", arguments=[("foo", TestType), ("bar", FloatScalar)], return_type=TestType)
+            name="func",
+            arguments=[("foo", TestType), ("bar", FloatScalar)],
+            return_type=TestType,
+        )
         self.assertEqual(2, func.num_arguments)
         self.assertIsInstance(func.return_type, type_info.CustomType)
 
@@ -86,7 +94,7 @@ class ExternalFunctionWrapperTest(MathTestBase):
 
         self.assertIsInstance(output, TestType)
         for element in [output.a, output.b[0], output.b[1]]:
-            self.assertEqual('CompoundExpressionElement', element.type_name)
+            self.assertEqual("CompoundExpressionElement", element.type_name)
 
         self.assertRaises(exceptions.TypeError, lambda: func(y, x))
         self.assertRaises(TypeError, lambda: func(foo=2, bar=TestType(a=1, b=v)))
@@ -100,9 +108,13 @@ class ExternalFunctionWrapperTest(MathTestBase):
 
         # Define two functions - one that returns the type, and another accepts it.
         func_1 = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", FloatScalar)], return_type=TestType)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=TestType
+        )
         func_2 = external_functions.declare_external_function(
-            name="func_2", arguments=[("q", TestType), ("w", FloatScalar)], return_type=FloatScalar)
+            name="func_2",
+            arguments=[("q", TestType), ("w", FloatScalar)],
+            return_type=FloatScalar,
+        )
         self.assertEqual(1, func_1.num_arguments)
         self.assertIsInstance(func_1.return_type, type_info.CustomType)
 
@@ -126,20 +138,24 @@ class ExternalFunctionWrapperTest(MathTestBase):
     def test_comparisons(self):
         """Check that we can test external functions for equality."""
         func_1 = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2
+        )
         func_1_dup = external_functions.declare_external_function(
-            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2)
+            name="func_1", arguments=[("x", FloatScalar)], return_type=Vector2
+        )
         self.assertEqual(func_1, func_1_dup)
 
         func_2 = external_functions.declare_external_function(
-            name="func_2", arguments=[("x", FloatScalar)], return_type=Vector2)
+            name="func_2", arguments=[("x", FloatScalar)], return_type=Vector2
+        )
         self.assertNotEqual(func_1, func_2)
 
         func_3 = external_functions.declare_external_function(
-            name="func_2", arguments=[("x", Vector3)], return_type=Vector2)
+            name="func_2", arguments=[("x", Vector3)], return_type=Vector2
+        )
         self.assertNotEqual(func_1, func_2)
         self.assertNotEqual(func_2, func_3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/components/wrapper/tests/geometry_wrapper_test.py
+++ b/components/wrapper/tests/geometry_wrapper_test.py
@@ -3,6 +3,7 @@ Test of geometry module wrapper.
 
 NB: Most of this is tested in `quaternion_test.cc`. This is just a test of the wrapper itself.
 """
+
 import unittest
 
 from wrenfold import exceptions, sym
@@ -12,7 +13,6 @@ from .test_base import MathTestBase
 
 
 class GeometryWrapperTest(MathTestBase):
-
     def assertQuatIdentical(self, a: Quaternion, b: Quaternion):
         self.assertIdentical(a.w, b.w)
         self.assertIdentical(a.x, b.x)
@@ -39,8 +39,8 @@ class GeometryWrapperTest(MathTestBase):
         """Test repr()"""
         w, x, y, z = sym.symbols("w, x, y, z")
         q = Quaternion(w, x, y, z)
-        self.assertEqual('Quaternion(w, x, y, z)', repr(q))
-        self.assertEqual('Quaternion(1, 0, 0, 0)', repr(Quaternion()))
+        self.assertEqual("Quaternion(w, x, y, z)", repr(q))
+        self.assertEqual("Quaternion(1, 0, 0, 0)", repr(Quaternion()))
 
     def test_convert_quaternion_formats(self):
         """Test conversion between formats."""
@@ -58,8 +58,10 @@ class GeometryWrapperTest(MathTestBase):
         self.assertIdentical(sym.vector(w, x, y, z), q.to_vector_wxyz())
 
         self.assertRaises(exceptions.DimensionError, lambda: Quaternion.from_xyzw([x, y, z]))
-        self.assertRaises(exceptions.DimensionError,
-                          lambda: Quaternion.from_xyzw([1.0, -0.23, w, y, 3]))
+        self.assertRaises(
+            exceptions.DimensionError,
+            lambda: Quaternion.from_xyzw([1.0, -0.23, w, y, 3]),
+        )
 
     def test_normalize(self):
         """Test normalize."""
@@ -101,25 +103,40 @@ class GeometryWrapperTest(MathTestBase):
     def test_rotation_constructors(self):
         """Test construction via rotation helpers."""
         self.assertQuatIdentical(
-            Quaternion.from_angle_axis(sym.pi / 2, 1, 0, 0), Quaternion.from_x_angle(sym.pi / 2))
+            Quaternion.from_angle_axis(sym.pi / 2, 1, 0, 0),
+            Quaternion.from_x_angle(sym.pi / 2),
+        )
         self.assertQuatIdentical(
-            Quaternion.from_angle_axis(-sym.pi / 4, 0, 1, 0), Quaternion.from_y_angle(-sym.pi / 4))
+            Quaternion.from_angle_axis(-sym.pi / 4, 0, 1, 0),
+            Quaternion.from_y_angle(-sym.pi / 4),
+        )
         self.assertQuatIdentical(
-            Quaternion.from_angle_axis(sym.pi / 6, 0, 0, 1), Quaternion.from_z_angle(sym.pi / 6))
+            Quaternion.from_angle_axis(sym.pi / 6, 0, 0, 1),
+            Quaternion.from_z_angle(sym.pi / 6),
+        )
         self.assertQuatIdentical(
             Quaternion.from_x_angle(0.125),
-            Quaternion.from_rotation_vector(sym.vector(0.125, 0, 0), None))
+            Quaternion.from_rotation_vector(sym.vector(0.125, 0, 0), None),
+        )
         self.assertQuatIdentical(
-            Quaternion.from_y_angle(-0.32), Quaternion.from_rotation_vector(0.0, -0.32, 0.0, None))
+            Quaternion.from_y_angle(-0.32),
+            Quaternion.from_rotation_vector(0.0, -0.32, 0.0, None),
+        )
 
     def test_from_rotation_matrix(self):
         """Test calling from_rotation_matrix."""
         theta = sym.symbols("theta")
-        R = sym.matrix([[1, 0, 0], [0, sym.cos(theta), -sym.sin(theta)],
-                        [0, sym.sin(theta), sym.cos(theta)]])
+        R = sym.matrix(
+            [
+                [1, 0, 0],
+                [0, sym.cos(theta), -sym.sin(theta)],
+                [0, sym.sin(theta), sym.cos(theta)],
+            ]
+        )
         self.assertIdentical(
             Quaternion(0, 1, 0, 0),
-            Quaternion.from_rotation_matrix(R).subs(theta, sym.pi))
+            Quaternion.from_rotation_matrix(R).subs(theta, sym.pi),
+        )
 
     def test_derivative_matrices(self):
         """Test calling right_retract_derivative and right_local_coordinates_derivative."""
@@ -129,8 +146,8 @@ class GeometryWrapperTest(MathTestBase):
         J1 = q.right_local_coordinates_derivative()
         self.assertIsInstance(J0, sym.MatrixExpr)
         self.assertIsInstance(J1, sym.MatrixExpr)
-        self.assertIdentical(sym.eye(3), (J1 * J0).subs(w ** 2 + x ** 2 + y ** 2 + z ** 2, 1))
+        self.assertIdentical(sym.eye(3), (J1 * J0).subs(w**2 + x**2 + y**2 + z**2, 1))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -176,8 +176,8 @@ class MatrixWrapperTest(MathTestBase):
         rows, cols = np.mgrid[0 : shape[0], 0 : shape[1]]
         rows = rows.reshape(-1)
         cols = cols.reshape(-1)
-        for start_row, start_col in zip(rows, cols, strict=False):
-            for end_row, end_col in zip(rows, cols, strict=False):
+        for start_row, start_col in zip(rows, cols):
+            for end_row, end_col in zip(rows, cols):
                 for sz in step_sizes:
                     row_slice = slice(start_row, end_row, sz if end_row >= start_row else -sz)
                     col_slice = slice(start_col, end_col, sz if end_col >= start_col else -sz)

--- a/components/wrapper/tests/matrix_wrapper_test.py
+++ b/components/wrapper/tests/matrix_wrapper_test.py
@@ -4,18 +4,17 @@ Test of matrix-specific functionality.
 These tests are here to make sure that wrapped methods behave as expected, and that we
 don't accidentally remove any wrappers. Algorithmic tests are in C++.
 """
+
 import typing as T
 import unittest
 
 import numpy as np
-
 from wrenfold import exceptions, sym
 
 from .test_base import MathTestBase
 
 
 class MatrixWrapperTest(MathTestBase):
-
     def test_matrix_constructors(self):
         """Test different methods of constructing matrices."""
         x, y, z, a, b, c = sym.symbols("x, y, z, a, b, c")
@@ -57,8 +56,7 @@ class MatrixWrapperTest(MathTestBase):
         self.assertIdentical(sym.MatrixExpr([[a, x], [b, y]]), sym.matrix([[a, x], [b, y]]))
 
         def generator_func(*args):
-            for element in args:
-                yield element
+            yield from args
 
         # construct from generators
         gen = generator_func(z, x, c)
@@ -66,20 +64,21 @@ class MatrixWrapperTest(MathTestBase):
         gen = generator_func([a, x], [b, y])
         self.assertIdentical(sym.matrix([[a, x], [b, y]]), sym.matrix(gen))
         gen = generator_func(
-            generator_func(x, y, z), generator_func(a, b, c), generator_func(1, 2, 3))
+            generator_func(x, y, z), generator_func(a, b, c), generator_func(1, 2, 3)
+        )
         self.assertIdentical(sym.matrix([[x, y, z], [a, b, c], [1, 2, 3]]), sym.matrix(gen))
 
         # combine generator with other inputs
         self.assertIdentical(
-            sym.matrix([(a, c), (1.0, z)]), sym.matrix([(a, c), generator_func(1.0, z)]))
+            sym.matrix([(a, c), (1.0, z)]), sym.matrix([(a, c), generator_func(1.0, z)])
+        )
         self.assertIdentical(
             sym.matrix([(b, x, x), (z, 5, z)]),
             sym.matrix([sym.row_vector(b, x, x), generator_func(z, 5, z)]),
         )
         self.assertIdentical(
             sym.matrix([(sym.pi, x, 2), (y, z, c)]),
-            sym.matrix([generator_func(sym.pi, x, 2),
-                        generator_func(y, z, c)]),
+            sym.matrix([generator_func(sym.pi, x, 2), generator_func(y, z, c)]),
         )
 
         # throw if empty
@@ -90,8 +89,9 @@ class MatrixWrapperTest(MathTestBase):
         # cannot nest matrices:
         self.assertRaises(RuntimeError, lambda: sym.vector(m, 1.5, 2))
         self.assertRaises(RuntimeError, lambda: sym.row_vector(x, y, sym.vector(z, 9.0)))
-        self.assertRaises(RuntimeError,
-                          lambda: sym.matrix([[sym.row_vector(1, x), 1], [0.0, sym.pi]]))
+        self.assertRaises(
+            RuntimeError, lambda: sym.matrix([[sym.row_vector(1, x), 1], [0.0, sym.pi]])
+        )
 
         # mixing iterable/non-iterable:
         self.assertRaises(TypeError, lambda: sym.matrix([sym.row_vector(x, y), 5]))
@@ -118,10 +118,7 @@ class MatrixWrapperTest(MathTestBase):
         u = sym.vector(x * y, sym.cos(x), 0)
         self.assertNotEqual(hash(v), hash(u))  # Not likely.
         # Use matrix expressions as keys in a dict:
-        storage = {
-            v: 1939,
-            u: 1984
-        }
+        storage = {v: 1939, u: 1984}
         self.assertEqual(1939, storage[v])
         self.assertEqual(1984, storage[u])
 
@@ -169,17 +166,18 @@ class MatrixWrapperTest(MathTestBase):
                     yield slice(start, end, sz if end >= start else -sz)
 
     @staticmethod
-    def generate_row_and_col_slices(shape: T.Tuple[int, int],
-                                    step_sizes: T.Iterable[int] = (1, 2, 3)):
+    def generate_row_and_col_slices(
+        shape: tuple[int, int], step_sizes: T.Iterable[int] = (1, 2, 3)
+    ):
         """
-        Generate slices that extract all possible sub-blocks (for the given step sizes) for a 2D array
-        of size `shape`.
+        Generate slices that extract all possible sub-blocks (for the given step sizes) for a 2D
+        array of size `shape`.
         """
-        rows, cols = np.mgrid[0:shape[0], 0:shape[1]]
+        rows, cols = np.mgrid[0 : shape[0], 0 : shape[1]]
         rows = rows.reshape(-1)
         cols = cols.reshape(-1)
-        for start_row, start_col in zip(rows, cols):
-            for end_row, end_col in zip(rows, cols):
+        for start_row, start_col in zip(rows, cols, strict=False):
+            for end_row, end_col in zip(rows, cols, strict=False):
                 for sz in step_sizes:
                     row_slice = slice(start_row, end_row, sz if end_row >= start_row else -sz)
                     col_slice = slice(start_col, end_col, sz if end_col >= start_col else -sz)
@@ -259,7 +257,7 @@ class MatrixWrapperTest(MathTestBase):
         q = sym.symbols("q")
         v = sym.vector(sym.pi, 7, q)
         v_mapped = v.unary_map(lambda x: sym.pow(x, 2) * 3)
-        self.assertIdentical(sym.vector(3 * sym.pi ** 2, 147, 3 * q ** 2), v_mapped)
+        self.assertIdentical(sym.vector(3 * sym.pi**2, 147, 3 * q**2), v_mapped)
 
     def test_vec(self):
         """Test column-order vectorization."""
@@ -298,19 +296,20 @@ class MatrixWrapperTest(MathTestBase):
         x, y, z, a, b, c = sym.symbols("x, y, z, a, b, c")
         self.assertIdentical(
             sym.matrix([[x * a, y, 2], [-3, b + z, c]]),
-            sym.hstack([sym.matrix([x * a, -3]),
-                        sym.matrix([[y, 2], [b + z, c]])]))
+            sym.hstack([sym.matrix([x * a, -3]), sym.matrix([[y, 2], [b + z, c]])]),
+        )
 
         self.assertIdentical(
-            sym.matrix([(a, b), (x, c)]).T,
-            sym.vector(a, b).row_join(sym.vector(x, c)))
+            sym.matrix([(a, b), (x, c)]).T, sym.vector(a, b).row_join(sym.vector(x, c))
+        )
 
     def test_vstack(self):
         """Test vertical stacking."""
         x, y, z = sym.symbols("x, y, z")
         self.assertIdentical(
             sym.matrix([[x, y], [-3, z], [0, 2]]),
-            sym.vstack([sym.matrix([x, y]).T, sym.matrix([[-3, z], [0, 2]])]))
+            sym.vstack([sym.matrix([x, y]).T, sym.matrix([[-3, z], [0, 2]])]),
+        )
 
         self.assertIdentical(sym.matrix([3, z, x, y]), sym.vector(3, z).col_join(sym.vector(x, y)))
 
@@ -325,11 +324,13 @@ class MatrixWrapperTest(MathTestBase):
         m2 = sym.matrix([[y, z], [b, c]])
         m3 = sym.matrix([[c, 1], [2, a]])
 
-        m_expected = sym.vstack([
-            sym.hstack([m1, sym.zeros(1, 2), sym.zeros(1, 2)]),
-            sym.hstack([sym.zeros(2, 1), m2, sym.zeros(2, 2)]),
-            sym.hstack([sym.zeros(2, 1), sym.zeros(2, 2), m3])
-        ])
+        m_expected = sym.vstack(
+            [
+                sym.hstack([m1, sym.zeros(1, 2), sym.zeros(1, 2)]),
+                sym.hstack([sym.zeros(2, 1), m2, sym.zeros(2, 2)]),
+                sym.hstack([sym.zeros(2, 1), sym.zeros(2, 2), m3]),
+            ]
+        )
         self.assertIdentical(m_expected, sym.diag([m1, m2, m3]))
 
     def test_matrix_operations(self):
@@ -373,7 +374,7 @@ class MatrixWrapperTest(MathTestBase):
 
         # multiply/divide by scalar
         self.assertIdentical(sym.vector(x * 2, z * 2), sym.vector(x, z) * 2)
-        self.assertIdentical(sym.row_vector(x * z, z ** 2), z * sym.row_vector(x, z))
+        self.assertIdentical(sym.row_vector(x * z, z**2), z * sym.row_vector(x, z))
         self.assertIdentical(sym.row_vector(x, 1), sym.row_vector(x * z, z) / z)
 
         # cannot add incompatible dimensions
@@ -389,8 +390,7 @@ class MatrixWrapperTest(MathTestBase):
         x, y, z = sym.symbols("x, y, z")
         m = sym.vector((x + y) * (2 + z), sym.sin(x) * (y + 2))
         self.assertIdentical(
-            sym.vector(2 * x + z * x + y * 2 + y * z,
-                       sym.sin(x) * y + sym.sin(x) * 2),
+            sym.vector(2 * x + z * x + y * 2 + y * z, sym.sin(x) * y + sym.sin(x) * 2),
             m.distribute(),
         )
         self.assertIdentical(m.distribute(), sym.distribute(m))
@@ -410,16 +410,18 @@ class MatrixWrapperTest(MathTestBase):
         m = sym.matrix([(x * sym.cos(y * z), y + sym.tan(z)), (z * x * y / w, w * sym.pow(x, y))])
         for var in (x, y, z, w):
             m_diff = m.diff(var=var, order=1)
-            self.assertIdentical(m_diff, m.unary_map(lambda el: el.diff(var)))
+            self.assertIdentical(m_diff, m.unary_map(lambda el: el.diff(var)))  # noqa: B023
 
     def test_jacobian(self):
         """Test calling jacobian on a matrix."""
         x, y, z, w = sym.symbols("x, y, z, w")
         m = sym.matrix([x * x + y * z * w, w * y * sym.cos(x - z) + z])
-        jac_expected = sym.matrix([
-            [m[0].diff(x), m[0].diff(y), m[0].diff(z)],
-            [m[1].diff(x), m[1].diff(y), m[1].diff(z)],
-        ])
+        jac_expected = sym.matrix(
+            [
+                [m[0].diff(x), m[0].diff(y), m[0].diff(z)],
+                [m[1].diff(x), m[1].diff(y), m[1].diff(z)],
+            ]
+        )
         self.assertIdentical(jac_expected, m.jacobian([x, y, z]))
         self.assertIdentical(jac_expected, m.jacobian(sym.vector(x, y, z)))
         self.assertIdentical(jac_expected, sym.jacobian(m, [x, y, z]))
@@ -439,7 +441,8 @@ class MatrixWrapperTest(MathTestBase):
         self.assertIdentical(m1.subs(a, -x * 2), sym.subs(m1, a, -x * 2))
         self.assertIdentical(
             sym.matrix([(3 * x, b - 4), (4 - sym.sin(x), d + sym.log(d))]),
-            m1.subs([(a, x), (c, 4), (y, x)]))
+            m1.subs([(a, x), (c, 4), (y, x)]),
+        )
 
         # Boolean substitution:
         m2 = sym.where(a > d, sym.vector(a, b, c), sym.vector(x, y, z))
@@ -466,10 +469,10 @@ class MatrixWrapperTest(MathTestBase):
 
     def test_cse(self):
         """Test calling `eliminate_subexpressions()` on matrix."""
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
 
-        def var(idx: int, letter: str = 'v'):
-            return sym.symbols(f'{letter}{idx}')
+        def var(idx: int, letter: str = "v"):
+            return sym.symbols(f"{letter}{idx}")
 
         m1 = sym.vector(sym.cos(x * y) - sym.sin(x * y), 3 / sym.sin(x * y), 22 + x)
         m1_cse, replacements = sym.eliminate_subexpressions(m1)

--- a/components/wrapper/tests/python_code_generation_test.py
+++ b/components/wrapper/tests/python_code_generation_test.py
@@ -49,7 +49,7 @@ def create_evaluator(func: T.Callable) -> T.Callable:
             f"Mismatch in # of input args: {len(args)} != {len(input_args)}"
         )
         sub_list: list[tuple[sym.Expr, sym.Expr]] = []
-        for numeric_arg, arg_desc in zip(args, input_args, strict=False):
+        for numeric_arg, arg_desc in zip(args, input_args):
             sym_arg = arg_desc.create_symbolic_input()
             if isinstance(sym_arg, sym.Expr):
                 if isinstance(numeric_arg, (float, np.float32, np.float64)):
@@ -68,7 +68,7 @@ def create_evaluator(func: T.Callable) -> T.Callable:
                 if len(numeric_arg.shape) > 2:
                     raise TypeError("Numpy array must be 1D or 2D")
                 matrix = sym.matrix(numeric_arg.astype(float))
-                for var, num in zip(sym_arg.to_flat_list(), matrix.to_flat_list(), strict=False):
+                for var, num in zip(sym_arg.to_flat_list(), matrix.to_flat_list()):
                     sub_list.append((var, num))
             else:
                 raise TypeError(f"Not supported yet: {arg_desc.type}")
@@ -106,7 +106,7 @@ def batch_evaluator(func: T.Callable) -> T.Callable:
 
     def batched(*args):
         outputs = collections.defaultdict(list)
-        for x in zip(*args, strict=False):
+        for x in zip(*args):
             y = func(*x)
             if isinstance(y, tuple):
                 rv, oa = y
@@ -320,7 +320,7 @@ class PythonCodeGenerationTestBase(MathTestBase):
 
         ws = np.array([[-0.5e-8, -1.3e-7, 4.2e-8], [0.1, -0.3, 0.7], [1.2, -0.3, -0.8]])
         vs = np.array([[-4.2, 3.6, 8.1], [3.0, -7.0, 1.2], [0.02, -0.4, -3.0]])
-        for w, v in zip(ws, vs, strict=False):
+        for w, v in zip(ws, vs):
             rv_num, oa_num = func(w, v)
             rv_sym, oa_sym = evaluator(w, v)
             np.testing.assert_allclose(desired=rv_sym, actual=rv_num, rtol=1.0e-6)

--- a/components/wrapper/tests/python_code_generation_test.py
+++ b/components/wrapper/tests/python_code_generation_test.py
@@ -14,7 +14,7 @@ import numpy as np
 try:
     import torch as th
 except ImportError:
-    print('Torch not installed, PyTorch tests will be skipped.')
+    print("Torch not installed, PyTorch tests will be skipped.")
     th = None
 
 from wrenfold import code_generation, external_functions, sym, type_info
@@ -45,10 +45,11 @@ def create_evaluator(func: T.Callable) -> T.Callable:
     input_args = [a for a in desc.arguments if a.is_input]
 
     def evaluator(*args):
-        assert len(args) == len(
-            input_args), f"Mismatch in # of input args: {len(args)} != {len(input_args)}"
-        sub_list: T.List[T.Tuple[sym.Expr, sym.Expr]] = []
-        for numeric_arg, arg_desc in zip(args, input_args):
+        assert len(args) == len(input_args), (
+            f"Mismatch in # of input args: {len(args)} != {len(input_args)}"
+        )
+        sub_list: list[tuple[sym.Expr, sym.Expr]] = []
+        for numeric_arg, arg_desc in zip(args, input_args, strict=False):
             sym_arg = arg_desc.create_symbolic_input()
             if isinstance(sym_arg, sym.Expr):
                 if isinstance(numeric_arg, (float, np.float32, np.float64)):
@@ -57,16 +58,17 @@ def create_evaluator(func: T.Callable) -> T.Callable:
                     numeric_arg = sym.integer(int(numeric_arg))
                 else:
                     raise TypeError(
-                        f"Invalid type for numeric arg: value = {numeric_arg}, type = {type(numeric_arg)}"
+                        f"Invalid type for numeric arg: value = {numeric_arg}, type = {type(numeric_arg)}"  # noqa: E501
                     )
                 sub_list.append((sym_arg, numeric_arg))
             elif isinstance(sym_arg, sym.MatrixExpr):
-                assert isinstance(numeric_arg,
-                                  np.ndarray), f"{type(numeric_arg)}, arg = {arg_desc.name}"
+                assert isinstance(numeric_arg, np.ndarray), (
+                    f"{type(numeric_arg)}, arg = {arg_desc.name}"
+                )
                 if len(numeric_arg.shape) > 2:
                     raise TypeError("Numpy array must be 1D or 2D")
                 matrix = sym.matrix(numeric_arg.astype(float))
-                for var, num in zip(sym_arg.to_flat_list(), matrix.to_flat_list()):
+                for var, num in zip(sym_arg.to_flat_list(), matrix.to_flat_list(), strict=False):
                     sub_list.append((var, num))
             else:
                 raise TypeError(f"Not supported yet: {arg_desc.type}")
@@ -78,8 +80,9 @@ def create_evaluator(func: T.Callable) -> T.Callable:
         output_arg_dict = dict()
         for key, output_exprs in output_expressions.items():
             output_exprs = sym.subs(output_exprs, sub_list).eval()
-            assert isinstance(output_exprs,
-                              (float, np.ndarray)), f"Failed to evaluate output: {key}"
+            assert isinstance(output_exprs, (float, np.ndarray)), (
+                f"Failed to evaluate output: {key}"
+            )
             if not key.name:
                 return_value = output_exprs
             else:
@@ -103,7 +106,7 @@ def batch_evaluator(func: T.Callable) -> T.Callable:
 
     def batched(*args):
         outputs = collections.defaultdict(list)
-        for x in zip(*args):
+        for x in zip(*args, strict=False):
             y = func(*x)
             if isinstance(y, tuple):
                 rv, oa = y
@@ -146,8 +149,12 @@ class PythonCodeGenerationTestBase(MathTestBase):
     VERBOSE = False
 
     @classmethod
-    def generate(cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
-                 batch: bool, **kwargs) -> T.Callable:
+    def generate(
+        cls,
+        func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
+        batch: bool,
+        **kwargs,
+    ) -> T.Callable:
         """Derived classes may override to customize the code-generation process."""
         raise NotImplementedError()
 
@@ -157,26 +164,19 @@ class PythonCodeGenerationTestBase(MathTestBase):
 
     @classmethod
     def convert_outputs_to_array(cls, outputs, strip_batch_dim: bool = False):
-        if strip_batch_dim:
-            constructor = lambda x: np.squeeze(np.array(x), axis=0)
-        else:
-            constructor = np.array
+        constructor = (lambda x: np.squeeze(np.array(x), axis=0)) if strip_batch_dim else np.array
         if isinstance(outputs, tuple):
             return_val, output_args = outputs
-            return constructor(return_val), {
-                k: constructor(v) for (k, v) in output_args.items()
-            }
+            return constructor(return_val), {k: constructor(v) for (k, v) in output_args.items()}
         elif isinstance(outputs, dict):
-            return {
-                k: constructor(v) for (k, v) in outputs.items()
-            }
+            return {k: constructor(v) for (k, v) in outputs.items()}
         else:
             return constructor(outputs)
 
     @classmethod
     def get_optional_output_flags(
         cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult]
-    ) -> T.Tuple[int, T.Dict[str, bool]]:
+    ) -> tuple[int, dict[str, bool]]:
         """
         Get the function description and do two things:
         - Count the # of input args.
@@ -261,7 +261,8 @@ class PythonCodeGenerationTestBase(MathTestBase):
         func_batched = self.generate(nested_cond, batch=True, context=dict())
         evaluator_batched = batch_evaluator(evaluator)
         np.testing.assert_allclose(
-            desired=evaluator_batched(x, y), actual=func_batched(x, y), rtol=1.0e-6)
+            desired=evaluator_batched(x, y), actual=func_batched(x, y), rtol=1.0e-6
+        )
 
     def test_std_math_functions(self):
         """Test a function that uses every built-in math function."""
@@ -300,13 +301,14 @@ class PythonCodeGenerationTestBase(MathTestBase):
         evaluator_batched = batch_evaluator(evaluator)
         x = np.linspace(-5.0, 5.0, num=20)
         np.testing.assert_allclose(
-            desired=evaluator_batched(x), actual=func_batched(x), rtol=1.0e-6)
+            desired=evaluator_batched(x), actual=func_batched(x), rtol=1.0e-6
+        )
 
     def test_rotate_vector(self):
         """Test a function that creates a rotation matrix."""
 
         def rotate_vector(w: Vector3, v: Vector3):
-            v_rot = (Quaternion.from_rotation_vector(w, epsilon=1.0e-6).to_rotation_matrix() * v)
+            v_rot = Quaternion.from_rotation_vector(w, epsilon=1.0e-6).to_rotation_matrix() * v
             v_rot_D_w = v_rot.jacobian(vars=w)
             return (
                 code_generation.ReturnValue(v_rot),
@@ -318,12 +320,13 @@ class PythonCodeGenerationTestBase(MathTestBase):
 
         ws = np.array([[-0.5e-8, -1.3e-7, 4.2e-8], [0.1, -0.3, 0.7], [1.2, -0.3, -0.8]])
         vs = np.array([[-4.2, 3.6, 8.1], [3.0, -7.0, 1.2], [0.02, -0.4, -3.0]])
-        for w, v in zip(ws, vs):
+        for w, v in zip(ws, vs, strict=False):
             rv_num, oa_num = func(w, v)
             rv_sym, oa_sym = evaluator(w, v)
             np.testing.assert_allclose(desired=rv_sym, actual=rv_num, rtol=1.0e-6)
             np.testing.assert_allclose(
-                desired=oa_sym["v_rot_D_w"], actual=oa_num["v_rot_D_w"], rtol=2.0e-6)
+                desired=oa_sym["v_rot_D_w"], actual=oa_num["v_rot_D_w"], rtol=2.0e-6
+            )
 
         if not self.SUPPORTS_BATCH:
             return
@@ -335,7 +338,8 @@ class PythonCodeGenerationTestBase(MathTestBase):
         rv_sym, oa_sym = evaluator_batched(ws, vs)
         np.testing.assert_allclose(desired=rv_sym, actual=rv_num, rtol=1.0e-6)
         np.testing.assert_allclose(
-            desired=oa_sym["v_rot_D_w"], actual=oa_num["v_rot_D_w"], rtol=2.0e-6)
+            desired=oa_sym["v_rot_D_w"], actual=oa_num["v_rot_D_w"], rtol=2.0e-6
+        )
 
     def test_quaternion_to_and_from_matrix(self):
         """Test conversion of a quaternion to/from a matrix."""
@@ -352,28 +356,30 @@ class PythonCodeGenerationTestBase(MathTestBase):
         m2q_func = self.generate(quat_from_matrix, batch=False, context=dict())
         m2q_evaluator = create_evaluator(quat_from_matrix)
 
-        qs = np.array([
-            [0.34275355, -0.4911505, 0.74564528, 0.292069],
-            [-0.55168672, -0.3643096, -0.24763068, -0.70823678],
-            [-0.62807818, -0.61816808, -0.05451869, -0.46948242],
-            [0.66212773, -0.69169043, 0.08646926, 0.27508959],
-            [0.59426466, 0.57949089, -0.44302533, -0.33877483],
-            [-0.32050495, -0.4959491, 0.49529348, -0.63717771],
-            [-0.33024803, -0.55360404, 0.69653515, 0.3151152],
-            [-0.42917766, 0.73698446, 0.29120886, -0.43342572],
-            [-0.96585751, -0.21180895, 0.11426334, -0.09591728],
-            [0.82019495, -0.20024658, 0.49402012, -0.20766724],
-            [-0.88405116, -0.00382236, -0.43228709, -0.17767051],
-            [-0.20492276, -0.84642162, -0.09095168, 0.48301645],
-            [-0.50511663, 0.38294217, -0.34734593, 0.69105954],
-            [0.7151773, -0.05036465, -0.63918558, -0.2782564],
-            [-0.69895435, 0.37952658, 0.34789252, 0.49638008],
-            [0.69070411, -0.29540322, -0.61085795, 0.25003466],
-            [-0.5953591, -0.62963857, -0.45582188, -0.20329591],
-            [0.87445741, -0.36888073, 0.12098375, 0.29088517],
-            [-0.69501499, 0.68907201, -0.00272476, -0.20524742],
-            [-0.70538009, 0.62270118, 0.12854222, 0.31330346],
-        ])
+        qs = np.array(
+            [
+                [0.34275355, -0.4911505, 0.74564528, 0.292069],
+                [-0.55168672, -0.3643096, -0.24763068, -0.70823678],
+                [-0.62807818, -0.61816808, -0.05451869, -0.46948242],
+                [0.66212773, -0.69169043, 0.08646926, 0.27508959],
+                [0.59426466, 0.57949089, -0.44302533, -0.33877483],
+                [-0.32050495, -0.4959491, 0.49529348, -0.63717771],
+                [-0.33024803, -0.55360404, 0.69653515, 0.3151152],
+                [-0.42917766, 0.73698446, 0.29120886, -0.43342572],
+                [-0.96585751, -0.21180895, 0.11426334, -0.09591728],
+                [0.82019495, -0.20024658, 0.49402012, -0.20766724],
+                [-0.88405116, -0.00382236, -0.43228709, -0.17767051],
+                [-0.20492276, -0.84642162, -0.09095168, 0.48301645],
+                [-0.50511663, 0.38294217, -0.34734593, 0.69105954],
+                [0.7151773, -0.05036465, -0.63918558, -0.2782564],
+                [-0.69895435, 0.37952658, 0.34789252, 0.49638008],
+                [0.69070411, -0.29540322, -0.61085795, 0.25003466],
+                [-0.5953591, -0.62963857, -0.45582188, -0.20329591],
+                [0.87445741, -0.36888073, 0.12098375, 0.29088517],
+                [-0.69501499, 0.68907201, -0.00272476, -0.20524742],
+                [-0.70538009, 0.62270118, 0.12854222, 0.31330346],
+            ]
+        )
 
         for q_wxyz_in in qs:
             R_num = q2m_func(q_wxyz_in)
@@ -381,7 +387,8 @@ class PythonCodeGenerationTestBase(MathTestBase):
 
             q_wxyz_out_num = m2q_func(R_num)
             np.testing.assert_allclose(
-                desired=m2q_evaluator(R_num), actual=q_wxyz_out_num, rtol=1.0e-6)
+                desired=m2q_evaluator(R_num), actual=q_wxyz_out_num, rtol=1.0e-6
+            )
 
             # Signs may differ in the round-trip conversion, so multiply by sign of `w`.
             q_wxyz_out_num = q_wxyz_out_num.reshape([-1])
@@ -411,18 +418,18 @@ class PythonCodeGenerationTestBase(MathTestBase):
         Test calling an external function via a generated python method.
         """
         external_func = external_functions.declare_external_function(
-            name="external_func", arguments=[("x", FloatScalar)], return_type=Vector2)
+            name="external_func", arguments=[("x", FloatScalar)], return_type=Vector2
+        )
 
         def call_external_func(a: Vector2, b: Vector2):
-            dot, = a.T * b
+            (dot,) = a.T * b
             return external_func(3 * dot + 0.2)
 
         func = self.generate(
             call_external_func,
             batch=False,
-            context={
-                external_func.name: lambda x: self.make_array([x * x, x * x * x])
-            })
+            context={external_func.name: lambda x: self.make_array([x * x, x * x * x])},
+        )
 
         np.testing.assert_allclose(
             desired=np.array([1.283689, 1.4544196370000002]).reshape([2, 1]),
@@ -436,7 +443,7 @@ class PythonCodeGenerationTestBase(MathTestBase):
         """
 
         def only_optional_outputs(x: Vector3, y: Vector3):
-            inner_product, = x.T * y
+            (inner_product,) = x.T * y
             outer_product = x * y.T
             return [
                 code_generation.OutputArg(inner_product, name="inner", is_optional=True),
@@ -446,14 +453,14 @@ class PythonCodeGenerationTestBase(MathTestBase):
         func = self.generate(only_optional_outputs, batch=False)
         evaluator = create_evaluator(only_optional_outputs)
 
-        xs = np.array([[-0.5, -8.5, -2.8], [-3., 3.5, 8.2], [9.8, 5.1, -4.3]])
+        xs = np.array([[-0.5, -8.5, -2.8], [-3.0, 3.5, 8.2], [9.8, 5.1, -4.3]])
         ys = np.array([[7.3, -1.1, -1.3], [-2.5, -0.4, 0.6], [5.9, 3.3, -1.8]])
 
         for x in xs:
             for y in ys:
                 oa_sym = evaluator(x, y)
                 oa_num = func(x, y)
-                for key in ('inner', 'outer'):
+                for key in ("inner", "outer"):
                     np.testing.assert_allclose(desired=oa_sym[key], actual=oa_num[key], rtol=1.0e-6)
 
         if not self.SUPPORTS_BATCH:
@@ -465,7 +472,7 @@ class PythonCodeGenerationTestBase(MathTestBase):
         oa_sym = evaluator_batched(xs, ys)
         oa_num = func_batched(xs, ys)
 
-        for key in ('inner', 'outer'):
+        for key in ("inner", "outer"):
             np.testing.assert_allclose(desired=oa_sym[key], actual=oa_num[key], rtol=1.0e-6)
 
     def test_integer_inputs(self):
@@ -528,6 +535,7 @@ class SimParams:
 @dataclasses.dataclass
 class SimState:
     """Numeric equivalent of ``SimStateSymbolic`."""
+
     position: np.ndarray
     velocity: np.ndarray
 
@@ -549,12 +557,13 @@ def integrate_sim(
     """
     # Compute force:
     f = sym.vector(0, -params.gravity * params.mass) - x.velocity * x.velocity.norm() * (
-        params.drag_coefficient / 2)
+        params.drag_coefficient / 2
+    )
     accel = f * (1 / params.mass)
 
     # Euler integration:
     velocity = x.velocity + accel * dt
-    position = x.position + x.velocity * dt + accel * (dt ** 2) / 2
+    position = x.position + x.velocity * dt + accel * (dt**2) / 2
 
     return SimStateSymbolic(position=position, velocity=velocity)
 
@@ -566,8 +575,12 @@ class NumPyCodeGenerationTest(PythonCodeGenerationTestBase):
     VERBOSE = False
 
     @classmethod
-    def generate(cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
-                 batch: bool, **kwargs) -> T.Callable:
+    def generate(
+        cls,
+        func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
+        batch: bool,
+        **kwargs,
+    ) -> T.Callable:
         _, optional_arg_flags = cls.get_optional_output_flags(func)
         func_gen, code = code_generation.generate_python(func=func, **kwargs)
         if cls.VERBOSE:
@@ -588,7 +601,6 @@ class NumPyCodeGenerationTest(PythonCodeGenerationTestBase):
         """
 
         class CustomPythonGenerator(code_generation.PythonGenerator):
-
             def format_custom_type(self, custom: type_info.CustomType):
                 if custom.python_type == SimParamsSymbolic:
                     return "SimParams"
@@ -603,7 +615,8 @@ class NumPyCodeGenerationTest(PythonCodeGenerationTestBase):
                 "SimParams": SimParams,
                 "SimState": SimState,
             },
-            generator_type=CustomPythonGenerator)
+            generator_type=CustomPythonGenerator,
+        )
 
         # Test against the symbolic implementation:
         p_in = np.array([10.2, -5.0]).reshape((2, 1))
@@ -629,10 +642,15 @@ class JaxCodeGenerationTest(PythonCodeGenerationTestBase):
     """Run with JAX configuration."""
 
     @classmethod
-    def generate(cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
-                 batch: bool, **kwargs) -> T.Callable:
+    def generate(
+        cls,
+        func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
+        batch: bool,
+        **kwargs,
+    ) -> T.Callable:
         func_gen, code = code_generation.generate_python(
-            func=func, target=code_generation.PythonGeneratorTarget.JAX, **kwargs)
+            func=func, target=code_generation.PythonGeneratorTarget.JAX, **kwargs
+        )
         if cls.VERBOSE:
             print(code)
 
@@ -663,10 +681,15 @@ class PyTorchCodeGenerationTest(PythonCodeGenerationTestBase):
     """Run with PyTorch configuration."""
 
     @classmethod
-    def generate(cls, func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
-                 batch: bool, **kwargs) -> T.Callable:
+    def generate(
+        cls,
+        func: T.Callable[..., code_generation.CodegenFuncInvocationResult],
+        batch: bool,
+        **kwargs,
+    ) -> T.Callable:
         func_gen, code = code_generation.generate_python(
-            func=func, target=code_generation.PythonGeneratorTarget.PyTorch, **kwargs)
+            func=func, target=code_generation.PythonGeneratorTarget.PyTorch, **kwargs
+        )
         if cls.VERBOSE:
             print(code)
 
@@ -706,7 +729,7 @@ def test_apply_preamble():
     target_imports = {
         code_generation.PythonGeneratorTarget.NumPy: "import numpy as np",
         code_generation.PythonGeneratorTarget.JAX: "import jax.numpy as jnp",
-        code_generation.PythonGeneratorTarget.PyTorch: "import torch as th"
+        code_generation.PythonGeneratorTarget.PyTorch: "import torch as th",
     }
 
     code = "def foo():\n\tpass"

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -1,12 +1,12 @@
 """
 Test conversion of wrenfold expressions to sympy, and visa-versa.
 """
+
 import sys
 import typing as T
 import unittest
 
 import sympy as sp
-
 from wrenfold import exceptions, sym, sympy_conversion
 
 from .test_base import MathTestBase
@@ -29,19 +29,20 @@ class SympyConversionTest(MathTestBase):
 
     def test_variables(self):
         """Test conversion of Variable <-> Symbol."""
-        self.assertEqualSp(sp.symbols('x'), sym.symbols('x'))
-        self.assertEqualSp(sp.symbols('x', real=True), sym.symbols('x', real=True))
-        self.assertEqualSp(sp.symbols('x', positive=True), sym.symbols('x', positive=True))
-        self.assertEqualSp(sp.symbols('x', nonnegative=True), sym.symbols('x', nonnegative=True))
-        self.assertEqualSp(sp.symbols('x', complex=True), sym.symbols('x', complex=True))
+        self.assertEqualSp(sp.symbols("x"), sym.symbols("x"))
+        self.assertEqualSp(sp.symbols("x", real=True), sym.symbols("x", real=True))
+        self.assertEqualSp(sp.symbols("x", positive=True), sym.symbols("x", positive=True))
+        self.assertEqualSp(sp.symbols("x", nonnegative=True), sym.symbols("x", nonnegative=True))
+        self.assertEqualSp(sp.symbols("x", complex=True), sym.symbols("x", complex=True))
 
         # sympy --> wf
-        self.assertIdenticalFromSp(sym.symbols('x'), sp.symbols('x'))
-        self.assertIdenticalFromSp(sym.symbols('x', real=True), sp.symbols('x', real=True))
-        self.assertIdenticalFromSp(sym.symbols('x', positive=True), sp.symbols('x', positive=True))
+        self.assertIdenticalFromSp(sym.symbols("x"), sp.symbols("x"))
+        self.assertIdenticalFromSp(sym.symbols("x", real=True), sp.symbols("x", real=True))
+        self.assertIdenticalFromSp(sym.symbols("x", positive=True), sp.symbols("x", positive=True))
         self.assertIdenticalFromSp(
-            sym.symbols('x', nonnegative=True), sp.symbols('x', nonnegative=True))
-        self.assertIdenticalFromSp(sym.symbols('x', complex=True), sp.symbols('x', complex=True))
+            sym.symbols("x", nonnegative=True), sp.symbols("x", nonnegative=True)
+        )
+        self.assertIdenticalFromSp(sym.symbols("x", complex=True), sp.symbols("x", complex=True))
 
     def test_numeric_constants(self):
         self.assertEqualSp(sp.Integer(0), sym.zero)
@@ -66,8 +67,8 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.one, sp.Integer(1))
         self.assertIdenticalFromSp(sym.integer(-1), sp.Integer(-1))
         self.assertIdenticalFromSp(sym.integer(-23), -sp.Integer(23))
-        self.assertIdenticalFromSp(sym.integer(2 ** 63 - 1), sp.Integer(2 ** 63 - 1))
-        self.assertIdenticalFromSp(sym.integer(-1 * 2 ** 63), -sp.Integer(2 ** 63))
+        self.assertIdenticalFromSp(sym.integer(2**63 - 1), sp.Integer(2**63 - 1))
+        self.assertIdenticalFromSp(sym.integer(-1 * 2**63), -sp.Integer(2**63))
 
         self.assertIdenticalFromSp(sym.float(0.0), sp.Float(0.0))
         self.assertIdenticalFromSp(sym.float(1.0), sp.Float(1.0))
@@ -105,7 +106,7 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.false, sp.false)
 
     def test_addition(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIsInstance(spy(x + y), sp.Add)
         self.assertEqualSp(spy(x) + spy(y), x + y)
         self.assertEqualSp(spy(x) + spy(3), x + 3)
@@ -120,7 +121,7 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(-x - y, -spy(x) - spy(y))
 
     def test_multiplication(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertIsInstance(spy(x * y), sp.Mul)
         self.assertIsInstance(spy(x / y), sp.Mul)
         self.assertIsInstance(spy(x + x), sp.Mul)
@@ -140,8 +141,8 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(x / y / 55, spy(x) / spy(y) / 55)
 
     def test_power(self):
-        x, y = sym.symbols('x, y')
-        w = sym.symbols('w', real=True, nonnegative=True)
+        x, y = sym.symbols("x, y")
+        w = sym.symbols("w", real=True, nonnegative=True)
         self.assertIsInstance(spy(x * x), sp.Pow)
         self.assertIsInstance(spy(1 / x), sp.Pow)
         self.assertEqualSp(sp.Pow(spy(x), 2), x * x)
@@ -152,23 +153,28 @@ class SympyConversionTest(MathTestBase):
         self.assertEqualSp(sp.Pow(spy(w), 2) * sp.Pow(spy(x), 2), sym.pow(w * x, 2))
         self.assertEqualSp(-sp.Pow(spy(x), 3), sym.pow(-x, 3))
         self.assertEqualSp(
-            sp.Pow(-145212480 * spy(x),
-                   sp.Integer(1) / 6), sym.pow(-145212480 * x, sym.one / 6))
+            sp.Pow(-145212480 * spy(x), sp.Integer(1) / 6),
+            sym.pow(-145212480 * x, sym.one / 6),
+        )
 
         # sympy --> wf
-        self.assertIdenticalFromSp(x ** 2, spy(x) ** 2)
-        self.assertIdenticalFromSp(x ** 3, spy(x) ** 3)
-        self.assertIdenticalFromSp(x ** y, spy(x) ** spy(y))
-        self.assertIdenticalFromSp((x ** y) ** (sym.integer(1) / 3),
-                                   sp.Pow(spy(x), spy(y)) ** (sp.Integer(1) / 3))
-        self.assertIdenticalFromSp(y ** -0.8721, spy(y) ** -0.8721)
-        self.assertIdenticalFromSp(x ** -1, 1 / spy(x))
-        self.assertIdenticalFromSp(x ** -2, 1 / sp.Pow(spy(x), 2))
-        self.assertIdenticalFromSp(w ** sym.rational(1, 3) * x ** sym.rational(1, 3),
-                                   sp.Pow(spy(w) * spy(x), sp.Rational(1, 3)))
+        self.assertIdenticalFromSp(x**2, spy(x) ** 2)
+        self.assertIdenticalFromSp(x**3, spy(x) ** 3)
+        self.assertIdenticalFromSp(x**y, spy(x) ** spy(y))
+        self.assertIdenticalFromSp(
+            (x**y) ** (sym.integer(1) / 3),
+            sp.Pow(spy(x), spy(y)) ** (sp.Integer(1) / 3),
+        )
+        self.assertIdenticalFromSp(y**-0.8721, spy(y) ** -0.8721)
+        self.assertIdenticalFromSp(x**-1, 1 / spy(x))
+        self.assertIdenticalFromSp(x**-2, 1 / sp.Pow(spy(x), 2))
+        self.assertIdenticalFromSp(
+            w ** sym.rational(1, 3) * x ** sym.rational(1, 3),
+            sp.Pow(spy(w) * spy(x), sp.Rational(1, 3)),
+        )
 
     def test_functions(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(sp.cos(spy(x)), sym.cos(x))
         self.assertEqualSp(sp.sin(spy(x)), sym.sin(x))
         self.assertEqualSp(sp.tan(spy(x)), sym.tan(x))
@@ -208,7 +214,7 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.atan2(y, x), sp.atan2(sy, sx))
 
     def test_relational(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(spy(x) < spy(y), x < y)
         self.assertEqualSp(spy(y) < spy(x), x > y)
         self.assertEqualSp(spy(x) <= spy(y), x <= y)
@@ -223,29 +229,29 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.eq(x, y), sp.Eq(spy(x), spy(y)))
 
     def test_conditional(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(sp.Piecewise((2, spy(x < y)), (3, True)), sym.where(x < y, 2, 3))
         self.assertEqualSp(
             sp.Piecewise((sp.cos(spy(x)), spy(x <= y + 2)), (sp.sin(spy(y)) * 2, True)),
-            sym.where(x <= y + 2, sym.cos(x),
-                      sym.sin(y) * 2))
+            sym.where(x <= y + 2, sym.cos(x), sym.sin(y) * 2),
+        )
 
         # sympy --> wf
         self.assertIdenticalFromSp(sym.where(x < y, 2, 3), sp.Piecewise((2, spy(x < y)), (3, True)))
         self.assertIdenticalFromSp(
-            sym.where(x <= y + 2, sym.cos(x),
-                      sym.sin(y) * 2),
-            sp.Piecewise((sp.cos(spy(x)), spy(x <= y + 2)), (sp.sin(spy(y)) * 2, True)))
+            sym.where(x <= y + 2, sym.cos(x), sym.sin(y) * 2),
+            sp.Piecewise((sp.cos(spy(x)), spy(x <= y + 2)), (sp.sin(spy(y)) * 2, True)),
+        )
 
     def test_iverson_bracket(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(sp.Piecewise((1, spy(x < y)), (0, True)), sym.iverson(x < y))
 
         # sympy --> wf
         self.assertIdenticalFromSp(sym.iverson(x < y), sp.Piecewise((1, spy(x < y)), (0, True)))
 
     def test_min_max(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(sp.Min(spy(x), spy(y)), sym.min(x, y))
         self.assertEqualSp(sp.Max(spy(x), spy(y)), sym.max(x, y))
 
@@ -253,83 +259,94 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.min(x, y), sp.Min(spy(x), spy(y)))
         self.assertIdenticalFromSp(sym.max(x, y), sp.Max(spy(x), spy(y)))
 
-        self.assertRaises(NotImplementedError, lambda: unspy(sp.Min(spy(x), 3, spy(x ** 2))))
-        self.assertRaises(NotImplementedError, lambda: unspy(sp.Max(spy(x), 3, spy(x ** 2))))
+        self.assertRaises(NotImplementedError, lambda: unspy(sp.Min(spy(x), 3, spy(x**2))))
+        self.assertRaises(NotImplementedError, lambda: unspy(sp.Max(spy(x), 3, spy(x**2))))
 
     def test_heaviside(self):
         # Heaviside only goes one way for now:
-        x = sym.symbols('x')
+        x = sym.symbols("x")
         # sympy --> wf
         self.assertIdenticalFromSp(
-            sym.where(0 < x, 1, sym.where(x < 0, -1, sym.rational(1, 2))), sp.Heaviside(spy(x)))
+            sym.where(x > 0, 1, sym.where(x < 0, -1, sym.rational(1, 2))),
+            sp.Heaviside(spy(x)),
+        )
         self.assertIdenticalFromSp(
-            sym.where(0 < x, 1, sym.where(x < 0, -1, sym.nan)), sp.Heaviside(spy(x), sp.nan))
+            sym.where(x > 0, 1, sym.where(x < 0, -1, sym.nan)),
+            sp.Heaviside(spy(x), sp.nan),
+        )
 
     def test_unevaluated(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertEqualSp(sp.UnevaluatedExpr(spy(x)), sym.unevaluated(x))
         self.assertEqualSp(sp.UnevaluatedExpr(spy(x) * spy(y)) * spy(y), sym.unevaluated(x * y) * y)
 
         # sympy --> wf
         self.assertIdenticalFromSp(
-            sym.unevaluated(x * y) * y,
-            sp.UnevaluatedExpr(spy(x) * spy(y)) * spy(y))
+            sym.unevaluated(x * y) * y, sp.UnevaluatedExpr(spy(x) * spy(y)) * spy(y)
+        )
 
     def test_derivative_expression(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         sx, sy = spy(x), spy(y)
         self.assertEqualSp(sp.Derivative(sp.cos(sx), sx), sym.derivative(sym.cos(x), x))
         self.assertEqualSp(sp.Derivative(sp.cos(sx), sx, 2), sym.derivative(sym.cos(x), x).diff(x))
 
         # sympy --> wf
         self.assertIdenticalFromSp(
-            sym.derivative(sym.abs(x * y), x), sp.Derivative(abs(sx * sy), sx))
+            sym.derivative(sym.abs(x * y), x), sp.Derivative(abs(sx * sy), sx)
+        )
         self.assertIdenticalFromSp(
-            sym.derivative(sym.abs(x * y), x, 2), sp.Derivative(abs(sx * sy), (sx, 2)))
+            sym.derivative(sym.abs(x * y), x, 2), sp.Derivative(abs(sx * sy), (sx, 2))
+        )
         self.assertIdenticalFromSp(
             sym.derivative(sym.abs(x * y), x).diff(y),
-            sp.Derivative(abs(sx * sy), sx).diff(sy, evaluate=False))
+            sp.Derivative(abs(sx * sy), sx).diff(sy, evaluate=False),
+        )
 
     def test_symbolic_function_evaluation(self):
-        x, y = sym.symbols('x, y')
-        f = sym.Function('f')
+        x, y = sym.symbols("x, y")
+        f = sym.Function("f")
 
         sx, sy = spy(x), spy(y)
-        sf = sp.Function('f')
+        sf = sp.Function("f")
 
         self.assertEqualSp(sf(sx), f(x))
         self.assertEqualSp(sf(sx + 2), f(x + 2))
         self.assertEqualSp(sf(sx).diff(sx), f(x).diff(x))
-        self.assertEqualSp(sf(sf(sx), sy ** 2), f(f(x), y ** 2))
+        self.assertEqualSp(sf(sf(sx), sy**2), f(f(x), y**2))
 
         # sympy --> wf
         self.assertIdenticalFromSp(f(x), sf(sx))
         self.assertIdenticalFromSp(f(x, y * 2), sf(sx, sy * 2))
         self.assertIdenticalFromSp(f(x, y).diff(x), sf(sx, sy).diff(sx))
 
-        sg = sp.Function('g', real=True)
+        sg = sp.Function("g", real=True)
         self.assertRaises(NotImplementedError, lambda: unspy(sg(sx)))
 
     def test_substitute_expression(self):
-        x, y = sym.symbols('x, y')
-        f = sym.Function('f')
+        x, y = sym.symbols("x, y")
+        f = sym.Function("f")
 
         sx, sy = spy(x), spy(y)
-        sf = sp.Function('f')
+        sf = sp.Function("f")
 
         self.assertEqualSp(
-            sp.Subs(sx + 3, sx, sp.pi, evaluate=False), sym.substitution(x + 3, x, sym.pi))
-        self.assertEqualSp(sp.Subs(sf(sx), sx, sy ** 2), sym.substitution(f(x), x, y ** 2))
+            sp.Subs(sx + 3, sx, sp.pi, evaluate=False),
+            sym.substitution(x + 3, x, sym.pi),
+        )
+        self.assertEqualSp(sp.Subs(sf(sx), sx, sy**2), sym.substitution(f(x), x, y**2))
 
         # sympy --> wf
         self.assertIdenticalFromSp(
-            sym.substitution(f(x), x, y), sp.Subs(sf(sx), sx, sy, evaluate=False))
+            sym.substitution(f(x), x, y), sp.Subs(sf(sx), sx, sy, evaluate=False)
+        )
         self.assertIdenticalFromSp(
-            sym.substitution(sym.substitution(f(x, y), x, y ** 2), y, sym.pi),
-            sp.Subs(sf(sx, sy), (sx, sy), (sy ** 2, sp.pi)))
+            sym.substitution(sym.substitution(f(x, y), x, y**2), y, sym.pi),
+            sp.Subs(sf(sx, sy), (sx, sy), (sy**2, sp.pi)),
+        )
 
     def test_matrix(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
 
         m1_sp = sp.Matrix([[spy(x) + 3, -2 * spy(y)], [spy(x * y), 22]])
         m1_wf = sym.matrix([[x + 3, -2 * y], [x * y, 22]])
@@ -347,11 +364,11 @@ class SympyConversionTest(MathTestBase):
         self.assertIdenticalFromSp(sym.zeros(3, 5), sp.zeros(3, 5))
 
     def test_unsupported(self):
-        x, y = sym.symbols('x, y')
+        x, y = sym.symbols("x, y")
         self.assertRaises(exceptions.TypeError, lambda: spy(sym.stop_derivative(x * y)))
         u = sym.unique_symbols(1)
         self.assertRaises(exceptions.TypeError, lambda: spy(u))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/components/wrapper/tests/test_base.py
+++ b/components/wrapper/tests/test_base.py
@@ -1,4 +1,5 @@
 """Shared utilities for unit testing."""
+
 import sys
 import typing as T
 import unittest
@@ -14,19 +15,21 @@ class MathTestBase(unittest.TestCase):
             sys.stdout.reconfigure(encoding="utf-8")
             sys.stderr.reconfigure(encoding="utf-8")
 
-    def assertIdentical(self, a: T.Union[sym.AnyExpression, int, float], b: sym.AnyExpression):
+    def assertIdentical(self, a: sym.AnyExpression | int | float, b: sym.AnyExpression):
         """Assert that two expressions are identical."""
         if isinstance(a, (int, float)):
             a = sym.Expr(a)
 
         if a.is_identical_to(b):
             return
-        message = (f'The expressions a:\n{repr(a)}\nb:\n{repr(b)}\nare not identical.\n' +
-                   f'The expression tree for `a` is:\n{a.expression_tree_str()}\n' +
-                   f'The expression tree for `b` is:\n{b.expression_tree_str()}')
+        message = (
+            f"The expressions a:\n{repr(a)}\nb:\n{repr(b)}\nare not identical.\n"
+            + f"The expression tree for `a` is:\n{a.expression_tree_str()}\n"
+            + f"The expression tree for `b` is:\n{b.expression_tree_str()}"
+        )
         raise self.failureException(message)
 
-    def assertNotIdentical(self, a: T.Union[sym.AnyExpression, int, float], b: sym.AnyExpression):
+    def assertNotIdentical(self, a: sym.AnyExpression | int | float, b: sym.AnyExpression):
         """Assert that two expressions are not identical."""
         if isinstance(a, (int, float)):
             a = sym.Expr(a)
@@ -34,9 +37,10 @@ class MathTestBase(unittest.TestCase):
         if not a.is_identical_to(b):
             return
         message = (
-            f'The expressions a:\n{repr(a)}\nb:\n{repr(b)}\n are identical (they should not be).\n'
-            + f'The expression tree for `a` is:\n{a.expression_tree_str()}\n' +
-            f'The expression tree for `b` is:\n{b.expression_tree_str()}')
+            f"The expressions a:\n{repr(a)}\nb:\n{repr(b)}\n are identical (they should not be).\n"
+            + f"The expression tree for `a` is:\n{a.expression_tree_str()}\n"
+            + f"The expression tree for `b` is:\n{b.expression_tree_str()}"
+        )
         raise self.failureException(message)
 
     def assertReprEqual(self, a: str, b: sym.AnyExpression):

--- a/components/wrapper/tests/test_base.py
+++ b/components/wrapper/tests/test_base.py
@@ -15,7 +15,7 @@ class MathTestBase(unittest.TestCase):
             sys.stdout.reconfigure(encoding="utf-8")
             sys.stderr.reconfigure(encoding="utf-8")
 
-    def assertIdentical(self, a: sym.AnyExpression | int | float, b: sym.AnyExpression):
+    def assertIdentical(self, a: T.Union[sym.AnyExpression, int, float], b: sym.AnyExpression):
         """Assert that two expressions are identical."""
         if isinstance(a, (int, float)):
             a = sym.Expr(a)
@@ -29,7 +29,7 @@ class MathTestBase(unittest.TestCase):
         )
         raise self.failureException(message)
 
-    def assertNotIdentical(self, a: sym.AnyExpression | int | float, b: sym.AnyExpression):
+    def assertNotIdentical(self, a: T.Union[sym.AnyExpression, int, float], b: sym.AnyExpression):
         """Assert that two expressions are not identical."""
         if isinstance(a, (int, float)):
             a = sym.Expr(a)

--- a/docs/generate_api_rst.py
+++ b/docs/generate_api_rst.py
@@ -1,12 +1,11 @@
 """
 Script that generates the `python_api_docs.rst` file.
 """
+
 import argparse
 import inspect
 import typing as T
 from pathlib import Path
-
-DOCS_DIR = Path(__file__).parent.absolute()
 
 # The built library needs to be on the import path by this point.
 from wrenfold import (
@@ -23,6 +22,8 @@ from wrenfold import (
     type_info,
 )
 
+DOCS_DIR = Path(__file__).parent.absolute()
+
 
 def generate_rst_for_module(module: T.Any, module_name: str, output_dir: Path):
     """
@@ -31,13 +32,13 @@ def generate_rst_for_module(module: T.Any, module_name: str, output_dir: Path):
     functions = []
     classes = []
     for member_name in sorted(dir(module)):
-        if member_name.startswith('_'):
+        if member_name.startswith("_"):
             continue
 
         member = getattr(module, member_name)
         if inspect.ismodule(member):
             continue
-        if member.__doc__ is None or 'OMIT_FROM_SPHINX' in member.__doc__:
+        if member.__doc__ is None or "OMIT_FROM_SPHINX" in member.__doc__:
             continue
 
         # Pybind11 functions show up as built-in functions:
@@ -49,22 +50,26 @@ def generate_rst_for_module(module: T.Any, module_name: str, output_dir: Path):
             # TODO: Attach __doc__ to attributes? Presently there is no way to do this.
             pass
 
-    parts = [f'{module_name}\n{"=" * len(module_name)}']
-    parts.extend(f'.. autofunction:: wrenfold.{module_name}.{func}' for func in functions)
+    parts = [f"{module_name}\n{'=' * len(module_name)}"]
+    parts.extend(f".. autofunction:: wrenfold.{module_name}.{func}" for func in functions)
 
-    class_directives = "\n  ".join([
-        ':members:', ':special-members:',
-        ':exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__'
-    ])
+    class_directives = "\n  ".join(
+        [
+            ":members:",
+            ":special-members:",
+            ":exclude-members: __dict__,__weakref__,__repr__,__getstate__,__setstate__",
+        ]
+    )
     parts.extend(
-        f'.. autoclass:: wrenfold.{module_name}.{klass}\n  {class_directives}' for klass in classes)
+        f".. autoclass:: wrenfold.{module_name}.{klass}\n  {class_directives}" for klass in classes
+    )
 
-    contents = '\n\n'.join(parts)
-    contents += '\n'
+    contents = "\n\n".join(parts)
+    contents += "\n"
 
-    output_path = output_dir / f'{module_name}.rst'
-    with open(output_path, 'wb') as handle:
-        handle.write(contents.encode('utf-8'))
+    output_path = output_dir / f"{module_name}.rst"
+    with open(output_path, "wb") as handle:
+        handle.write(contents.encode("utf-8"))
 
 
 def main(args: argparse.Namespace):
@@ -73,28 +78,35 @@ def main(args: argparse.Namespace):
     generate_rst_for_module(module=geometry, module_name="geometry", output_dir=output_dir)
     generate_rst_for_module(module=ast, module_name="ast", output_dir=output_dir)
     generate_rst_for_module(
-        module=code_generation, module_name="code_generation", output_dir=output_dir)
+        module=code_generation, module_name="code_generation", output_dir=output_dir
+    )
     generate_rst_for_module(
-        module=sympy_conversion, module_name="sympy_conversion", output_dir=output_dir)
+        module=sympy_conversion, module_name="sympy_conversion", output_dir=output_dir
+    )
     generate_rst_for_module(
-        module=type_annotations, module_name="type_annotations", output_dir=output_dir)
+        module=type_annotations, module_name="type_annotations", output_dir=output_dir
+    )
     generate_rst_for_module(module=enumerations, module_name="enumerations", output_dir=output_dir)
     generate_rst_for_module(module=exceptions, module_name="exceptions", output_dir=output_dir)
     generate_rst_for_module(module=expressions, module_name="expressions", output_dir=output_dir)
     generate_rst_for_module(module=type_info, module_name="type_info", output_dir=output_dir)
     generate_rst_for_module(
-        module=external_functions, module_name="external_functions", output_dir=output_dir)
+        module=external_functions,
+        module_name="external_functions",
+        output_dir=output_dir,
+    )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '--output_dir',
+        "--output_dir",
         type=str,
-        help='Output directory write the RST file into.',
-        default=str(DOCS_DIR / "source" / "python_api"))
+        help="Output directory write the RST file into.",
+        default=str(DOCS_DIR / "source" / "python_api"),
+    )
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(parse_args())

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,18 +6,18 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'wrenfold'
-copyright = '2024, Wrenfold Authors'
-author = 'Gareth Cross'
+project = "wrenfold"
+copyright = "2024, Wrenfold Authors"
+author = "Gareth Cross"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-IMPORT_PATH_REPLACEMENTS = [('pywrenfold.', 'wrenfold.')]
+IMPORT_PATH_REPLACEMENTS = [("pywrenfold.", "wrenfold.")]
 
 
 def apply_replacements(string: str) -> str:
-    for (target, replacement) in IMPORT_PATH_REPLACEMENTS:
+    for target, replacement in IMPORT_PATH_REPLACEMENTS:
         string = string.replace(target, replacement)
     return string
 
@@ -47,8 +47,8 @@ def process_docstring(app, what, name, obj, options, lines):
 
 
 def setup(app):
-    app.connect('autodoc-process-signature', process_signature)
-    app.connect('autodoc-process-docstring', process_docstring)
+    app.connect("autodoc-process-signature", process_signature)
+    app.connect("autodoc-process-docstring", process_docstring)
 
 
 extensions = [
@@ -59,17 +59,17 @@ extensions = [
     # Breathe is used to convert C++ doxygen to sphinx.
     "breathe",
     # MyST enables inclusion of markdown.
-    "myst_parser"
+    "myst_parser",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'
-html_static_path = ['_static']
+html_theme = "furo"
+html_static_path = ["_static"]
 html_logo = "_static/logo.png"
 html_favicon = "_static/favicon.ico"
 

--- a/docs/source/quick_start_files/quick_start_script.py
+++ b/docs/source/quick_start_files/quick_start_script.py
@@ -11,9 +11,11 @@ def rosenbrock(
 ):
     """Evaluates the Rosenbrock function and its first derivative wrt `x` and `y`."""
     x, y = xy
-    f = (a - x) ** 2 + b * (y - x ** 2) ** 2
-    return (code_generation.ReturnValue(f),
-            code_generation.OutputArg(sym.jacobian([f], xy), name="f_D_xy"))
+    f = (a - x) ** 2 + b * (y - x**2) ** 2
+    return (
+        code_generation.ReturnValue(f),
+        code_generation.OutputArg(sym.jacobian([f], xy), name="f_D_xy"),
+    )
     # [function_def_end]
 
 

--- a/docs/source/reference/custom_types_script.py
+++ b/docs/source/reference/custom_types_script.py
@@ -1,6 +1,7 @@
 """
 Source code for the `custom_types.rst` file.
 """
+
 import dataclasses
 
 from wrenfold import ast, code_generation, sym, type_annotations, type_info
@@ -10,6 +11,7 @@ from wrenfold import ast, code_generation, sym, type_annotations, type_info
 @dataclasses.dataclass
 class Vec2:
     """Symbolic version of geo::vec2."""
+
     x: type_annotations.FloatScalar
     y: type_annotations.FloatScalar
 
@@ -36,14 +38,13 @@ def rotate_vector(angle: type_annotations.FloatScalar, v: Vec2):
     # We also want to return `Vec2`:
     return [
         code_generation.ReturnValue(Vec2.from_vector(v_rot)),
-        code_generation.OutputArg(Vec2.from_vector(v_rot_diff), name="v_rot_D_angle")
+        code_generation.OutputArg(Vec2.from_vector(v_rot_diff), name="v_rot_D_angle"),
     ]
     # [function_definition_end]
 
 
 # [code_generator_start]
 class CustomCppGenerator(code_generation.CppGenerator):
-
     def format_get_field(self, element: ast.GetField) -> str:
         """
         geo::vec2 members are private, so call the accessor method instead:
@@ -57,14 +58,13 @@ class CustomCppGenerator(code_generation.CppGenerator):
         Place our custom type into the `geo` namespace.
         """
         if element.python_type == Vec2:
-            return 'geo::vec2'
+            return "geo::vec2"
         return self.super_format(element)
         # [code_generator_end]
 
 
 # [rust_code_generator_start]
 class CustomRustGenerator(code_generation.RustGenerator):
-
     def format_get_field(self, element: ast.GetField) -> str:
         if element.struct_type.python_type == Vec2:
             return f"{self.format(element.arg)}.{element.field_name}()"
@@ -75,13 +75,13 @@ class CustomRustGenerator(code_generation.RustGenerator):
         Place our custom type into the `geo` crate.
         """
         if element.python_type == Vec2:
-            return 'geo::Vec2'
+            return "geo::Vec2"
         return self.super_format(element)
 
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
         if element.type.python_type == Vec2:
-            x = self.format(element.get_field_value('x'))
-            y = self.format(element.get_field_value('y'))
+            x = self.format(element.get_field_value("x"))
+            y = self.format(element.get_field_value("y"))
             return f"geo::Vec2::new({x}, {y})"
         return self.super_format(element)
         # [rust_code_generator_end]

--- a/docs/source/reference/external_functions_script.py
+++ b/docs/source/reference/external_functions_script.py
@@ -1,6 +1,7 @@
 """
 Source code for the `external_functions.rst` file.
 """
+
 from wrenfold import (
     ast,
     code_generation,
@@ -16,14 +17,16 @@ class LookupTable(type_annotations.Opaque):
     """
     A placeholder we will map to our actual type during the code-generation step.
     """
-    pass  #[lookup_table_end]
+
+    pass  # [lookup_table_end]
 
 
 # [interpolate_table_start]
 interpolate_table = external_functions.declare_external_function(
     name="interpolate_table",
     arguments=[("table", LookupTable), ("arg", type_annotations.FloatScalar)],
-    return_type=type_annotations.FloatScalar)  # [interpolate_table_end]
+    return_type=type_annotations.FloatScalar,
+)  # [interpolate_table_end]
 
 
 # [function_definition_start]
@@ -50,14 +53,13 @@ def lookup_angle(table: LookupTable, p_0: type_annotations.Vector2, p_1: type_an
 
 # [code_generator_start]
 class CustomCppGenerator(code_generation.CppGenerator):
-
     def format_call_external_function(self, element: ast.CallExternalFunction) -> str:
         """
         Place our external function in the ``utilities`` namespace.
         """
         if element.function == interpolate_table:
-            args = ', '.join(self.format(x) for x in element.args)
-            return f'utilities::{element.function.name}({args})'
+            args = ", ".join(self.format(x) for x in element.args)
+            return f"utilities::{element.function.name}({args})"
         return self.super_format(element)
 
     def format_custom_type(self, element: type_info.CustomType) -> str:
@@ -65,7 +67,7 @@ class CustomCppGenerator(code_generation.CppGenerator):
         Assume the lookup table is implemented as a std::vector<double>.
         """
         if element.python_type == LookupTable:
-            return 'std::vector<double>'
+            return "std::vector<double>"
         return self.super_format(element)
 
 

--- a/examples/bspline/bspline.py
+++ b/examples/bspline/bspline.py
@@ -146,14 +146,14 @@ def create_piecewise_polynomials(
             # one hot vector where the j'th zero order basis is active:
             values = [sym.zero] * len(degree_zero_bases)
             values[j + (order - 1)] = sym.one
-            key_and_value = list(zip(degree_zero_bases, values, strict=False))
+            key_and_value = list(zip(degree_zero_bases, values))
             interval_expressions.append(bases[i].subs(key_and_value))
 
         # Cumulative spline is 1 after its relevant interval:
         terminal_value = sym.integer(1 if is_cumulative else 0)
         piecewise_poly = terminal_value
 
-        for interval_index, poly_piece in zip(range(0, order), interval_expressions, strict=False):
+        for interval_index, poly_piece in zip(range(0, order), interval_expressions):
             # If the piece is 0 or 1 on this interval, we don't need another branch for it:
             if poly_piece == terminal_value:
                 continue

--- a/examples/bspline/bspline.py
+++ b/examples/bspline/bspline.py
@@ -13,6 +13,7 @@ To build the piecewise polynomials, we first construct the order `k` basis funct
 cox-de-boor formula. Then the polynomial segments for each sub-interval between uniformly spaced
 knots are combined into piecewise continuous (to derivative k - 1) polynomials.
 """
+
 import argparse
 import collections
 import typing as T
@@ -32,8 +33,13 @@ def weight(x: sym.Expr, i: int, k: int, knots: T.Sequence[sym.Expr]) -> sym.Expr
     return (x - knots[i]) / (knots[i + k] - knots[i])
 
 
-def B(x: sym.Expr, i: int, k: int, degree_zero: T.Sequence[sym.Expr],
-      knots: T.Sequence[sym.Expr]) -> sym.Expr:
+def B(
+    x: sym.Expr,
+    i: int,
+    k: int,
+    degree_zero: T.Sequence[sym.Expr],
+    knots: T.Sequence[sym.Expr],
+) -> sym.Expr:
     """
     Construct b-spline basis function `i` of order `k + 1` using the De-Boor recursive
     relation: https://en.wikipedia.org/wiki/B-spline#Definition
@@ -42,33 +48,41 @@ def B(x: sym.Expr, i: int, k: int, degree_zero: T.Sequence[sym.Expr],
     :param i: Index of the basis function.
     :param k: The degree of the resulting polynomial (1 = linear, 2 = quadratic, etc...)
     :param degree_zero: Symbolic values that represent the degree zero bases B(i, 0).
-    :param knots: Symbolic positions of the knots in the normalized interval [0, 1] (including repeated knots).
+    :param knots: Symbolic positions of the knots in the normalized interval [0, 1] (including
+      repeated knots).
     """
-    assert i >= 0, f'i = {i}'
-    assert k >= 0, f'k = {k}'
+    assert i >= 0, f"i = {i}"
+    assert k >= 0, f"k = {k}"
     if k == 0:
-        assert i < len(
-            degree_zero), f'Insufficient degree-zero bases. i = {i}, len = {len(degree_zero)}'
+        assert i < len(degree_zero), (
+            f"Insufficient degree-zero bases. i = {i}, len = {len(degree_zero)}"
+        )
         # B(i, 0)
         return degree_zero[i]
 
-    result = weight(x, i, k, knots) * B(x=x, i=i, k=k - 1, degree_zero=degree_zero, knots=knots) + \
-        (1 - weight(x, i + 1, k, knots)) * B(x=x, i=i + 1, k=k - 1, degree_zero=degree_zero, knots=knots)
+    result = weight(x, i, k, knots) * B(x=x, i=i, k=k - 1, degree_zero=degree_zero, knots=knots) + (
+        1 - weight(x, i + 1, k, knots)
+    ) * B(x=x, i=i + 1, k=k - 1, degree_zero=degree_zero, knots=knots)
 
     return result
 
 
-def create_bases(x: sym.Expr, knots: T.Sequence[sym.Expr], order: int,
-                 degree_zero_bases: T.Sequence[sym.Expr]) -> T.List[sym.Expr]:
+def create_bases(
+    x: sym.Expr,
+    knots: T.Sequence[sym.Expr],
+    order: int,
+    degree_zero_bases: T.Sequence[sym.Expr],
+) -> list[sym.Expr]:
     """
     Create the degree `order` b-spline basis functions.
 
     :param x: Variable in which to create the polynomials.
-    :param knots: Symbolic positions of the knots in the normalized interval [0, 1] (including repeated knots).
+    :param knots: Symbolic positions of the knots in the normalized interval [0, 1] (including
+      repeated knots).
     :param order: Order of the b-spline.
     :param degree_zero_bases: Symbolic values that represent the degree zero bases B(i, 0).
     """
-    bases: T.List[sym.Expr] = []
+    bases: list[sym.Expr] = []
     for i in range(0, len(knots) - order):
         b_func = B(x=x, i=i, k=order - 1, degree_zero=degree_zero_bases, knots=knots)
         b_func = b_func.distribute().collect(degree_zero_bases)
@@ -77,8 +91,12 @@ def create_bases(x: sym.Expr, knots: T.Sequence[sym.Expr], order: int,
     return bases
 
 
-def create_cumulative_bases(number_of_knots: int, order: int, bases: T.Sequence[sym.Expr],
-                            degree_zero_bases: T.Sequence[sym.Expr]) -> T.List[sym.Expr]:
+def create_cumulative_bases(
+    number_of_knots: int,
+    order: int,
+    bases: T.Sequence[sym.Expr],
+    degree_zero_bases: T.Sequence[sym.Expr],
+) -> list[sym.Expr]:
     """
     Given the result of `create_bases`, form the cumulative b-spline basis functions.
 
@@ -87,7 +105,7 @@ def create_cumulative_bases(number_of_knots: int, order: int, bases: T.Sequence[
     :param order: Order of the b-spline.
     :param degree_zero_bases: Symbolic values that represent the degree zero bases B(i, 0).
     """
-    cumulative_bases: T.List[sym.Expr] = []
+    cumulative_bases: list[sym.Expr] = []
     for i in range(0, number_of_knots - order):
         b_sum = sym.zero
         for s in range(i, number_of_knots - order):
@@ -98,9 +116,13 @@ def create_cumulative_bases(number_of_knots: int, order: int, bases: T.Sequence[
     return cumulative_bases
 
 
-def create_piecewise_polynomials(x: sym.Expr, order: int, bases: T.Sequence[sym.Expr],
-                                 degree_zero_bases: T.Sequence[sym.Expr],
-                                 is_cumulative: bool) -> T.List[sym.Expr]:
+def create_piecewise_polynomials(
+    x: sym.Expr,
+    order: int,
+    bases: T.Sequence[sym.Expr],
+    degree_zero_bases: T.Sequence[sym.Expr],
+    is_cumulative: bool,
+) -> list[sym.Expr]:
     """
     Convert order `order` b-spline basis functions into `order` piecewise polynomials. The resulting
     expressions are piecewise functions over the interval `x` = [0, 1].
@@ -115,36 +137,38 @@ def create_piecewise_polynomials(x: sym.Expr, order: int, bases: T.Sequence[sym.
     # point `x` is located, between [0, order - 1].
     x_interval = sym.min(sym.floor(x * order), order - 1)
 
-    polynomials: T.List[sym.Expr] = []
+    polynomials: list[sym.Expr] = []
     for i in range(0, order + (order - 1)):
         # Create the segments that make up each piecewise polynomial. Each of these segments is a
         # polynomial that is active between two knots, and zero everywhere else.
-        interval_expressions: T.List[sym.Expr] = []
+        interval_expressions: list[sym.Expr] = []
         for j in range(0, order):
             # one hot vector where the j'th zero order basis is active:
             values = [sym.zero] * len(degree_zero_bases)
             values[j + (order - 1)] = sym.one
-            key_and_value = list(zip(degree_zero_bases, values))
+            key_and_value = list(zip(degree_zero_bases, values, strict=False))
             interval_expressions.append(bases[i].subs(key_and_value))
 
         # Cumulative spline is 1 after its relevant interval:
         terminal_value = sym.integer(1 if is_cumulative else 0)
         piecewise_poly = terminal_value
 
-        for interval_index, poly_piece in zip(range(0, order), interval_expressions):
+        for interval_index, poly_piece in zip(range(0, order), interval_expressions, strict=False):
             # If the piece is 0 or 1 on this interval, we don't need another branch for it:
             if poly_piece == terminal_value:
                 continue
             piecewise_poly = sym.where(
-                sym.eq(x_interval, interval_index), poly_piece, piecewise_poly)
+                sym.eq(x_interval, interval_index), poly_piece, piecewise_poly
+            )
 
         polynomials.append(piecewise_poly)
 
     return polynomials
 
 
-def create_polynomial_functions(x: sym.Expr, polynomials: T.Sequence[sym.Expr], order: int,
-                                is_cumulative: bool) -> T.List[code_generation.FunctionDescription]:
+def create_polynomial_functions(
+    x: sym.Expr, polynomials: T.Sequence[sym.Expr], order: int, is_cumulative: bool
+) -> list[code_generation.FunctionDescription]:
     """
     Convert the output of `create_basis_polynomials` into function code-generated functions
     that evaluate the polynomials, and their first `order - 2` derivatives.
@@ -154,31 +178,31 @@ def create_polynomial_functions(x: sym.Expr, polynomials: T.Sequence[sym.Expr], 
     :param polynomials: The result of `create_basis_polynomials`.
     :param is_cumulative: If true, assume the output is cumulative.
     """
-    descriptions: T.List[code_generation.FunctionDescription] = []
+    descriptions: list[code_generation.FunctionDescription] = []
     for i in range(0, len(polynomials)):
 
         def bspline(arg: FloatScalar, arg_scale: FloatScalar):
             # Output the function, plus (order - 2) derivatives that are continuous.
             # The last non-zero derivative is discontinuous.
-            rows = [polynomials[i].subs(x, arg)]
+            rows = [polynomials[i].subs(x, arg)]  # noqa: B023
             for _ in range(0, order - 2):
                 rows.append(rows[-1].diff(arg) * arg_scale)
 
             return [
-                code_generation.OutputArg(expression=sym.vector(*rows).transpose(), name=f"b_{i}")
+                code_generation.OutputArg(expression=sym.vector(*rows).transpose(), name=f"b_{i}")  # noqa: B023
             ]
 
         if is_cumulative:
-            name = f'bspline_cumulative_order{order}_poly_{i}'
+            name = f"bspline_cumulative_order{order}_poly_{i}"
         else:
-            name = f'bspline_order{order}_poly_{i}'
+            name = f"bspline_order{order}_poly_{i}"
         desc = code_generation.create_function_description(func=bspline, name=name)
         descriptions.append(desc)
 
     return descriptions
 
 
-def plot_polynomials(polynomials: T.List[sym.Expr], x: sym.Expr, order: int, num_knots: int):
+def plot_polynomials(polynomials: list[sym.Expr], x: sym.Expr, order: int, num_knots: int):
     """
     Plot the symbolic polynomial segments.
     """
@@ -186,7 +210,7 @@ def plot_polynomials(polynomials: T.List[sym.Expr], x: sym.Expr, order: int, num
     import matplotlib.pyplot as plt
     import numpy as np
 
-    cmap = plt.colormaps.get_cmap('hsv')
+    cmap = plt.colormaps.get_cmap("hsv")
 
     # Determine the width of intervals for the fundamental basis functions:
     base_interval_width = 1.0 / order
@@ -233,10 +257,10 @@ def plot_polynomials(polynomials: T.List[sym.Expr], x: sym.Expr, order: int, num
     for i, poly_vals in computed_polys.items():
         poly_vals = np.array(poly_vals)
         alpha = (i + 0.5) / float(total_num_bases)
-        plt.plot(poly_vals[:, 0], poly_vals[:, 1], label=f'Function {i}', color=cmap(alpha))
+        plt.plot(poly_vals[:, 0], poly_vals[:, 1], label=f"Function {i}", color=cmap(alpha))
 
     for k in np.linspace(0.0, 1.0, num_knots):
-        plt.axvline(x=k, linestyle=':', color='black')
+        plt.axvline(x=k, linestyle=":", color="black")
 
     plt.grid()
     plt.legend()
@@ -244,11 +268,12 @@ def plot_polynomials(polynomials: T.List[sym.Expr], x: sym.Expr, order: int, num
 
 
 def create_bspline_functions(
-        order: int, visualize: bool = False) -> T.List[code_generation.FunctionDescription]:
+    order: int, visualize: bool = False
+) -> list[code_generation.FunctionDescription]:
     """
     Construct function descriptions for an order `order` b-spline.
     """
-    assert order >= 2, f'order = {order}'
+    assert order >= 2, f"order = {order}"
 
     # Number of knots, not considering the repeated endpoints.
     n = order + 1
@@ -263,7 +288,7 @@ def create_bspline_functions(
 
     # Define the zero order bases as symbolic variables.
     # We will later substitute 0 or 1, depending on whether the interval is active.
-    degree_zero_bases = sym.symbols(f'b_{i}_0' for i in range(0, number_of_knots - 1))
+    degree_zero_bases = sym.symbols(f"b_{i}_0" for i in range(0, number_of_knots - 1))
 
     # Variable for the argument to the spline.
     x = sym.symbols("x")
@@ -273,24 +298,36 @@ def create_bspline_functions(
 
     # Cumulative b-spline basis functions:
     cumulative_bases = create_cumulative_bases(
-        number_of_knots=len(knots), order=order, bases=bases, degree_zero_bases=degree_zero_bases)
+        number_of_knots=len(knots),
+        order=order,
+        bases=bases,
+        degree_zero_bases=degree_zero_bases,
+    )
 
     # Convert the basis functions into piecewise continuous polynomials:
     polynomials = create_piecewise_polynomials(
-        x=x, order=order, bases=bases, degree_zero_bases=degree_zero_bases, is_cumulative=False)
+        x=x,
+        order=order,
+        bases=bases,
+        degree_zero_bases=degree_zero_bases,
+        is_cumulative=False,
+    )
 
     cumulative_polynomials = create_piecewise_polynomials(
         x=x,
         order=order,
         bases=cumulative_bases,
         degree_zero_bases=degree_zero_bases,
-        is_cumulative=True)
+        is_cumulative=True,
+    )
 
     # Create function descriptions that we can code-generate.
     descriptions = create_polynomial_functions(
-        x=x, polynomials=polynomials, order=order, is_cumulative=False)
+        x=x, polynomials=polynomials, order=order, is_cumulative=False
+    )
     descriptions += create_polynomial_functions(
-        x=x, polynomials=cumulative_polynomials, order=order, is_cumulative=True)
+        x=x, polynomials=cumulative_polynomials, order=order, is_cumulative=True
+    )
 
     # Set to true to visualize the polynomial pieces we are code-generating.
     if visualize:
@@ -322,11 +359,16 @@ def main(args: argparse.Namespace):
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--language", type=str, choices=["cpp", "rust"], required=True, help="Target language.")
+        "--language",
+        type=str,
+        choices=["cpp", "rust"],
+        required=True,
+        help="Target language.",
+    )
     parser.add_argument("--visualize", action="store_true", help="Plot stuff.")
     parser.add_argument("output", type=str, help="Output path")
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(parse_args())

--- a/examples/c_generation/c_generation.py
+++ b/examples/c_generation/c_generation.py
@@ -3,6 +3,7 @@ Generate some example functions in C:
 - Kannala-Brandt camera model (forward and backward projection).
 - A method that converts a rotation matrix to a quaternion.
 """
+
 import argparse
 import dataclasses
 
@@ -20,6 +21,7 @@ class quaternion_t:
     """
     The equivalent C-struct is declared in `c_span_types.h`.
     """
+
     w: type_annotations.FloatScalar
     x: type_annotations.FloatScalar
     y: type_annotations.FloatScalar
@@ -37,8 +39,11 @@ def quaternion_from_rotation_matrix(R: type_annotations.Matrix3):
 def main(args: argparse.Namespace):
     functions = [
         code_generation.generate_function(function, generator=CCodeGenerator())
-        for function in (kb_camera_projection_with_jacobians, kb_camera_unprojection_with_jacobians,
-                         quaternion_from_rotation_matrix)
+        for function in (
+            kb_camera_projection_with_jacobians,
+            kb_camera_unprojection_with_jacobians,
+            quaternion_from_rotation_matrix,
+        )
     ]
     code = C_PREAMBLE.format(code="\n\n".join(functions), header_name="C_GENERATION_EXAMPLE")
     code_generation.mkdir_and_write_file(code=code, path=args.output)

--- a/examples/cart_pole/cart_pole_dynamics.py
+++ b/examples/cart_pole/cart_pole_dynamics.py
@@ -141,7 +141,7 @@ def get_cart_double_pole_dynamics() -> T.Callable:
     )
 
     M_inv, m_symbols = get_mat_inverse(dim=3)
-    substitutions = list(zip(m_symbols, A.to_flat_list(), strict=False))
+    substitutions = list(zip(m_symbols, A.to_flat_list()))
 
     # Compute expressions for x'' = A(x, x')^-1 * f(x, x', u)
     x_ddot = M_inv.subs(substitutions) * f
@@ -157,8 +157,8 @@ def get_cart_double_pole_dynamics() -> T.Callable:
         """
         # We substitute `vel_states` first so that Derivative(x(t), t) is replaced first.
         # Then we can replace x(t).
-        states = list(zip([b_x, th_1, th_2], x[:3].to_flat_list(), strict=False))
-        vel_states = list(zip([b_x_dot, th_1_dot, th_2_dot], x[3:].to_flat_list(), strict=False))
+        states = list(zip([b_x, th_1, th_2], x[:3].to_flat_list()))
+        vel_states = list(zip([b_x_dot, th_1_dot, th_2_dot], x[3:].to_flat_list()))
 
         constants = [
             (m_b, params.m_b),

--- a/examples/cart_pole/cart_pole_dynamics.py
+++ b/examples/cart_pole/cart_pole_dynamics.py
@@ -80,14 +80,18 @@ def get_cart_double_pole_dynamics() -> T.Callable:
     # Compute kinetic energy. This is the sum of (1/2)*m*v^2 for all pieces.
     half = 1 / sym.integer(2)
     T: sym.Expr = (
-        half * m_b * b_dot.squared_norm() + half * m_1 * p_1_dot.squared_norm() +
-        half * m_2 * p_2_dot.squared_norm())
+        half * m_b * b_dot.squared_norm()
+        + half * m_1 * p_1_dot.squared_norm()
+        + half * m_2 * p_2_dot.squared_norm()
+    )
 
     # Simplify this a bit by eliminating: cos^2(x) + sin^2(x) --> 1
     T = (
-        T.distribute().collect([m_1, m_2, l_1, l_2, th_1_dot, th_2_dot]).subs(
-            (sym.cos(th_1) ** 2 + sym.sin(th_1) ** 2) / 2, half).subs(
-                (sym.cos(th_2) ** 2 + sym.sin(th_2) ** 2) / 2, half))
+        T.distribute()
+        .collect([m_1, m_2, l_1, l_2, th_1_dot, th_2_dot])
+        .subs((sym.cos(th_1) ** 2 + sym.sin(th_1) ** 2) / 2, half)
+        .subs((sym.cos(th_2) ** 2 + sym.sin(th_2) ** 2) / 2, half)
+    )
 
     # Compute potential energy. This is the sum of m*g*y for all pieces.
     V = g * m_1 * p_1[1] + g * m_2 * p_2[1]
@@ -101,14 +105,16 @@ def get_cart_double_pole_dynamics() -> T.Callable:
     q_th_2 = L.diff(th_2_dot)
 
     # Dissipative force due to friction on the base.
-    F_friction_base = (-mu_b * (m_1 + m_2 + m_b) * g * sym.tanh(b_x_dot / sym.max(v_mu_b, 1.0e-6)))
+    F_friction_base = -mu_b * (m_1 + m_2 + m_b) * g * sym.tanh(b_x_dot / sym.max(v_mu_b, 1.0e-6))
 
     # Dissipative _power_ due to air drag on the pendulum mass.
     # We use a `where` statement to guard against a singularity in the Jacobian.
-    D_air_mass_1 = ((sym.integer(1) / 6) * c_d * sym.where(p_1_dot.squared_norm() > 0,
-                                                           p_1_dot.norm() ** 3, 0))
-    D_air_mass_2 = ((sym.integer(1) / 6) * c_d * sym.where(p_2_dot.squared_norm() > 0,
-                                                           p_2_dot.norm() ** 3, 0))
+    D_air_mass_1 = (
+        (sym.integer(1) / 6) * c_d * sym.where(p_1_dot.squared_norm() > 0, p_1_dot.norm() ** 3, 0)
+    )
+    D_air_mass_2 = (
+        (sym.integer(1) / 6) * c_d * sym.where(p_2_dot.squared_norm() > 0, p_2_dot.norm() ** 3, 0)
+    )
     D_air_mass = D_air_mass_1 + D_air_mass_2
 
     # External force from the boundary spring:
@@ -116,21 +122,26 @@ def get_cart_double_pole_dynamics() -> T.Callable:
     F_s_left = k_s * sym.max(0, -x_s - b_x)
 
     # Form the Euler-Lagrange equations (each of these is equal to zero).
-    el_b = ((q_b.diff(t) - L.diff(b_x)).distribute() - u_b - F_friction_base - F_s_left -
-            F_s_right + D_air_mass.diff(b_x_dot))
-    el_th_1 = ((q_th_1.diff(t) - L.diff(th_1)).distribute() + D_air_mass.diff(th_1_dot))
-    el_th_2 = ((q_th_2.diff(t) - L.diff(th_2)).distribute() + D_air_mass.diff(th_2_dot))
+    el_b = (
+        (q_b.diff(t) - L.diff(b_x)).distribute()
+        - u_b
+        - F_friction_base
+        - F_s_left
+        - F_s_right
+        + D_air_mass.diff(b_x_dot)
+    )
+    el_th_1 = (q_th_1.diff(t) - L.diff(th_1)).distribute() + D_air_mass.diff(th_1_dot)
+    el_th_2 = (q_th_2.diff(t) - L.diff(th_2)).distribute() + D_air_mass.diff(th_2_dot)
 
     # Reformulate the Euler-Lagrange equations into form:
     #   A(x, x') * x'' = f(x, x', u)
     A, f = get_euler_lagrange_coefficients(
         euler_lagrange=[el_b, el_th_1, el_th_2],
-        second_derivatives=[b_x.diff(t, 2), th_1.diff(t, 2),
-                            th_2.diff(t, 2)],
+        second_derivatives=[b_x.diff(t, 2), th_1.diff(t, 2), th_2.diff(t, 2)],
     )
 
     M_inv, m_symbols = get_mat_inverse(dim=3)
-    substitutions = list(zip(m_symbols, A.to_flat_list()))
+    substitutions = list(zip(m_symbols, A.to_flat_list(), strict=False))
 
     # Compute expressions for x'' = A(x, x')^-1 * f(x, x', u)
     x_ddot = M_inv.subs(substitutions) * f
@@ -146,12 +157,23 @@ def get_cart_double_pole_dynamics() -> T.Callable:
         """
         # We substitute `vel_states` first so that Derivative(x(t), t) is replaced first.
         # Then we can replace x(t).
-        states = list(zip([b_x, th_1, th_2], x[:3].to_flat_list()))
-        vel_states = list(zip([b_x_dot, th_1_dot, th_2_dot], x[3:].to_flat_list()))
+        states = list(zip([b_x, th_1, th_2], x[:3].to_flat_list(), strict=False))
+        vel_states = list(zip([b_x_dot, th_1_dot, th_2_dot], x[3:].to_flat_list(), strict=False))
 
-        constants = [(m_b, params.m_b), (m_1, params.m_1), (m_2, params.m_2), (l_1, params.l_1),
-                     (l_2, params.l_2), (g, params.g), (mu_b, params.mu_b), (v_mu_b, params.v_mu_b),
-                     (c_d, params.c_d), (x_s, params.x_s), (k_s, params.k_s), (u_b, u)]
+        constants = [
+            (m_b, params.m_b),
+            (m_1, params.m_1),
+            (m_2, params.m_2),
+            (l_1, params.l_1),
+            (l_2, params.l_2),
+            (g, params.g),
+            (mu_b, params.mu_b),
+            (v_mu_b, params.v_mu_b),
+            (c_d, params.c_d),
+            (x_s, params.x_s),
+            (k_s, params.k_s),
+            (u_b, u),
+        ]
 
         x_ddot_subbed = x_ddot.subs(constants).subs(vel_states).subs(states)
         total_energy = (T + V).subs(constants).subs(vel_states).subs(states)
@@ -183,7 +205,8 @@ class CustomRustGenerator(code_generation.RustGenerator):
 
 def main():
     code = code_generation.generate_function(
-        func=get_cart_double_pole_dynamics(), generator=CustomRustGenerator())
+        func=get_cart_double_pole_dynamics(), generator=CustomRustGenerator()
+    )
     code = CustomRustGenerator.apply_preamble(code=code)
     code_generation.mkdir_and_write_file(code, sys.argv[1])
 

--- a/examples/cart_pole/cart_pole_test.py
+++ b/examples/cart_pole/cart_pole_test.py
@@ -153,7 +153,7 @@ class CartPoleTest(unittest.TestCase):
             D_sym = func_jit(x)["J_x"]
 
             # Tolerance is not amazing here, the use of float32 bites us a bit.
-            np.testing.assert_allclose(desired=jnp.squeeze(D_jax), actual=D_sym, rtol=3.5e-3)
+            np.testing.assert_allclose(desired=jnp.squeeze(D_jax), actual=D_sym, rtol=4.0e-3)
 
 
 if __name__ == "__main__":

--- a/examples/cart_pole/sympy_helpers.py
+++ b/examples/cart_pole/sympy_helpers.py
@@ -1,13 +1,12 @@
 import typing as T
 
 import sympy as sp
-
 from wrenfold import sym, sympy_conversion
 
 
 def get_euler_lagrange_coefficients(
-        euler_lagrange: T.List[sym.Expr],
-        second_derivatives: T.List[sym.Expr]) -> T.Tuple[sym.MatrixExpr, sym.MatrixExpr]:
+    euler_lagrange: list[sym.Expr], second_derivatives: list[sym.Expr]
+) -> tuple[sym.MatrixExpr, sym.MatrixExpr]:
     """
     Given the Euler-Lagrange equations, extract coefficients on `second_derivatives` so that
     we can write the system in the form:
@@ -37,7 +36,7 @@ def get_euler_lagrange_coefficients(
     return sym.matrix(A_rows), sym.matrix(b_rows)
 
 
-def get_mat_inverse(dim: int) -> T.Tuple[sym.MatrixExpr, T.List[sym.Expr]]:
+def get_mat_inverse(dim: int) -> tuple[sym.MatrixExpr, list[sym.Expr]]:
     """
     Use SymPy to get closed formed inverse for a matrix. This really only works for 2x2 and 3x3.
     """

--- a/examples/cart_pole/sympy_helpers.py
+++ b/examples/cart_pole/sympy_helpers.py
@@ -1,5 +1,3 @@
-import typing as T
-
 import sympy as sp
 from wrenfold import sym, sympy_conversion
 

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -12,7 +12,6 @@ interface with types in an existing codebase.
 
 import argparse
 import dataclasses
-import typing as T
 
 from wrenfold import ast, code_generation, sym, type_info
 from wrenfold.geometry import Quaternion

--- a/examples/custom_types/custom_types_gen.py
+++ b/examples/custom_types/custom_types_gen.py
@@ -34,7 +34,9 @@ class EigenQuaternion:
     w: FloatScalar
 
     def to_quaternion(self) -> Quaternion:
-        """Convert to the wrenfold quaternion type, so we can more easily manipulate symbolically."""
+        """
+        Convert to the wrenfold quaternion type, so we can more easily manipulate symbolically.
+        """
         return Quaternion(w=self.w, x=self.x, y=self.y, z=self.z)
 
     @staticmethod
@@ -58,7 +60,7 @@ class Pose3d:
     rotation: EigenQuaternion
     translation: Vector3
 
-    def to_flat_list(self) -> T.List[sym.Expr]:
+    def to_flat_list(self) -> list[sym.Expr]:
         """Flatten to a single list of expressions."""
         return self.rotation.to_quaternion().to_list() + self.translation.to_flat_list()
 
@@ -75,10 +77,12 @@ class Pose3d:
         """
         The 6x7 derivative of the right-tangent with respect to the 7 pose elements.
         """
-        return sym.diag([
-            self.rotation.to_quaternion().right_local_coordinates_derivative(),
-            sym.eye(3),
-        ])
+        return sym.diag(
+            [
+                self.rotation.to_quaternion().right_local_coordinates_derivative(),
+                sym.eye(3),
+            ]
+        )
 
     def inverse(self) -> "Pose3d":
         """
@@ -96,7 +100,8 @@ class Pose3d:
         Compute the pose obtained by right multiplying `other` onto `self`.
 
         If the input poses `self` and `other` are represented as 4x4 homogeneous transformation
-        matrices `A` and `B`, then the result of this method will correspond to the matrix C = A * B.
+        matrices `A` and `B`, then the result of this method will correspond to the matrix
+        C = A * B.
         """
         rot = self.rotation.to_quaternion() * other.rotation.to_quaternion()
         return Pose3d(
@@ -137,11 +142,13 @@ def transform_point(world_T_body: Pose3d, p_body: Point3d):
     :param p_body: A point in the right frame (body) of the input pose.
     """
     p_world = (
-        world_T_body.rotation.rotation_matrix() * p_body.to_vector() + world_T_body.translation)
+        world_T_body.rotation.rotation_matrix() * p_body.to_vector() + world_T_body.translation
+    )
 
     # Output some jacobians as well for good measure.
     p_world_D_pose = (
-        p_world.jacobian(world_T_body.to_flat_list()) * world_T_body.right_retract_derivative())
+        p_world.jacobian(world_T_body.to_flat_list()) * world_T_body.right_retract_derivative()
+    )
     p_world_D_p_body = p_world.jacobian(p_body.to_vector())
 
     # Custom types can be returned as well:
@@ -170,12 +177,16 @@ def compose_poses(a_T_b: Pose3d, b_T_c: Pose3d):
     # appropriately chain our derivatives with the mapping from our variables to the tangent
     # space we will use for retraction (the update step) in our optimization.
     composed_D_first = (
-        a_T_c.right_local_coordinates_derivative() *
-        sym.jacobian(a_T_c.to_flat_list(), a_T_b.to_flat_list()) * a_T_b.right_retract_derivative())
+        a_T_c.right_local_coordinates_derivative()
+        * sym.jacobian(a_T_c.to_flat_list(), a_T_b.to_flat_list())
+        * a_T_b.right_retract_derivative()
+    )
 
     composed_D_second = (
-        a_T_c.right_local_coordinates_derivative() *
-        sym.jacobian(a_T_c.to_flat_list(), b_T_c.to_flat_list()) * b_T_c.right_retract_derivative())
+        a_T_c.right_local_coordinates_derivative()
+        * sym.jacobian(a_T_c.to_flat_list(), b_T_c.to_flat_list())
+        * b_T_c.right_retract_derivative()
+    )
 
     return [
         code_generation.ReturnValue(a_T_c),
@@ -185,7 +196,6 @@ def compose_poses(a_T_b: Pose3d, b_T_c: Pose3d):
 
 
 class CustomCppGenerator(code_generation.CppGenerator):
-
     def format_get_field(self, element: ast.GetField) -> str:
         """
         Customize access to struct Pose3. We assume that the pose type has functions to access each
@@ -200,14 +210,14 @@ class CustomCppGenerator(code_generation.CppGenerator):
         if element.python_type in [Point3d, Pose3d]:
             return f"geo::{element.name}"
         elif element.python_type == EigenQuaternion:
-            return f"Eigen::Quaternion<double>"
+            return "Eigen::Quaternion<double>"
         return self.super_format(element)
 
     def format_construct_matrix(self, element: ast.ConstructMatrix) -> str:
         """
-        By default, wrenfold passes input and output matrices as spans. If we want to return a matrix,
-        we need to override this method and help the code-generator emit constructor syntax suitable
-        to our chosen types.
+        By default, wrenfold passes input and output matrices as spans. If we want to return a
+        matrix, we need to override this method and help the code-generator emit constructor syntax
+        suitable to our chosen types.
         """
         # For the small vector that we care about, this syntax works.
         formatted_args = ", ".join(self.format(x) for x in element.args)
@@ -216,18 +226,16 @@ class CustomCppGenerator(code_generation.CppGenerator):
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
         if element.type.python_type == EigenQuaternion:
             # Eigen quaternion expects constructor args in order (w, x, y, z)
-            arg_dict = {
-                f.name: element.get_field_value(f.name) for f in element.type.fields
-            }
+            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ", ".join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
-            # We normalize numerically on construction, rather than symbolically. This avoids introducing
-            # superfluous operations into the symbolic math tree, which saves on generated operations.
+            # We normalize numerically on construction, rather than symbolically. This avoids
+            # introducing superfluous operations into the symbolic math tree, which saves on
+            # generated operations.
             return f"Eigen::Quaternion<double>{{{formatted_args}}}.normalized()"
         return self.super_format(element)
 
 
 class CustomRustGenerator(code_generation.RustGenerator):
-
     def format_get_field(self, element: ast.GetField) -> str:
         """
         Use member accessors for the Pose3 type.
@@ -248,27 +256,30 @@ class CustomRustGenerator(code_generation.RustGenerator):
         if element.python_type in [Point3d, Pose3d]:
             return f"crate::geo::{element.name}"
         elif element.python_type == EigenQuaternion:
-            return f"nalgebra::UnitQuaternion::<f64>"
+            return "nalgebra::UnitQuaternion::<f64>"
         return self.super_format(element)
 
     def format_construct_matrix(self, element: ast.ConstructMatrix) -> str:
         """Generate constructor syntax for nalgebra matrices."""
         formatted_args = ", ".join(self.format(x) for x in element.args)
-        return f"nalgebra::SMatrix::<f64, {element.type.rows}, {element.type.cols}>::new({formatted_args})"
+        rows, cols = element.type.rows, element.type.cols
+        return f"nalgebra::SMatrix::<f64, {rows}, {cols}>::new({formatted_args})"
 
     def format_construct_custom_type(self, element: ast.ConstructCustomType) -> str:
-        """Use a `new()` method for our Pose3 type, and the UnitQuaternion constructor for rotations."""
+        """
+        Use a `new()` method for our Pose3 type, and the UnitQuaternion constructor for rotations.
+        """
         if element.type.python_type == Pose3d:
             r = self.format(element.get_field_value("rotation"))
             t = self.format(element.get_field_value("translation"))
             return f"crate::geo::Pose3d::new(\n  {r},\n  {t}\n)"
         elif element.type.python_type == EigenQuaternion:
             # Order for nalgebra is [w, x, y, z]
-            arg_dict = {
-                f.name: element.get_field_value(f.name) for f in element.type.fields
-            }
+            arg_dict = {f.name: element.get_field_value(f.name) for f in element.type.fields}
             formatted_args = ", ".join(self.format(arg_dict[i]) for i in ("w", "x", "y", "z"))
-            return f"nalgebra::Unit::new_normalize(nalgebra::Quaternion::<f64>::new({formatted_args}))"
+            return (
+                f"nalgebra::Unit::new_normalize(nalgebra::Quaternion::<f64>::new({formatted_args}))"
+            )
         return self.super_format(element)
 
 
@@ -282,10 +293,10 @@ def main(args: argparse.Namespace):
     else:
         raise RuntimeError("Invalid language selection")
 
-    code = str()
+    code = ""
     for function in [transform_point, compose_poses]:
         code += code_generation.generate_function(func=function, generator=generator)
-        code += '\n\n'
+        code += "\n\n"
 
     code = generator.apply_preamble(code=code, **preamble_args)
     code_generation.mkdir_and_write_file(code=code, path=args.output)

--- a/examples/imu_integration/imu_integration.py
+++ b/examples/imu_integration/imu_integration.py
@@ -19,8 +19,8 @@ from wrenfold.type_annotations import FloatScalar, Vector3, Vector4
 
 
 def blockwise_jacobians(
-    output_states: T.Iterable[sym.MatrixExpr | Quaternion],
-    input_states: T.Iterable[sym.MatrixExpr | Quaternion],
+    output_states: T.Iterable[T.Union[sym.MatrixExpr, Quaternion]],
+    input_states: T.Iterable[T.Union[sym.MatrixExpr, Quaternion]],
 ) -> sym.MatrixExpr:
     jacobians = []
     for out_state in output_states:

--- a/examples/quaternion_interpolation/quaternion_interpolation.py
+++ b/examples/quaternion_interpolation/quaternion_interpolation.py
@@ -1,6 +1,7 @@
 """
 Generate quaternion interpolation with tangent-space derivatives using wrenfold.
 """
+
 import argparse
 
 from wrenfold import code_generation, sym
@@ -8,10 +9,9 @@ from wrenfold.geometry import Quaternion
 from wrenfold.type_annotations import FloatScalar, Vector4
 
 
-def quaternion_interpolation_impl(q0_xyzw: Vector4,
-                                  q1_xyzw: Vector4,
-                                  alpha: FloatScalar,
-                                  use_conditional: bool = True):
+def quaternion_interpolation_impl(
+    q0_xyzw: Vector4, q1_xyzw: Vector4, alpha: FloatScalar, use_conditional: bool = True
+):
     """
     Interpolate between two quaternions, `q0` and `q1` (passed as scalar-last vectors). The
     resulting expression is:
@@ -30,15 +30,20 @@ def quaternion_interpolation_impl(q0_xyzw: Vector4,
 
     # Scale the vector by alpha, then apply it on the _right_ side of q0.
     q_out = q0 * Quaternion.from_rotation_vector(
-        w01 * alpha, epsilon=1.0e-16 if use_conditional else None)
+        w01 * alpha, epsilon=1.0e-16 if use_conditional else None
+    )
 
     # Use chain-rule to map the Jacobians from the quaternion elements to the tangent space.
     D0 = (
-        q_out.right_local_coordinates_derivative() *
-        sym.jacobian(q_out.to_vector_wxyz(), q0.to_vector_wxyz()) * q0.right_retract_derivative())
+        q_out.right_local_coordinates_derivative()
+        * sym.jacobian(q_out.to_vector_wxyz(), q0.to_vector_wxyz())
+        * q0.right_retract_derivative()
+    )
     D1 = (
-        q_out.right_local_coordinates_derivative() *
-        sym.jacobian(q_out.to_vector_wxyz(), q1.to_vector_wxyz()) * q1.right_retract_derivative())
+        q_out.right_local_coordinates_derivative()
+        * sym.jacobian(q_out.to_vector_wxyz(), q1.to_vector_wxyz())
+        * q1.right_retract_derivative()
+    )
 
     return (
         code_generation.OutputArg(q_out.to_vector_xyzw(), name="q_out"),
@@ -56,7 +61,7 @@ def quaternion_interpolation_no_conditional(q0_xyzw: Vector4, q1_xyzw: Vector4, 
 
 
 def main(args: argparse.Namespace):
-    code = str()
+    code = ""
     generator = code_generation.CppGenerator()
     for function in [quaternion_interpolation, quaternion_interpolation_no_conditional]:
         code += code_generation.generate_function(function, generator=generator)

--- a/examples/rosenbrock/rosenbrock.py
+++ b/examples/rosenbrock/rosenbrock.py
@@ -17,8 +17,8 @@ def rosenbrock(
 
     # We formulate function `h(x, y)` such that f(x, y) = h^T * h = (a - x)**2 + b*(y - x**2)**2
     # Then we can find the minima by doing ordinary NLS on residual h(x, y)
-    h = sym.vector(a - x, sym.sqrt(b) * (y - x ** 2))
-    f, = h.T * h
+    h = sym.vector(a - x, sym.sqrt(b) * (y - x**2))
+    (f,) = h.T * h
 
     J = sym.jacobian(h, xy)
     return (

--- a/examples/rotation_error/rotation_error.py
+++ b/examples/rotation_error/rotation_error.py
@@ -40,7 +40,10 @@ def main(args: argparse.Namespace):
     code = code_generation.generate_function(func=rotation_error, generator=generator)
     code += "\n\n"
     code += code_generation.generate_function(
-        func=rotation_error, generator=eigen_generator, name=f"{rotation_error.__name__}_eigen")
+        func=rotation_error,
+        generator=eigen_generator,
+        name=f"{rotation_error.__name__}_eigen",
+    )
     code = generator.apply_preamble(code, namespace="gen", imports="#include <Eigen/Core>")
     code_generation.mkdir_and_write_file(code=code, path=args.output)
 

--- a/examples/shared_expressions.py
+++ b/examples/shared_expressions.py
@@ -5,11 +5,12 @@ Symbolic expressions that are shared among the provided examples.
 from wrenfold import code_generation, sym, type_annotations
 
 
-def kb_fisheye_distortion(theta: type_annotations.FloatScalar,
-                          coeffs: type_annotations.Vector4) -> sym.Expr:
+def kb_fisheye_distortion(
+    theta: type_annotations.FloatScalar, coeffs: type_annotations.Vector4
+) -> sym.Expr:
     """Evaluate the Kannala-Brandt fisheye distortion curve (theta -> radius)."""
     k1, k2, k3, k4 = coeffs
-    radius = theta * (1 + k1 * theta ** 2 + k2 * theta ** 4 + k3 * theta ** 6 + k4 * theta ** 8)
+    radius = theta * (1 + k1 * theta**2 + k2 * theta**4 + k3 * theta**6 + k4 * theta**8)
     return radius
 
 
@@ -44,7 +45,7 @@ def kb_fisheye_invert_distortion(
         error = r_predicted.subs(theta_sym, theta) - radius
         updated_theta = sym.max(theta - error / r_D_theta, 0)
 
-        if iteration + 1 < num_iters:
+        if iteration + 1 < num_iters:  # noqa: SIM108
             theta = sym.stop_derivative(updated_theta)
         else:
             # Only allow derivative to propagate on the final iteration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 name = "wrenfold"
 version = "0.3.0"
 requires-python = ">=3.9"
-authors = [
-    { name = "Gareth Cross", email = "gcross.code@icloud.com" },
-]
+authors = [{ name = "Gareth Cross", email = "gcross.code@icloud.com" }]
 description = "Tools for code-generating mathematical functions."
 license = { text = "MIT" }
 readme = "docs/PACKAGE_README.md"
@@ -24,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]
@@ -33,11 +31,7 @@ Repository = "https://github.com/wrenfold/wrenfold/"
 Issues = "https://github.com/wrenfold/wrenfold/issues"
 
 [build-system]
-requires = [
-    "scikit-build-core==0.10.7",
-    "cmake>=3.20",
-    "ninja>=1.5"
-]
+requires = ["scikit-build-core==0.10.7", "cmake>=3.20", "ninja>=1.5"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -54,21 +48,37 @@ wheel.license-files = [
     "LICENSE",
     "dependencies/abseil-cpp/LICENSE",
     "dependencies/fmt/LICENSE",
-    "dependencies/pybind11/LICENSE"
+    "dependencies/pybind11/LICENSE",
 ]
 build.verbose = true
 
 [tool.cibuildwheel]
 skip = ["*musllinux_*", "*-win32", "*_i686", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
-test-command = [
-    "python \"{package}/support/test_wheel.py\"",
-]
+test-command = ["python \"{package}/support/test_wheel.py\""]
 # To test interop, we need NumPy, SymPy and JAX.
 test-requires = ["numpy", "sympy", "jax"]
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-known_first_party = ["wrenfold", "pywrenfold", "test_base"]
-skip_glob = ["components/wrapper/stubs/*"]
+[tool.ruff]
+exclude = ["components/wrapper/stubs"]
+target-version = "py39"
+line-length = 100
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = false
+
+[tool.ruff.lint]
+select = [
+    "E", # pycodestyle
+    "F", # Pyflakes
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    "SIM", # flake8-simplify
+    "I", # isort
+]
+ignore = [
+    "F401", # Unused-imports.
+    "E731" # Use def instead of lambda.
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,5 @@ select = [
     "I", # isort
 ]
 ignore = [
-    "F401", # Unused-imports.
     "E731" # Use def instead of lambda.
 ]

--- a/support/code_coverage.py
+++ b/support/code_coverage.py
@@ -21,40 +21,46 @@ def main(args: argparse.Namespace):
     os.makedirs(str(output_dir), exist_ok=True)
 
     # Generate coverage summary:
-    subprocess.check_call([
-        "lcov",
-        "--gcov-tool",
-        args.gcov_tool,
-        "--directory",
-        str(build_dir),
-        "--capture",
-        "--output-file",
-        str(output_dir / "coverage.info"),
-    ])
+    subprocess.check_call(
+        [
+            "lcov",
+            "--gcov-tool",
+            args.gcov_tool,
+            "--directory",
+            str(build_dir),
+            "--capture",
+            "--output-file",
+            str(output_dir / "coverage.info"),
+        ]
+    )
 
     # Filter the summary:
-    subprocess.check_call([
-        "lcov",
-        "--gcov-tool",
-        args.gcov_tool,
-        "--remove",
-        str(output_dir / "coverage.info"),
-        "-o",
-        str(output_dir / "filtered.info"),
-        "/usr/include/*",
-        "/usr/lib/*",
-        "*/dependencies/*",
-        "*/core/tests/*",
-        "*/core/test_support/*",
-    ])
+    subprocess.check_call(
+        [
+            "lcov",
+            "--gcov-tool",
+            args.gcov_tool,
+            "--remove",
+            str(output_dir / "coverage.info"),
+            "-o",
+            str(output_dir / "filtered.info"),
+            "/usr/include/*",
+            "/usr/lib/*",
+            "*/dependencies/*",
+            "*/core/tests/*",
+            "*/core/test_support/*",
+        ]
+    )
 
     # Generate HTML report:
-    subprocess.check_call([
-        "genhtml",
-        str(output_dir / "filtered.info"),
-        "--output-directory",
-        str(output_dir),
-    ])
+    subprocess.check_call(
+        [
+            "genhtml",
+            str(output_dir / "filtered.info"),
+            "--output-directory",
+            str(output_dir),
+        ]
+    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/support/print_coverage.py
+++ b/support/print_coverage.py
@@ -1,6 +1,7 @@
 """
 Print the code-coverage percentage. Invoked from coverage.yml
 """
+
 import re
 import subprocess
 import sys
@@ -9,12 +10,12 @@ from pathlib import Path
 
 def main():
     output = subprocess.check_output(
-        ["lcov", "--gcov-tool", sys.argv[1], "--summary",
-         Path(sys.argv[2]).absolute()])
+        ["lcov", "--gcov-tool", sys.argv[1], "--summary", Path(sys.argv[2]).absolute()]
+    )
     output = output.decode("utf-8")
     # Pull the percentage coverage out:
     regex = re.compile(r"lines\.+:\s+([0-9.]+)\%", flags=re.IGNORECASE)
-    percentage, = regex.findall(output)
+    (percentage,) = regex.findall(output)
     print(f"{percentage}%")
 
 

--- a/support/test_wheel.py
+++ b/support/test_wheel.py
@@ -13,7 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent.absolute()
 
 
-def get_module_path(script_path: Path | str) -> str:
+def get_module_path(script_path: T.Union[Path, str]) -> str:
     if isinstance(script_path, str):
         script_path = Path(script_path)
     test_path = script_path.with_suffix("").relative_to(ROOT)

--- a/support/test_wheel.py
+++ b/support/test_wheel.py
@@ -13,7 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent.absolute()
 
 
-def get_module_path(script_path: T.Union[Path, str]) -> str:
+def get_module_path(script_path: Path | str) -> str:
     if isinstance(script_path, str):
         script_path = Path(script_path)
     test_path = script_path.with_suffix("").relative_to(ROOT)


### PR DESCRIPTION
- Adopt [ruff](https://docs.astral.sh/ruff/) for linting and formatting.
- Update pre-commit configuration.
- Format all python in new style.