### PR TITLE
Fix heaviside conversion

### DIFF
--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -142,7 +142,7 @@ class Conversions:
         we need to use two conditionals here to match it.
         """
         x, zero_val = self(expr.args[0]), self(expr.args[1])
-        return sym.where(x > 0, 1, sym.where(x < 0, -1, zero_val))
+        return sym.where(x > 0, 1, sym.where(x < 0, 0, zero_val))
 
     def convert_derivative(self, expr) -> sym.Expr:
         """

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -280,11 +280,11 @@ class SympyConversionTest(MathTestBase):
         x = sym.symbol("x")
         # sympy --> wf
         self.assertIdenticalFromSp(
-            sym.where(x > 0, 1, sym.where(x < 0, -1, sym.rational(1, 2))),
+            sym.where(x > 0, 1, sym.where(x < 0, 0, sym.rational(1, 2))),
             sp.Heaviside(spy(x)),
         )
         self.assertIdenticalFromSp(
-            sym.where(x > 0, 1, sym.where(x < 0, -1, sym.nan)),
+            sym.where(x > 0, 1, sym.where(x < 0, 0, sym.nan)),
             sp.Heaviside(spy(x), sp.nan),
         )
 


### PR DESCRIPTION
`sympy.Heaviside(x)` is defined as 0 for `x < 0`, 1 for `x > 0`, and H0 at `x = 0`