### PR TITLE
Fix literal operator syntax

### DIFF
--- a/components/core/wf/expression.h
+++ b/components/core/wf/expression.h
@@ -177,10 +177,10 @@ precedence get_precedence(const scalar_expr& expr);
 
 // Custom literal suffix support.
 namespace custom_literals {
-inline scalar_expr operator"" _s(const unsigned long long int arg) {
+inline scalar_expr operator""_s(const unsigned long long int arg) {
   return scalar_expr{checked_int::from_unsigned_long_long(arg)};
 }
-inline scalar_expr operator"" _s(const long double arg) { return scalar_expr{arg}; }
+inline scalar_expr operator""_s(const long double arg) { return scalar_expr{arg}; }
 }  // namespace custom_literals
 
 // Create a tuple of `scalar_expr` from string arguments.

--- a/components/core/wf/utility/checked_int.h
+++ b/components/core/wf/utility/checked_int.h
@@ -96,7 +96,7 @@ class checked_int final {
 };
 
 // Custom literal suffix.
-constexpr checked_int operator"" _chk(unsigned long long int arg) {
+constexpr checked_int operator""_chk(unsigned long long int arg) {
   return checked_int::from_unsigned_long_long(arg);
 }
 


### PR DESCRIPTION
- Whitespace in literal operator syntax is deprecated by clang.