### PR TITLE
Fix assertion caused by having duplicated output expressions with matrix type

### DIFF
--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -557,6 +557,17 @@ TEST(CppGenerationTest, TestExternalFunctionCall6) {
                     gen::external_function_call_6(-3.5, 4.75).to_vector(), 1.0e-15);
 }
 
+TEST(CppGenerationTest, TestExternalFunctionCall7) {
+  Eigen::Matrix2d a;
+  Eigen::Vector2d b;
+  gen::external_function_call_7(0.5, -0.21, a, b);
+
+  const Eigen::Vector2d v{0.5 - -0.21, 0.5 * 2 + -0.21};
+  ASSERT_EIGEN_NEAR(test::external_function_3<double>(v, v + Eigen::Vector2d(2.0, 5.0)), a,
+                    1.0e-15);
+  ASSERT_EIGEN_NEAR(v, b, 1.0e-15);
+}
+
 TEST(CppGenerationTest, TestIntegerArgument1) {
   using return_type = decltype(gen::integer_argument_1(1, 2.0));
   static_assert(std::is_same_v<return_type, double>);

--- a/components/core/tests/cpp_generation_test.cc
+++ b/components/core/tests/cpp_generation_test.cc
@@ -594,4 +594,11 @@ TEST(CppGenerationTest, TestIntegerStructMember2) {
   ASSERT_EQ(-1.3 - 5.0, b.value);
 }
 
+TEST(CppGenerationTest, TestDuplicateOutputMatrices) {
+  Eigen::Vector2d a{};
+  Eigen::Vector2d b{};
+  gen::duplicate_matrix_return(0.5, -0.3, OPT_OUTPUT(a), OPT_OUTPUT(b));
+  ASSERT_EIGEN_NEAR(a, b, 0.0);
+}
+
 }  // namespace wf

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -1214,4 +1214,29 @@ pub fn integer_struct_member_2<>(x: f64, y: f64) -> crate::types::MixedNumerics
   }
 }
 
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn duplicate_matrix_return<T2, T3, >(x: f64, y: f64, foo: Option<&mut T2>, bar: Option<&mut T3>) -> ()
+where
+  T2: wrenfold_traits::OutputSpan2D<2, 1, ValueType = f64>,
+  T3: wrenfold_traits::OutputSpan2D<2, 1, ValueType = f64>,
+{
+  // Operation counts:
+  // add: 1
+  // branch: 2
+  // multiply: 1
+  // total: 4
+  
+  let v001: f64 = y;
+  let v000: f64 = x;
+  if let Some(foo) = foo {
+    foo.set(0, 0, v000 + v001);
+    foo.set(1, 0, v000 * v001);
+  }
+  if let Some(bar) = bar {
+    bar.set(0, 0, v000 + v001);
+    bar.set(1, 0, v000 * v001);
+  }
+}
+
 

--- a/components/core/tests/rust_generation_test/src/generated.rs
+++ b/components/core/tests/rust_generation_test/src/generated.rs
@@ -1145,6 +1145,33 @@ pub fn external_function_call_6<>(x: f64, y: f64) -> crate::types::Point2d
 
 #[inline]
 #[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
