### PR TITLE
Fix postponed Python annotations

### DIFF
--- a/components/python/wrenfold/code_generation.py
+++ b/components/python/wrenfold/code_generation.py
@@ -131,15 +131,16 @@ def create_function_description(
         }
     """
     spec = inspect.getfullargspec(func=func)
+    annotations = typing.get_type_hints(func, include_extras=True)
     description = FunctionDescription(name=name or func.__name__)
 
     cached_types: dict[type, type_info.CustomType] = dict()
     kwargs = dict()
     for arg_name in spec.args:
-        if arg_name not in spec.annotations:
+        if arg_name not in annotations:
             raise KeyError(f"Missing type annotation for argument: {arg_name}")
         # Map argument types to something the code-generation logic can understand:
-        annotated_type = spec.annotations[arg_name]
+        annotated_type = annotations[arg_name]
         arg_type = custom_types.convert_to_internal_type(
             python_type=annotated_type,
             cached_custom_types=cached_types,

--- a/components/python/wrenfold/custom_types.py
+++ b/components/python/wrenfold/custom_types.py
@@ -86,10 +86,11 @@ def _create_custom_type(
     """
     fields_converted: list[tuple[str, CodegenType]] = []
     if dataclasses.is_dataclass(python_type):
+        annotations = typing.get_type_hints(python_type, include_extras=True)
         # noinspection PyDataclass
         for field in dataclasses.fields(python_type):
             field_type = convert_to_internal_type(
-                python_type=field.type,
+                python_type=annotations[field.name],
                 cached_custom_types=cached_custom_types,
                 context=f"Dataclass field `{field.name}` on type `{python_type}`",
             )

--- a/components/wrapper/tests/codegen_wrapper_test.py
+++ b/components/wrapper/tests/codegen_wrapper_test.py
@@ -6,6 +6,8 @@ examples are also run as tests - these offer a lot more diverse coverage. The pu
 test is just to validate that the wrapper works and exposes the correct members.
 """
 
+from __future__ import annotations
+
 import dataclasses
 import typing
 import unittest


### PR DESCRIPTION
## Summary

  Fix support for postponed Python annotations enabled by:

  `from __future__ import annotations`

  Function and dataclass annotations were previously read directly, leaving them as strings that Wrenfold could not convert into internal code-generation types.

  ## Changes

  - Resolve function annotations with typing.get_type_hints().
  - Resolve custom dataclass field annotations similarly.
  - Preserve typing.Annotated metadata using include_extras=True.
  - Enable postponed annotations in the code-generation wrapper tests for regression coverage.
