### PR TITLE
Fix incomplete SymPy Piecewise conversion

### DIFF
--- a/components/python/wrenfold/sympy_conversion.py
+++ b/components/python/wrenfold/sympy_conversion.py
@@ -116,12 +116,19 @@ class Conversions:
         """
         if len(expr.args) == 2:
             # If the output values are one and zero, this is equivalent to the iverson bracket.
-            (true_val, cond), (false_val, _) = expr.args
-            if true_val == 1 and false_val == 0:
+            (true_val, cond), (false_val, false_cond) = expr.args
+            if true_val == 1 and false_val == 0 and false_cond == self.sp.true:
                 return sym.iverson(self(cond))
 
-        output = self(expr.args[-1][0])
-        for val, cond in reversed(expr.args[:-1]):
+        final_val, final_cond = expr.args[-1]
+        if final_cond == self.sp.true:
+            output = self(final_val)
+            conditional_args = expr.args[:-1]
+        else:
+            output = sym.nan
+            conditional_args = expr.args
+
+        for val, cond in reversed(conditional_args):
             output = sym.where(self(cond), self(val), output)
         return output
 

--- a/components/wrapper/tests/sympy_conversion_test.py
+++ b/components/wrapper/tests/sympy_conversion_test.py
@@ -256,12 +256,24 @@ class SympyConversionTest(MathTestBase):
             sp.Piecewise((sp.cos(spy(x)), spy(x <= y + 2)), (sp.sin(spy(y)) * 2, True)),
         )
 
+        # A Piecewise expression without an unconditional final branch evaluates to nan when no
+        # condition matches.
+        self.assertIdenticalFromSp(sym.where(x > 0, x, sym.nan), sp.Piecewise((spy(x), spy(x > 0))))
+        self.assertIdenticalFromSp(
+            sym.where(x > 0, x, sym.where(x < 0, y, sym.nan)),
+            sp.Piecewise((spy(x), spy(x > 0)), (spy(y), spy(x < 0))),
+        )
+
     def test_iverson_bracket(self):
         x, y = sym.make_symbols("x", "y")
         self.assertEqualSp(sp.Piecewise((1, spy(x < y)), (0, True)), sym.iverson(x < y))
 
         # sympy --> wf
         self.assertIdenticalFromSp(sym.iverson(x < y), sp.Piecewise((1, spy(x < y)), (0, True)))
+        self.assertIdenticalFromSp(
+            sym.where(x < y, 1, sym.where(x > y, 0, sym.nan)),
+            sp.Piecewise((1, spy(x < y)), (0, spy(x > y))),
+        )
 
     def test_min_max(self):
         x, y = sym.make_symbols("x", "y")


### PR DESCRIPTION
## Summary

  Fix conversion of SymPy `Piecewise` expressions that do not contain an unconditional fallback branch.

  Previously, the final branch value was always treated as the fallback, causing its condition to be ignored. Incomplete expressions such as:

  ```python
  sp.Piecewise((x, x > 0))
```

  were therefore converted to plain x instead of evaluating to nan when no condition matched.

  This change:

  - uses `sym.nan` as the fallback when the final branch is conditional
  - preserves every branch in first-matching order
  - retains the existing behavior for an unconditional final branch
  - applies the 1/0 iverson optimization only when the zero branch is unconditional

  ## Tests

  Added regression coverage for:

  - a single incomplete branch
  - multiple incomplete branches
  - complete piecewise expressions
  - complete 1/0 iverson conversion
  - a conditional zero branch that must not use the iverson optimization