+pub fn external_function_call_7<T2, T3, >(x: f64, y: f64, a: &mut T2, b: &mut T3) -> ()
+where
+  T2: wrenfold_traits::OutputSpan2D<2, 2, ValueType = f64>,
+  T3: wrenfold_traits::OutputSpan2D<2, 1, ValueType = f64>,
+{
+  // Operation counts:
+  // add: 4
+  // call: 1
+  // multiply: 1
+  // negate: 1
+  // total: 7
+  
+  let v000: f64 = x;
+  let v002: f64 = y;
+  let v025: f64 = v002 + v000 * (2i64) as f64;
+  let v024: f64 = v000 + -v002;
+  let v016: nalgebra::SMatrix<f64, 2, 2> = crate::external_functions::external_function_3(&nalgebra::SMatrix::<f64, 2, 1>::new(v024, v025), &nalgebra::SMatrix::<f64, 2, 1>::new((2i64) as f64 + v024, (5i64) as f64 + v025));
+  a.set(0, 0, v016[(0, 0)]);
+  a.set(0, 1, v016[(0, 1)]);
+  a.set(1, 0, v016[(1, 0)]);
+  a.set(1, 1, v016[(1, 1)]);
+  b.set(0, 0, v024);
+  b.set(1, 0, v025);
+}
+
+#[inline]
+#[allow(non_snake_case, clippy::unused_unit, clippy::collapsible_else_if, clippy::needless_late_init, unused_variables, unused_parens)]
 pub fn integer_argument_1<>(x: i64, y: f64) -> f64
 {
   // Operation counts:

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -321,4 +321,10 @@ inline auto integer_struct_member_2(scalar_expr x, scalar_expr y) {
   return out;
 }
 
+// Return two identical expressions.
+inline auto duplicate_matrix_return(scalar_expr x, scalar_expr y) {
+  ta::static_matrix<2, 1> v = make_vector(x + y, x * y);
+  return std::make_tuple(optional_output_arg("foo", v), optional_output_arg("bar", v));
+}
+
 }  // namespace wf

--- a/components/core/tests/test_expressions.h
+++ b/components/core/tests/test_expressions.h
@@ -282,6 +282,13 @@ inline auto external_function_call_6(scalar_expr x, scalar_expr y) {
   return external_function_4::call(p2);
 }
 
+// Call an external function with a matrix argument. Also return that matrix via output arg.
+inline auto external_function_call_7(scalar_expr x, scalar_expr y) {
+  auto v = make_vector(x - y, x * 2 + y);
+  return std::make_tuple(output_arg("a", external_function_3::call(v, v + make_vector(2, 5))),
+                         output_arg("b", ta::static_matrix<2, 1>(v)));
+}
+
 // Accept an integer argument for `x`.
 inline auto integer_argument_1(ta::int_scalar_expr x, scalar_expr y) { return x * y; }
 

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -58,6 +58,8 @@ std::string generate_test_expressions(Generator gen) {
                 arg("x"), arg("y"));
   generate_func(gen, code, &external_function_call_6, "external_function_call_6", arg("x"),
                 arg("y"));
