### PR TITLE
Add option to omit Python assert messages

### DIFF
--- a/components/core/wf/code_generation/python_code_generator.cc
+++ b/components/core/wf/code_generation/python_code_generator.cc
@@ -100,10 +100,11 @@ inline std::string format_scalar_type_cast(const python_generator_target target,
 
 python_code_generator::python_code_generator(python_generator_target target,
                                              python_generator_float_width float_width, int indent,
-                                             bool use_output_arguments)
+                                             bool use_output_arguments, bool include_assert_message)
     : target_(target),
       float_width_(float_width),
       use_output_arguments_(use_output_arguments),
+      include_assert_message_(include_assert_message),
       indent_(static_cast<std::size_t>(indent)) {
   if (indent < 1) {
     throw wf::invalid_argument_error("Indentation must be >= 1. Provided value: {}", indent);
@@ -493,11 +494,13 @@ std::string python_code_generator::operator()(const ast::optional_output_branch&
   if (use_output_arguments_) {
     fmt::format_to(std::back_inserter(result), "if {} is not None:", x.arg.name());
     if (const matrix_type* mat = std::get_if<matrix_type>(&x.arg.type()); mat != nullptr) {
-      fmt::format_to(std::back_inserter(result),
-                     "\n{:{}}assert {}.size == {}, f\"Matrix {} should have {} elements, but it "
-                     "has {{{}.size}}\"",
-                     "", indent_, x.arg.name(), mat->size(), x.arg.name(), mat->size(),
-                     x.arg.name());
+      fmt::format_to(std::back_inserter(result), "\n{:{}}assert {}.size == {}", "", indent_,
+                     x.arg.name(), mat->size());
+      if (include_assert_message_) {
+        fmt::format_to(std::back_inserter(result),
+                       ", f\"Matrix {} should have {} elements, but it has {{{}.size}}\"",
+                       x.arg.name(), mat->size(), x.arg.name());
+      }
     }
   } else {
     fmt::format_to(std::back_inserter(result), "if compute_{}:", x.arg.name());

--- a/components/core/wf/code_generation/python_code_generator.h
+++ b/components/core/wf/code_generation/python_code_generator.h
@@ -30,7 +30,7 @@ class python_code_generator {
  public:
   explicit python_code_generator(python_generator_target target,
                                  python_generator_float_width float_width, int indent,
-                                 bool use_output_arguments);
+                                 bool use_output_arguments, bool include_assert_message);
 
   virtual ~python_code_generator() = default;
 
@@ -115,6 +115,7 @@ class python_code_generator {
   python_generator_target target_;
   python_generator_float_width float_width_;
   bool use_output_arguments_;
+  bool include_assert_message_;
   std::size_t indent_;
 
   // Create a fmt_view. All args will be forwarded back to the operator on this class that matches

--- a/components/wrapper/pywrenfold/code_formatting_wrapper.cc
+++ b/components/wrapper/pywrenfold/code_formatting_wrapper.cc
@@ -341,10 +341,11 @@ void wrap_code_formatting_operations(py::module_& m) {
              "Float arrays/tensors will be interpreted as float64.");
 
   wrap_code_generator<python_code_generator>(m, "PythonGenerator")
-      .def(py::init<python_generator_target, python_generator_float_width, int, bool>(),
+      .def(py::init<python_generator_target, python_generator_float_width, int, bool, bool>(),
            py::arg("target") = python_generator_target::numpy,
            py::arg("float_width") = python_generator_float_width::float64,
            py::arg("indentation") = 4, py::arg("use_output_arguments") = false,
+           py::arg("include_assert_message") = true,
            docstrings::python_generator_constructor.data())
       .def_prop_ro(
           "target",

--- a/components/wrapper/pywrenfold/docs/code_formatting_wrapper.h
+++ b/components/wrapper/pywrenfold/docs/code_formatting_wrapper.h
@@ -17,6 +17,9 @@ Args:
     Python. When ``use_output_arguments=True``, matrix-type output arguments will become actual
     output arguments in the generated code. Optional outputs will have type ``np.ndarray | None``.
     This mode is only supported with ``target=NumPy``, and is untested in other configurations.
+  include_assert_message: Include a descriptive message in assertions that validate the size of
+    optional output arguments. Disable this to reduce recursion depth when compiling generated code
+    with Numba.
 )doc";
 
 }  // namespace wf::docstrings

--- a/components/wrapper/stubs/pywrenfold/gen.pyi
+++ b/components/wrapper/stubs/pywrenfold/gen.pyi
@@ -1349,7 +1349,7 @@ class PythonGeneratorFloatWidth(enum.Enum):
 class PythonGenerator:
     """Generates Python code. Can target NumPy, PyTorch, or JAX."""
 
-    def __init__(self, target: PythonGeneratorTarget = PythonGeneratorTarget.NumPy, float_width: PythonGeneratorFloatWidth = PythonGeneratorFloatWidth.Float64, indentation: int = 4, use_output_arguments: bool = False) -> None:
+    def __init__(self, target: PythonGeneratorTarget = PythonGeneratorTarget.NumPy, float_width: PythonGeneratorFloatWidth = PythonGeneratorFloatWidth.Float64, indentation: int = 4, use_output_arguments: bool = False, include_assert_message: bool = True) -> None:
         """
         Construct a python code generator.
 
@@ -1361,6 +1361,9 @@ class PythonGenerator:
             Python. When ``use_output_arguments=True``, matrix-type output arguments will become actual
             output arguments in the generated code. Optional outputs will have type ``np.ndarray | None``.
             This mode is only supported with ``target=NumPy``, and is untested in other configurations.
+          include_assert_message: Include a descriptive message in assertions that validate the size of
+            optional output arguments. Disable this to reduce recursion depth when compiling generated code
+            with Numba.
         """
 
     @overload

--- a/components/wrapper/tests/python_code_generation_test.py
+++ b/components/wrapper/tests/python_code_generation_test.py
@@ -968,6 +968,15 @@ def test_numpy_type_annotations():
         or str(spec.annotations["bar"]) == "np.ndarray | None"
     )
 
+    assert 'assert bar.size == 9, f"Matrix bar should have 9 elements' in _code
+
+    _, code_without_assert_message = wf.generate_python(
+        sym1,
+        generator=wf.PythonGenerator(use_output_arguments=True, include_assert_message=False),
+    )
+    assert "assert bar.size == 9\n" in code_without_assert_message
+    assert "Matrix bar should have 9 elements" not in code_without_assert_message
+
 
 def main():
     # TODO: Find a better way to test the different permutations.


### PR DESCRIPTION
## Summary

  - Add an include_assert_message option to PythonGenerator.
  - Allow generated optional-output size assertions to omit their descriptive f-string.
  - Preserve the existing behavior by default with include_assert_message=True.
  - Update Python bindings, type stubs, documentation, and tests.

  ## Motivation

  Numba requires a higher Python recursion limit when compiling generated NumPy code containing assert messages expressed as f-strings. Omitting the message substantially reduces this recursion requirement.

  Users can now generate message-free assertions with:
```py
  wf.PythonGenerator(
      use_output_arguments=True,
      include_assert_message=False,
  )
```
  This produces:

  `assert output.size == expected_size`

  instead of:

  `assert output.size == expected_size, f"..."`