### PR TITLE
Fix bug where return type annotations were incorrect when `use_output_arguments=True`

### DIFF
--- a/components/core/wf/code_generation/python_code_generator.cc
+++ b/components/core/wf/code_generation/python_code_generator.cc
@@ -265,7 +265,7 @@ std::string python_code_generator::operator()(const ast::function_signature& sig
   }
 
   std::vector<std::string> output_arg_ret_annotations;
-  if (use_output_arguments_) {
+  if (!use_output_arguments_) {
     output_arg_ret_annotations.reserve(signature.num_arguments());
     for (const auto& arg : signature.arguments()) {
       if (!arg.is_input()) {
@@ -498,8 +498,11 @@ std::string python_code_generator::operator()(const ast::negate& x) const {
 std::string python_code_generator::operator()(const ast::optional_output_branch& x) const {
   std::string result = use_output_arguments_ ? fmt::format("if {} is not None:", x.arg.name())
                                              : fmt::format("if compute_{}:", x.arg.name());
-  join_and_indent(result, indent_, "\n", "\n", "\n", x.statements, *this);
-  fmt::format_to(std::back_inserter(result), "else:\n{:{}}{} = None", "", indent_, x.arg.name());
+  join_and_indent(result, indent_, "\n", !use_output_arguments_ ? "\n" : "", "\n", x.statements,
+                  *this);
+  if (!use_output_arguments_) {
+    fmt::format_to(std::back_inserter(result), "else:\n{:{}}{} = None", "", indent_, x.arg.name());
+  }
   return result;
 }
 

--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -327,6 +327,8 @@ def generate_python(
       Because python lacks formal "output arguments", any symbolic outputs tagged as
       :class:`wrenfold.code_generation.OutputArg` will instead be **returned** from the generated
       function as elements of a tuple. The example listing below illustrates this behavior.
+      When targeting NumPy, this behavior can be changed by passing ``use_output_arguments=True``
+      to :class:`wrenfold.code_generation.PythonGenerator`.
 
       **Additionally**, remember that your target framework may not be able to reason about your
       custom types. For example,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
 
-    "License :: OSI Approved :: MIT License",
-
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Software Development :: Code Generators",
 


### PR DESCRIPTION
- Fix bug introduced in https://github.com/wrenfold/wrenfold/pull/334 and add a test to catch this in future.