### PR TITLE
Detect untracked generated Python stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Check stubs for diff
         working-directory: ${{github.workspace}}
-        run: git diff --exit-code components/wrapper/stubs
+        run: ${{ steps.pyinstall.outputs.python-path }} support/check_generated_stubs.py
 
       - name: Run CTest
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}

--- a/support/check_generated_stubs.py
+++ b/support/check_generated_stubs.py
@@ -1,0 +1,33 @@
+"""Check that generated Python stubs match the committed files."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+STUBS_DIR = Path("components/wrapper/stubs")
+
+
+def main() -> int:
+    result = subprocess.run(
+        [
+            "git",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            str(STUBS_DIR),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout:
+        print("Generated Python stubs differ from the committed files:", file=sys.stderr)
+        print(result.stdout, end="", file=sys.stderr)
+        print("Regenerate the stubs and commit the results.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
 ## Summary

  Make the generated-stub consistency check detect all changes under
  `components/wrapper/stubs`, including untracked files.

  The previous `git diff --exit-code` check only detected modifications to tracked
  files. A newly generated stub could therefore be omitted from a commit without
  causing CI to fail.

  ## Changes

  - Add `support/check_generated_stubs.py`.
  - Use `git status --porcelain --untracked-files=all` to detect:
    - modified stubs
    - deleted stubs
    - newly generated, untracked stubs
  - Print the affected paths and regeneration instructions when the check fails.
  - Run the new check from CI.

  ## Testing

  - Pre-commit checks pass.
  - The check passes when generated stubs match the repository.