+  generate_func(gen, code, &external_function_call_7, "external_function_call_7", arg("x"),
+                arg("y"));
   generate_func(gen, code, &integer_argument_1, "integer_argument_1", arg("x"), arg("y"));
   generate_func(gen, code, &integer_output_values_1, "integer_output_values_1", arg("x"), arg("y"));
   generate_func(gen, code, &integer_struct_member_1, "integer_struct_member_1", arg("inputs"),

--- a/components/core/tests/test_expressions_codegen.h
+++ b/components/core/tests/test_expressions_codegen.h
@@ -63,6 +63,7 @@ std::string generate_test_expressions(Generator gen) {
   generate_func(gen, code, &integer_struct_member_1, "integer_struct_member_1", arg("inputs"),
                 arg("scale"));
   generate_func(gen, code, &integer_struct_member_2, "integer_struct_member_2", arg("x"), arg("y"));
+  generate_func(gen, code, &duplicate_matrix_return, "duplicate_matrix_return", arg("x"), arg("y"));
   return code;
 }
 

--- a/components/core/wf/code_generation/ast_conversion.cc
+++ b/components/core/wf/code_generation/ast_conversion.cc
@@ -200,8 +200,9 @@ inline bool is_argument_read_operation(const ir::const_value_ptr val) {
 }
 
 inline bool is_output_matrix_construction(const ir::const_value_ptr val) {
-  const bool is_output = std::any_of(val->consumers().begin(), val->consumers().end(),
-                                     [](const auto& v) { return v->is_op<ir::save>(); });
+  const bool is_output =
+      std::any_of(val->consumers().begin(), val->consumers().end(),
+                  [](const ir::const_value_ptr& v) { return v->is_op<ir::save>(); });
   if (!is_output || !val->is_op<ir::construct>()) {
     return false;
   }

--- a/components/core/wf/code_generation/ast_conversion.h
+++ b/components/core/wf/code_generation/ast_conversion.h
@@ -65,7 +65,7 @@ class ast_form_visitor {
 
   // Create a `variable_ref` object with the name of the variable used to store `value`.
   ast::variable_ref make_variable_ref(const ir::const_value_ptr value) const {
-    WF_ASSERT(declared_values_.count(value), "value = {}", value);
+    WF_ASSERT(declared_values_.contains(value), "value = {}", value);
     return ast::variable_ref{format_variable_name(value)};
   }
 

--- a/components/core/wf/code_generation/ir_form_visitor.cc
+++ b/components/core/wf/code_generation/ir_form_visitor.cc
@@ -98,11 +98,11 @@ ir::value_ptr ir_form_visitor::operator()(const external_function_invocation& in
         // Type check the argument, and cast scalars.
         const auto& expected_type = f.argument_at(index).type();
         return std::visit(
-            [&](const auto& expected, const auto& actual) -> ir::value_ptr {
-              if constexpr (!std::is_same_v<decltype(expected), decltype(actual)>) {
+            [&]<typename T0, typename T1>(const T0& expected, const T1& actual) -> ir::value_ptr {
+              if constexpr (!std::is_same_v<T0, T1>) {
                 WF_ASSERT_ALWAYS("Mismatched argument types. Expected: {}, Actual: {}", expected,
                                  actual);
-              } else if constexpr (std::is_same_v<decltype(expected), const scalar_type&>) {
+              } else if constexpr (std::is_same_v<T0, scalar_type>) {
                 return maybe_cast(val, expected.numeric_type());
               }
               return val;
@@ -242,8 +242,7 @@ ir::value_ptr ir_form_visitor::operator()(const multiplication& mul) {
 
   // If the multiplication contains a negative integer, then negate it and put -1 in.
   // This facilitates identifying more common terms.
-  if (const auto it = std::find_if(mul_terms.begin(), mul_terms.end(), is_negative_integer);
-      it != mul_terms.end()) {
+  if (const auto it = std::ranges::find_if(mul_terms, is_negative_integer); it != mul_terms.end()) {
     *it = -*it;
     mul_terms.push_back(constants::negative_one);
   }
@@ -404,7 +403,7 @@ ir::value_ptr ir_form_visitor::operator()(const undefined&) const {
   throw type_error("Cannot generate code with expressions containing: {}", undefined::name_str);
 }
 
-ir::value_ptr ir_form_visitor::operator()(const unique_variable& var) {
+ir::value_ptr ir_form_visitor::operator()(const unique_variable& var) const {
   throw type_error(
       "Cannot generate code containing unique variable: {} (Did you intend to substitute something "
       "for this variable?)",

--- a/components/core/wf/code_generation/ir_form_visitor.h
+++ b/components/core/wf/code_generation/ir_form_visitor.h
@@ -70,7 +70,7 @@ class ir_form_visitor {
   ir::value_ptr operator()(const symbolic_function_invocation& invocation) const;
   ir::value_ptr operator()(const undefined&) const;
   ir::value_ptr operator()(const unevaluated& u);
-  ir::value_ptr operator()(const unique_variable& var);
+  ir::value_ptr operator()(const unique_variable& var) const;
   ir::value_ptr operator()(const variable& var);
 
   // Apply to any expression.


### PR DESCRIPTION
When two output matrices have identical expressions, an assertion would trigger during code generation because the output type of the expression was no longer `ast::construct_matrix` (but rather `variable_ref`). This fix works around this issue by preventing output matrices from being de-duplicated in this case, rather the matrix is constructed twice.